### PR TITLE
Adjusted bandwidth calculations

### DIFF
--- a/noc/networking/pcie/pcie.go
+++ b/noc/networking/pcie/pcie.go
@@ -80,7 +80,7 @@ func (c *Connector) WithVersion(version int, width int) *Connector {
 	}
 
 	linkBandwidth := linkBandwidthTable[version]
-	totalBandwidth := linkBandwidth * uint64(width)
+	totalBandwidth := linkBandwidth * uint64(width) / 8
 
 	return c.WithBandwidth(totalBandwidth)
 }

--- a/noc/networking/switching/endpoint.go
+++ b/noc/networking/switching/endpoint.go
@@ -356,6 +356,7 @@ func MakeEndPointBuilder() EndPointBuilder {
 		freq:                     1 * sim.GHz,
 		numInputChannels:         1,
 		numOutputChannels:        1,
+		encodingOverhead:         0.25,
 	}
 }
 
@@ -426,6 +427,8 @@ func (b EndPointBuilder) Build(name string) *EndPoint {
 
 	ep.assemblingMsgs = list.New()
 	ep.assemblingMsgTable = make(map[string]*list.Element)
+
+	ep.encodingOverhead = b.encodingOverhead
 
 	ep.NetworkPort = sim.NewLimitNumMsgPort(
 		ep, b.networkPortBufferSize,


### PR DESCRIPTION
Divide bandwidth by 8 (to account for bit-byte difference) and add 25% overhead to transfers (closer to measured performance)