### PR TITLE
Add public component iterator to Simulation

### DIFF
--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -47,6 +47,12 @@ func (s *Simulation) GetVisTracer() *tracing.DBTracer {
 	return s.visTracer
 }
 
+// Components returns all the components registered in the simulation. The
+// returned slice should be treated as read-only.
+func (s *Simulation) Components() []sim.Component {
+	return s.components
+}
+
 // RegisterComponent registers a component with the simulation.
 func (s *Simulation) RegisterComponent(c sim.Component) {
 	compName := c.Name()

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -44,4 +44,14 @@ var _ = Describe("Simulation", func() {
 		Expect(simulation.GetComponentByName("comp")).To(Equal(comp))
 		Expect(simulation.GetPortByName("port")).To(Equal(port))
 	})
+
+	It("should return all registered components", func() {
+		comp.EXPECT().Ports().Return([]sim.Port{port}).AnyTimes()
+
+		simulation.RegisterComponent(comp)
+
+		comps := simulation.Components()
+		Expect(comps).To(HaveLen(1))
+		Expect(comps[0]).To(Equal(comp))
+	})
 })


### PR DESCRIPTION
## Summary
- expose all registered components via a `Components()` accessor
- test that the accessor returns the expected slice

## Testing
- `go test ./simulation` *(fails: no route to host when downloading toolchain)*