### PR TITLE
Add idealmemcontrollerv5 (V5 Spec/State/Ports/Middlewares)

### DIFF
--- a/mem/idealmemcontrollerv5/builder.go
+++ b/mem/idealmemcontrollerv5/builder.go
@@ -1,16 +1,15 @@
 package idealmemcontrollerv5
 
 import (
-    "github.com/sarchlab/akita/v4/mem/mem"
     "github.com/sarchlab/akita/v4/sim"
+    "github.com/sarchlab/akita/v4/simv5"
 )
 
 // Builder constructs a Comp either from a Spec or per-field setters.
 type Builder struct {
     spec             Spec
     engine           sim.Engine
-    storage          *mem.Storage
-    addressConverter mem.AddressConverter
+    sim              *simv5.Simulation
 }
 
 // MakeBuilder returns a new Builder with default Spec.
@@ -19,17 +18,12 @@ func MakeBuilder() Builder {
 }
 
 func (b Builder) WithEngine(engine sim.Engine) Builder { b.engine = engine; return b }
+func (b Builder) WithSimulation(s *simv5.Simulation) Builder { b.sim = s; b.engine = s.Engine; return b }
 func (b Builder) WithSpec(spec Spec) Builder           { b.spec = spec; return b }
 func (b Builder) WithWidth(w int) Builder              { b.spec.Width = w; return b }
 func (b Builder) WithLatency(cycles int) Builder       { b.spec.LatencyCycles = cycles; return b }
 func (b Builder) WithFreq(freq sim.Freq) Builder       { b.spec.Freq = freq; return b }
-func (b Builder) WithNewStorage(cap uint64) Builder    { b.storage = nil; b.spec.CapacityBytes = cap; return b }
-func (b Builder) WithStorage(storage *mem.Storage) Builder { b.storage = storage; return b }
-func (b Builder) WithUnitSize(unit uint64) Builder     { b.spec.UnitSize = unit; return b }
-func (b Builder) WithAddressConverter(ac mem.AddressConverter) Builder {
-    b.addressConverter = ac
-    return b
-}
+func (b Builder) WithStorageRef(id string) Builder     { b.spec.StorageRef = id; return b }
 
 // Build constructs the component. Ports are created but not connected.
 func (b Builder) Build(name string) *Comp {
@@ -38,21 +32,12 @@ func (b Builder) Build(name string) *Comp {
     c := &Comp{Spec: b.spec}
     c.TickingComponent = sim.NewTickingComponent(name, b.engine, b.spec.Freq, c)
 
-    // Storage wiring
-    if b.storage != nil {
-        c.Storage = b.storage
-    } else {
-        if b.spec.UnitSize == 0 {
-            c.Storage = mem.NewStorage(b.spec.CapacityBytes)
-        } else {
-            c.Storage = mem.NewStorageWithUnitSize(b.spec.CapacityBytes, b.spec.UnitSize)
-        }
-    }
-    c.AddressConverter = b.addressConverter
-
     // Middlewares
     c.AddMiddleware(&ctrlMiddleware{Comp: c})
-    c.AddMiddleware(&memMiddleware{Comp: c})
+    // Pass emu registry and storage ref to middleware for resolution
+    var emu *simv5.EmuStateRegistry
+    if b.sim != nil { emu = b.sim.Emu() }
+    c.AddMiddleware(&memMiddleware{Comp: c, emu: emu, storageRef: b.spec.StorageRef})
 
     // Initial state
     c.state = state{Mode: modeEnabled}

--- a/mem/idealmemcontrollerv5/builder.go
+++ b/mem/idealmemcontrollerv5/builder.go
@@ -18,7 +18,6 @@ func MakeBuilder() Builder {
     return Builder{spec: defaults()}
 }
 
-func (b Builder) WithEngine(engine sim.Engine) Builder { b.engine = engine; return b }
 func (b Builder) WithSimulation(s *simv5.Simulation) Builder { b.sim = s; b.engine = s.GetEngine(); return b }
 func (b Builder) WithSpec(spec Spec) Builder           { b.spec = spec; return b }
 
@@ -26,11 +25,15 @@ func (b Builder) WithSpec(spec Spec) Builder           { b.spec = spec; return b
 func (b Builder) Build(name string) *Comp {
     _ = b.spec.validate()
 
+    if b.engine == nil {
+        panic("idealmemcontrollerv5.Builder: engine is nil; call WithSimulation")
+    }
+
     c := &Comp{Spec: b.spec}
     c.TickingComponent = sim.NewTickingComponent(name, b.engine, b.spec.Freq, c)
 
     // Resolve address converter locally based on spec (no global registry)
-    var conv mem.AddressConverter
+    var conv AddressConverter
     switch b.spec.AddrConv.Kind {
     case "", "identity":
         conv = nil

--- a/mem/idealmemcontrollerv5/builder.go
+++ b/mem/idealmemcontrollerv5/builder.go
@@ -23,8 +23,6 @@ func (b Builder) WithSpec(spec Spec) Builder           { b.spec = spec; return b
 func (b Builder) WithWidth(w int) Builder              { b.spec.Width = w; return b }
 func (b Builder) WithLatency(cycles int) Builder       { b.spec.LatencyCycles = cycles; return b }
 func (b Builder) WithFreq(freq sim.Freq) Builder       { b.spec.Freq = freq; return b }
-func (b Builder) WithTopBufSize(n int) Builder         { b.spec.TopBufSize = n; return b }
-func (b Builder) WithCtrlBufSize(n int) Builder        { b.spec.CtrlBufSize = n; return b }
 func (b Builder) WithNewStorage(cap uint64) Builder    { b.storage = nil; b.spec.CapacityBytes = cap; return b }
 func (b Builder) WithStorage(storage *mem.Storage) Builder { b.storage = storage; return b }
 func (b Builder) WithUnitSize(unit uint64) Builder     { b.spec.UnitSize = unit; return b }
@@ -55,12 +53,6 @@ func (b Builder) Build(name string) *Comp {
     // Middlewares
     c.AddMiddleware(&ctrlMiddleware{Comp: c})
     c.AddMiddleware(&memMiddleware{Comp: c})
-
-    // Ports
-    c.IO.Top = sim.NewPort(c, b.spec.TopBufSize, b.spec.TopBufSize, name+".Top")
-    c.AddPort("Top", c.IO.Top)
-    c.IO.Control = sim.NewPort(c, b.spec.CtrlBufSize, b.spec.CtrlBufSize, name+".Control")
-    c.AddPort("Control", c.IO.Control)
 
     // Initial state
     c.State = State{Mode: ModeEnabled}

--- a/mem/idealmemcontrollerv5/builder.go
+++ b/mem/idealmemcontrollerv5/builder.go
@@ -24,6 +24,27 @@ func (b Builder) WithWidth(w int) Builder              { b.spec.Width = w; retur
 func (b Builder) WithLatency(cycles int) Builder       { b.spec.LatencyCycles = cycles; return b }
 func (b Builder) WithFreq(freq sim.Freq) Builder       { b.spec.Freq = freq; return b }
 func (b Builder) WithStorageRef(id string) Builder     { b.spec.StorageRef = id; return b }
+// Address converter configuration (primitive-only)
+func (b Builder) WithIdentityAddressing() Builder {
+    b.spec.AddrConv = AddressConvSpec{Kind: "identity", Params: map[string]uint64{}}
+    return b
+}
+func (b Builder) WithInterleaving(blockSize uint64, total, index int, offset uint64) Builder {
+    b.spec.AddrConv = AddressConvSpec{Kind: "interleaving", Params: map[string]uint64{
+        "InterleavingSize":    blockSize,
+        "TotalNumOfElements":  uint64(total),
+        "CurrentElementIndex": uint64(index),
+        "Offset":              offset,
+    }}
+    return b
+}
+func (b Builder) WithAddressConverter(kind string, params map[string]uint64) Builder {
+    // Defensive copy
+    cp := make(map[string]uint64, len(params))
+    for k, v := range params { cp[k] = v }
+    b.spec.AddrConv = AddressConvSpec{Kind: kind, Params: cp}
+    return b
+}
 
 // Build constructs the component. Ports are created but not connected.
 func (b Builder) Build(name string) *Comp {
@@ -32,10 +53,17 @@ func (b Builder) Build(name string) *Comp {
     c := &Comp{Spec: b.spec}
     c.TickingComponent = sim.NewTickingComponent(name, b.engine, b.spec.Freq, c)
 
+    // Resolve address converter via sim registry (with built-ins as fallback)
+    var conv interface{}
+    if b.sim != nil {
+        if ac, err := b.sim.BuildAddressConverter(b.spec.AddrConv.Kind, b.spec.AddrConv.Params); err == nil {
+            conv = ac
+        }
+    }
+
     // Middlewares
     c.AddMiddleware(&ctrlMiddleware{Comp: c})
-    // Pass the simulation and storage ref to middleware for resolution via StateRegistry
-    c.AddMiddleware(&memMiddleware{Comp: c, sim: b.sim, storageRef: b.spec.StorageRef})
+    c.AddMiddleware(&memMiddleware{Comp: c, sim: b.sim, storageRef: b.spec.StorageRef, conv: conv})
 
     // Initial state
     c.state = state{Mode: modeEnabled}

--- a/mem/idealmemcontrollerv5/builder.go
+++ b/mem/idealmemcontrollerv5/builder.go
@@ -1,0 +1,69 @@
+package idealmemcontrollerv5
+
+import (
+    "github.com/sarchlab/akita/v4/mem/mem"
+    "github.com/sarchlab/akita/v4/sim"
+)
+
+// Builder constructs a Comp either from a Spec or per-field setters.
+type Builder struct {
+    spec             Spec
+    engine           sim.Engine
+    storage          *mem.Storage
+    addressConverter mem.AddressConverter
+}
+
+// MakeBuilder returns a new Builder with default Spec.
+func MakeBuilder() Builder {
+    return Builder{spec: Defaults()}
+}
+
+func (b Builder) WithEngine(engine sim.Engine) Builder { b.engine = engine; return b }
+func (b Builder) WithSpec(spec Spec) Builder           { b.spec = spec; return b }
+func (b Builder) WithWidth(w int) Builder              { b.spec.Width = w; return b }
+func (b Builder) WithLatency(cycles int) Builder       { b.spec.LatencyCycles = cycles; return b }
+func (b Builder) WithFreq(freq sim.Freq) Builder       { b.spec.Freq = freq; return b }
+func (b Builder) WithTopBufSize(n int) Builder         { b.spec.TopBufSize = n; return b }
+func (b Builder) WithCtrlBufSize(n int) Builder        { b.spec.CtrlBufSize = n; return b }
+func (b Builder) WithNewStorage(cap uint64) Builder    { b.storage = nil; b.spec.CapacityBytes = cap; return b }
+func (b Builder) WithStorage(storage *mem.Storage) Builder { b.storage = storage; return b }
+func (b Builder) WithUnitSize(unit uint64) Builder     { b.spec.UnitSize = unit; return b }
+func (b Builder) WithAddressConverter(ac mem.AddressConverter) Builder {
+    b.addressConverter = ac
+    return b
+}
+
+// Build constructs the component. Ports are created but not connected.
+func (b Builder) Build(name string) *Comp {
+    _ = b.spec.Validate()
+
+    c := &Comp{Spec: b.spec}
+    c.TickingComponent = sim.NewTickingComponent(name, b.engine, b.spec.Freq, c)
+
+    // Storage wiring
+    if b.storage != nil {
+        c.Storage = b.storage
+    } else {
+        if b.spec.UnitSize == 0 {
+            c.Storage = mem.NewStorage(b.spec.CapacityBytes)
+        } else {
+            c.Storage = mem.NewStorageWithUnitSize(b.spec.CapacityBytes, b.spec.UnitSize)
+        }
+    }
+    c.AddressConverter = b.addressConverter
+
+    // Middlewares
+    c.AddMiddleware(&ctrlMiddleware{Comp: c})
+    c.AddMiddleware(&memMiddleware{Comp: c})
+
+    // Ports
+    c.IO.Top = sim.NewPort(c, b.spec.TopBufSize, b.spec.TopBufSize, name+".Top")
+    c.AddPort("Top", c.IO.Top)
+    c.IO.Control = sim.NewPort(c, b.spec.CtrlBufSize, b.spec.CtrlBufSize, name+".Control")
+    c.AddPort("Control", c.IO.Control)
+
+    // Initial state
+    c.State = State{Mode: ModeEnabled}
+
+    return c
+}

--- a/mem/idealmemcontrollerv5/builder.go
+++ b/mem/idealmemcontrollerv5/builder.go
@@ -34,10 +34,8 @@ func (b Builder) Build(name string) *Comp {
 
     // Middlewares
     c.AddMiddleware(&ctrlMiddleware{Comp: c})
-    // Pass emu registry and storage ref to middleware for resolution
-    var emu *simv5.EmuStateRegistry
-    if b.sim != nil { emu = b.sim.Emu() }
-    c.AddMiddleware(&memMiddleware{Comp: c, emu: emu, storageRef: b.spec.StorageRef})
+    // Pass the simulation and storage ref to middleware for resolution via StateRegistry
+    c.AddMiddleware(&memMiddleware{Comp: c, sim: b.sim, storageRef: b.spec.StorageRef})
 
     // Initial state
     c.state = state{Mode: modeEnabled}

--- a/mem/idealmemcontrollerv5/builder.go
+++ b/mem/idealmemcontrollerv5/builder.go
@@ -15,7 +15,7 @@ type Builder struct {
 
 // MakeBuilder returns a new Builder with default Spec.
 func MakeBuilder() Builder {
-    return Builder{spec: Defaults()}
+    return Builder{spec: defaults()}
 }
 
 func (b Builder) WithEngine(engine sim.Engine) Builder { b.engine = engine; return b }
@@ -33,7 +33,7 @@ func (b Builder) WithAddressConverter(ac mem.AddressConverter) Builder {
 
 // Build constructs the component. Ports are created but not connected.
 func (b Builder) Build(name string) *Comp {
-    _ = b.spec.Validate()
+    _ = b.spec.validate()
 
     c := &Comp{Spec: b.spec}
     c.TickingComponent = sim.NewTickingComponent(name, b.engine, b.spec.Freq, c)
@@ -55,7 +55,7 @@ func (b Builder) Build(name string) *Comp {
     c.AddMiddleware(&memMiddleware{Comp: c})
 
     // Initial state
-    c.State = State{Mode: ModeEnabled}
+    c.state = state{Mode: modeEnabled}
 
     return c
 }

--- a/mem/idealmemcontrollerv5/builder.go
+++ b/mem/idealmemcontrollerv5/builder.go
@@ -18,7 +18,7 @@ func MakeBuilder() Builder {
 }
 
 func (b Builder) WithEngine(engine sim.Engine) Builder { b.engine = engine; return b }
-func (b Builder) WithSimulation(s *simv5.Simulation) Builder { b.sim = s; b.engine = s.Engine; return b }
+func (b Builder) WithSimulation(s *simv5.Simulation) Builder { b.sim = s; b.engine = s.GetEngine(); return b }
 func (b Builder) WithSpec(spec Spec) Builder           { b.spec = spec; return b }
 func (b Builder) WithWidth(w int) Builder              { b.spec.Width = w; return b }
 func (b Builder) WithLatency(cycles int) Builder       { b.spec.LatencyCycles = cycles; return b }

--- a/mem/idealmemcontrollerv5/comp.go
+++ b/mem/idealmemcontrollerv5/comp.go
@@ -5,19 +5,13 @@ import (
     "github.com/sarchlab/akita/v4/sim"
 )
 
-// Ports groups named ports for clarity.
-type IO struct {
-    Top    sim.Port
-    Control sim.Port
-}
-
 // Comp is an ideal memory controller with Spec/State/Ports/Middlewares.
 type Comp struct {
     *sim.TickingComponent
     sim.MiddlewareHolder
 
     Spec  Spec
-    State State
+    state state
 
     // External dependencies
     Storage          *mem.Storage
@@ -33,19 +27,37 @@ func (c *Comp) Tick() bool { return c.MiddlewareHolder.Tick() }
 // SnapshotState returns a serializable (pure data) snapshot of the state.
 // Note: pendingDrainCmd is intentionally excluded.
 func (c *Comp) SnapshotState() any {
-    return c.State
+    // Deep copy the state to avoid exposing mutable slices to callers.
+    snap := state{
+        Mode:         c.state.Mode,
+        DrainPending: c.state.DrainPending,
+    }
+    if len(c.state.Inflight) > 0 {
+        snap.Inflight = make([]txn, len(c.state.Inflight))
+        for i, t := range c.state.Inflight {
+            // Copy txn value, then deep copy slices
+            nt := t
+            if len(t.Data) > 0 {
+                nt.Data = append([]byte(nil), t.Data...)
+            }
+            if len(t.DirtyMask) > 0 {
+                nt.DirtyMask = append([]bool(nil), t.DirtyMask...)
+            }
+            snap.Inflight[i] = nt
+        }
+    }
+    return snap
 }
 
 // RestoreState restores the controller state from a snapshot.
 func (c *Comp) RestoreState(snapshot any) error {
-    if s, ok := snapshot.(State); ok {
-        c.State = s
-        return nil
-    }
-    // Support pointer form too
-    if sp, ok := snapshot.(*State); ok {
-        c.State = *sp
-        return nil
+    switch s := snapshot.(type) {
+    case state:
+        c.state = s
+    case *state:
+        c.state = *s
+    default:
+        // Best effort: ignore unknown shapes silently.
     }
     return nil
 }

--- a/mem/idealmemcontrollerv5/comp.go
+++ b/mem/idealmemcontrollerv5/comp.go
@@ -13,10 +13,6 @@ type Comp struct {
     Spec  Spec
     state state
 
-    // External dependencies
-    Storage          *mem.Storage
-    AddressConverter mem.AddressConverter
-
     // Non-serializable transient field to answer drain completion.
     pendingDrainCmd *mem.ControlMsg
 }

--- a/mem/idealmemcontrollerv5/comp.go
+++ b/mem/idealmemcontrollerv5/comp.go
@@ -1,0 +1,52 @@
+package idealmemcontrollerv5
+
+import (
+    "github.com/sarchlab/akita/v4/mem/mem"
+    "github.com/sarchlab/akita/v4/sim"
+)
+
+// Ports groups named ports for clarity.
+type IO struct {
+    Top    sim.Port
+    Control sim.Port
+}
+
+// Comp is an ideal memory controller with Spec/State/Ports/Middlewares.
+type Comp struct {
+    *sim.TickingComponent
+    sim.MiddlewareHolder
+
+    Spec  Spec
+    State State
+    IO IO
+
+    // External dependencies
+    Storage          *mem.Storage
+    AddressConverter mem.AddressConverter
+
+    // Non-serializable transient field to answer drain completion.
+    pendingDrainCmd *mem.ControlMsg
+}
+
+// Tick delegates to the middleware pipeline.
+func (c *Comp) Tick() bool { return c.MiddlewareHolder.Tick() }
+
+// SnapshotState returns a serializable (pure data) snapshot of the state.
+// Note: pendingDrainCmd is intentionally excluded.
+func (c *Comp) SnapshotState() any {
+    return c.State
+}
+
+// RestoreState restores the controller state from a snapshot.
+func (c *Comp) RestoreState(snapshot any) error {
+    if s, ok := snapshot.(State); ok {
+        c.State = s
+        return nil
+    }
+    // Support pointer form too
+    if sp, ok := snapshot.(*State); ok {
+        c.State = *sp
+        return nil
+    }
+    return nil
+}

--- a/mem/idealmemcontrollerv5/comp.go
+++ b/mem/idealmemcontrollerv5/comp.go
@@ -18,7 +18,6 @@ type Comp struct {
 
     Spec  Spec
     State State
-    IO IO
 
     // External dependencies
     Storage          *mem.Storage

--- a/mem/idealmemcontrollerv5/ctrl_middleware.go
+++ b/mem/idealmemcontrollerv5/ctrl_middleware.go
@@ -1,0 +1,70 @@
+package idealmemcontrollerv5
+
+import (
+    "github.com/sarchlab/akita/v4/mem/mem"
+)
+
+// ctrlMiddleware handles control messages enable/pause/drain.
+type ctrlMiddleware struct { *Comp }
+
+func (m *ctrlMiddleware) Tick() bool {
+    made := false
+    made = m.handleIncomingCommands() || made
+    made = m.handleDrainState() || made
+    return made
+}
+
+func (m *ctrlMiddleware) handleIncomingCommands() bool {
+    msg := m.IO.Control.PeekIncoming()
+    if msg == nil { return false }
+
+    ctrlMsg := msg.(*mem.ControlMsg)
+
+    // Enable
+    if ctrlMsg.Enable {
+        m.State.Mode = ModeEnabled
+        rsp := ctrlMsg.GenerateRsp()
+        if err := m.IO.Control.Send(rsp); err != nil { return false }
+        m.IO.Control.RetrieveIncoming()
+        return true
+    }
+
+    // Drain
+    if ctrlMsg.Drain {
+        m.State.Mode = ModeDraining
+        m.pendingDrainCmd = ctrlMsg
+        m.State.DrainPending = true
+        m.IO.Control.RetrieveIncoming()
+        return true
+    }
+
+    // Pause (not enable and not drain)
+    m.State.Mode = ModePaused
+    rsp := ctrlMsg.GenerateRsp()
+    if err := m.IO.Control.Send(rsp); err != nil { return false }
+    m.IO.Control.RetrieveIncoming()
+    return true
+}
+
+func (m *ctrlMiddleware) handleDrainState() bool {
+    if m.State.Mode != ModeDraining || !m.State.DrainPending {
+        return false
+    }
+    if len(m.State.Inflight) != 0 {
+        return false
+    }
+    // Now inflight is empty; respond to the pending drain
+    if m.pendingDrainCmd == nil {
+        // Could happen across snapshot if ControlMsg wasn't persisted.
+        // Simply transition to paused.
+        m.State.Mode = ModePaused
+        m.State.DrainPending = false
+        return true
+    }
+    rsp := m.pendingDrainCmd.GenerateRsp()
+    if err := m.IO.Control.Send(rsp); err != nil { return false }
+    m.State.Mode = ModePaused
+    m.State.DrainPending = false
+    m.pendingDrainCmd = nil
+    return true
+}

--- a/mem/idealmemcontrollerv5/doc.go
+++ b/mem/idealmemcontrollerv5/doc.go
@@ -1,0 +1,10 @@
+// Package idealmemcontrollerv5 provides a Spec/State based ideal memory
+// controller that uses tick-driven countdowns instead of ad-hoc events.
+//
+// This version aligns with the V5 guidelines:
+// - Spec: immutable configuration
+// - State: pure data, serializable friendly
+// - Ports: explicit, named ports
+// - Middlewares: ordered, stateless processors acting on component state
+package idealmemcontrollerv5
+

--- a/mem/idealmemcontrollerv5/idealmemcontrollerv5_suite_test.go
+++ b/mem/idealmemcontrollerv5/idealmemcontrollerv5_suite_test.go
@@ -1,0 +1,13 @@
+package idealmemcontrollerv5
+
+import (
+    "testing"
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+)
+
+func TestIdealmemcontrollerv5(t *testing.T) {
+    RegisterFailHandler(Fail)
+    RunSpecs(t, "IdealMemControllerV5 Suite")
+}
+

--- a/mem/idealmemcontrollerv5/idealmemcontrollerv5_test.go
+++ b/mem/idealmemcontrollerv5/idealmemcontrollerv5_test.go
@@ -26,11 +26,13 @@ var _ = Describe("IdealMemControllerV5", func() {
         store := mem.NewStorage(1 * mem.MB)
         Expect(simx.RegisterState("dram0", store)).To(Succeed())
 
+        spec := defaults()
+        spec.Freq = 1000 * sim.MHz
+        spec.LatencyCycles = 5
+        spec.StorageRef = "dram0"
         ctrl := MakeBuilder().
             WithSimulation(simx).
-            WithFreq(1000 * sim.MHz).
-            WithLatency(5).
-            WithStorageRef("dram0").
+            WithSpec(spec).
             Build("MemCtrlV5")
 
         // Inject ports and attach dummy conn to avoid nil deref on send
@@ -64,11 +66,13 @@ var _ = Describe("IdealMemControllerV5", func() {
         store := mem.NewStorage(1 * mem.MB)
         Expect(simx.RegisterState("dram0", store)).To(Succeed())
 
+        spec := defaults()
+        spec.Freq = 1 * sim.GHz
+        spec.LatencyCycles = 3
+        spec.StorageRef = "dram0"
         ctrl := MakeBuilder().
             WithSimulation(simx).
-            WithFreq(1 * sim.GHz).
-            WithLatency(3).
-            WithStorageRef("dram0").
+            WithSpec(spec).
             Build("MemCtrlV5")
 
         top := sim.NewPort(ctrl, 4, 4, "MemCtrlV5.Top")
@@ -105,10 +109,12 @@ var _ = Describe("IdealMemControllerV5", func() {
         store := mem.NewStorage(1 * mem.MB)
         _ = simx.RegisterState("dram0", store)
 
+        spec := defaults()
+        spec.LatencyCycles = 2
+        spec.StorageRef = "dram0"
         ctrl := MakeBuilder().
             WithSimulation(simx).
-            WithLatency(2).
-            WithStorageRef("dram0").
+            WithSpec(spec).
             Build("MemCtrlV5")
 
         top := sim.NewPort(ctrl, 4, 4, "MemCtrlV5.Top")

--- a/mem/idealmemcontrollerv5/idealmemcontrollerv5_test.go
+++ b/mem/idealmemcontrollerv5/idealmemcontrollerv5_test.go
@@ -24,7 +24,7 @@ var _ = Describe("IdealMemControllerV5", func() {
         simx := simv5.NewSimulation(engine)
         // Register storage emulation state
         store := mem.NewStorage(1 * mem.MB)
-        Expect(simx.Emu().Register("dram0", store)).To(Succeed())
+        Expect(simx.RegisterState("dram0", store)).To(Succeed())
 
         ctrl := MakeBuilder().
             WithSimulation(simx).
@@ -62,7 +62,7 @@ var _ = Describe("IdealMemControllerV5", func() {
         engine := sim.NewSerialEngine()
         simx := simv5.NewSimulation(engine)
         store := mem.NewStorage(1 * mem.MB)
-        Expect(simx.Emu().Register("dram0", store)).To(Succeed())
+        Expect(simx.RegisterState("dram0", store)).To(Succeed())
 
         ctrl := MakeBuilder().
             WithSimulation(simx).
@@ -103,7 +103,7 @@ var _ = Describe("IdealMemControllerV5", func() {
         engine := sim.NewSerialEngine()
         simx := simv5.NewSimulation(engine)
         store := mem.NewStorage(1 * mem.MB)
-        _ = simx.Emu().Register("dram0", store)
+        _ = simx.RegisterState("dram0", store)
 
         ctrl := MakeBuilder().
             WithSimulation(simx).

--- a/mem/idealmemcontrollerv5/idealmemcontrollerv5_test.go
+++ b/mem/idealmemcontrollerv5/idealmemcontrollerv5_test.go
@@ -1,0 +1,130 @@
+package idealmemcontrollerv5
+
+import (
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+
+    "github.com/sarchlab/akita/v4/mem/mem"
+    "github.com/sarchlab/akita/v4/sim"
+)
+
+// dummyConn is a minimal Connection to avoid nil panics from Port.Send.
+type dummyConn struct{ sim.HookableBase }
+
+func (d *dummyConn) Name() string              { return "dummy" }
+func (d *dummyConn) PlugIn(p sim.Port)         { p.SetConnection(d) }
+func (d *dummyConn) Unplug(_ sim.Port)         {}
+func (d *dummyConn) NotifyAvailable(_ sim.Port) {}
+func (d *dummyConn) NotifySend()               {}
+
+var _ = Describe("IdealMemControllerV5", func() {
+    It("processes a read request after latency cycles", func() {
+        engine := sim.NewSerialEngine()
+        ctrl := MakeBuilder().
+            WithEngine(engine).
+            WithFreq(1000 * sim.MHz).
+            WithLatency(5).
+            WithTopBufSize(4).
+            Build("MemCtrlV5")
+
+        // Attach dummy conn to avoid nil deref on send
+        dc := &dummyConn{}
+        dc.PlugIn(ctrl.IO.Top)
+
+        // Deliver a read req
+        read := mem.ReadReqBuilder{}.
+            WithSrc(sim.RemotePort("Agent.Port")).
+            WithDst(ctrl.IO.Top.AsRemote()).
+            WithAddress(0).
+            WithByteSize(4).
+            Build()
+        _ = ctrl.IO.Top.Deliver(read)
+
+        // Tick until response available
+        for i := 0; i < 6; i++ { _ = ctrl.Tick() }
+
+        // Retrieve outgoing response
+        msg := ctrl.IO.Top.RetrieveOutgoing()
+        Expect(msg).NotTo(BeNil())
+        _, isDataReady := msg.(*mem.DataReadyRsp)
+        Expect(isDataReady).To(BeTrue())
+    })
+
+    It("processes a write request and updates storage", func() {
+        engine := sim.NewSerialEngine()
+        ctrl := MakeBuilder().
+            WithEngine(engine).
+            WithFreq(1 * sim.GHz).
+            WithLatency(3).
+            Build("MemCtrlV5")
+
+        dc := &dummyConn{}
+        dc.PlugIn(ctrl.IO.Top)
+
+        data := []byte{1,2,3,4}
+        write := mem.WriteReqBuilder{}.
+            WithSrc(sim.RemotePort("Agent.Port")).
+            WithDst(ctrl.IO.Top.AsRemote()).
+            WithAddress(0).
+            WithData(data).
+            Build()
+        _ = ctrl.IO.Top.Deliver(write)
+
+        for i := 0; i < 4; i++ { _ = ctrl.Tick() }
+
+        // Verify response
+        msg := ctrl.IO.Top.RetrieveOutgoing()
+        Expect(msg).NotTo(BeNil())
+        _, isWriteDone := msg.(*mem.WriteDoneRsp)
+        Expect(isWriteDone).To(BeTrue())
+
+        // Verify storage content
+        stored, err := ctrl.Storage.Read(0, 4)
+        Expect(err).To(BeNil())
+        Expect(stored).To(Equal(data))
+    })
+
+    It("drains inflight then responds to control", func() {
+        engine := sim.NewSerialEngine()
+        ctrl := MakeBuilder().
+            WithEngine(engine).
+            WithLatency(2).
+            WithTopBufSize(4).
+            WithCtrlBufSize(2).
+            Build("MemCtrlV5")
+
+        dc := &dummyConn{}
+        dc.PlugIn(ctrl.IO.Top)
+        dc.PlugIn(ctrl.IO.Control)
+
+        // One inflight read
+        read := mem.ReadReqBuilder{}.
+            WithSrc(sim.RemotePort("Agent.Port")).
+            WithDst(ctrl.IO.Top.AsRemote()).
+            WithAddress(16).
+            WithByteSize(4).
+            Build()
+        _ = ctrl.IO.Top.Deliver(read)
+        _ = ctrl.Tick()
+
+        // Send drain control
+        ctrlMsg := mem.ControlMsgBuilder{}.
+            WithSrc(sim.RemotePort("Agent.Ctrl")).
+            WithDst(ctrl.IO.Control.AsRemote()).
+            WithCtrlInfo(false, true, false, false, false).
+            Build()
+        _ = ctrl.IO.Control.Deliver(ctrlMsg)
+
+        // Progress a few ticks: first complete read, then drain rsp
+        for i := 0; i < 5; i++ { _ = ctrl.Tick() }
+
+        // First, data ready should have been sent
+        _ = ctrl.IO.Top.RetrieveOutgoing()
+
+        // Then, control response
+        rsp := ctrl.IO.Control.RetrieveOutgoing()
+        Expect(rsp).NotTo(BeNil())
+        _, isGeneral := rsp.(*sim.GeneralRsp)
+        Expect(isGeneral).To(BeTrue())
+    })
+})

--- a/mem/idealmemcontrollerv5/interface.go
+++ b/mem/idealmemcontrollerv5/interface.go
@@ -1,0 +1,28 @@
+package idealmemcontrollerv5
+
+// Local abstraction layer for external dependencies. The goal is for the
+// idealmemcontrollerv5 package to depend on these interfaces only, so tests
+// can mock them without importing external packages.
+//
+//go:generate mockgen -destination "mock_local_test.go" -package $GOPACKAGE -write_package_comment=false github.com/sarchlab/akita/v4/mem/idealmemcontrollerv5 Storage,AddressConverter,StateAccessor
+
+// Storage models the minimal storage operations used by the controller.
+// It is implemented by mem.Storage.
+type Storage interface {
+    Read(address uint64, length uint64) ([]byte, error)
+    Write(address uint64, data []byte) error
+}
+
+// AddressConverter models address translation strategy.
+// It is implemented by types like mem.InterleavingConverter.
+type AddressConverter interface {
+    ConvertExternalToInternal(external uint64) uint64
+    ConvertInternalToExternal(internal uint64) uint64
+}
+
+// StateAccessor provides read access to shared state by ID.
+// It is implemented by simv5.Simulation.
+type StateAccessor interface {
+    GetState(id string) (interface{}, bool)
+}
+

--- a/mem/idealmemcontrollerv5/interface.go
+++ b/mem/idealmemcontrollerv5/interface.go
@@ -4,7 +4,7 @@ package idealmemcontrollerv5
 // idealmemcontrollerv5 package to depend on these interfaces only, so tests
 // can mock them without importing external packages.
 //
-//go:generate mockgen -destination "mock_local_test.go" -package $GOPACKAGE -write_package_comment=false github.com/sarchlab/akita/v4/mem/idealmemcontrollerv5 Storage,AddressConverter,StateAccessor
+//go:generate mockgen -destination "mock_local_test.go" -package $GOPACKAGE -write_package_comment=false -source interface.go
 
 // Storage models the minimal storage operations used by the controller.
 // It is implemented by mem.Storage.
@@ -25,4 +25,3 @@ type AddressConverter interface {
 type StateAccessor interface {
     GetState(id string) (interface{}, bool)
 }
-

--- a/mem/idealmemcontrollerv5/mem_middleware.go
+++ b/mem/idealmemcontrollerv5/mem_middleware.go
@@ -15,8 +15,8 @@ type memMiddleware struct {
     *Comp
     sim        *simv5.Simulation
     storageRef string
-    stor       *mem.Storage
-    conv       mem.AddressConverter
+    stor       Storage
+    conv       AddressConverter
 }
 
 func (m *memMiddleware) Tick() bool {
@@ -170,7 +170,7 @@ func (m *memMiddleware) Handle(e sim.Event) error {
     return nil
 }
 
-func (m *memMiddleware) storage() *mem.Storage {
+func (m *memMiddleware) storage() Storage {
     if m.stor != nil { return m.stor }
     if m.sim == nil {
         log.Panic("emu registry not provided; cannot resolve storage")
@@ -179,7 +179,7 @@ func (m *memMiddleware) storage() *mem.Storage {
     if !ok {
         log.Panicf("storage ref %q not found in emu registry", m.storageRef)
     }
-    s, ok := v.(*mem.Storage)
+    s, ok := v.(Storage)
     if !ok {
         log.Panicf("storage ref %q has unexpected type", m.storageRef)
     }

--- a/mem/idealmemcontrollerv5/mem_middleware.go
+++ b/mem/idealmemcontrollerv5/mem_middleware.go
@@ -16,7 +16,7 @@ type memMiddleware struct {
     sim        *simv5.Simulation
     storageRef string
     stor       *mem.Storage
-    conv       interface{} // mem.AddressConverter; kept as interface{} to avoid import cycles if needed
+    conv       mem.AddressConverter
 }
 
 func (m *memMiddleware) Tick() bool {
@@ -155,13 +155,8 @@ func (m *memMiddleware) progressInflight() bool {
 }
 
 func (m *memMiddleware) toInternalAddr(addr uint64) uint64 {
-    if m.conv == nil {
-        return addr
-    }
-    if ac, ok := m.conv.(mem.AddressConverter); ok {
-        return ac.ConvertExternalToInternal(addr)
-    }
-    return addr
+    if m.conv == nil { return addr }
+    return m.conv.ConvertExternalToInternal(addr)
 }
 
 // Satisfy sim.Handler for tick events forwarded by TickingComponent.

--- a/mem/idealmemcontrollerv5/mem_middleware.go
+++ b/mem/idealmemcontrollerv5/mem_middleware.go
@@ -16,6 +16,7 @@ type memMiddleware struct {
     sim        *simv5.Simulation
     storageRef string
     stor       *mem.Storage
+    conv       interface{} // mem.AddressConverter; kept as interface{} to avoid import cycles if needed
 }
 
 func (m *memMiddleware) Tick() bool {
@@ -154,7 +155,12 @@ func (m *memMiddleware) progressInflight() bool {
 }
 
 func (m *memMiddleware) toInternalAddr(addr uint64) uint64 {
-    // Address conversion strategy will be addressed separately; keep passthrough for now.
+    if m.conv == nil {
+        return addr
+    }
+    if ac, ok := m.conv.(mem.AddressConverter); ok {
+        return ac.ConvertExternalToInternal(addr)
+    }
     return addr
 }
 

--- a/mem/idealmemcontrollerv5/mem_middleware.go
+++ b/mem/idealmemcontrollerv5/mem_middleware.go
@@ -1,0 +1,161 @@
+package idealmemcontrollerv5
+
+import (
+    "log"
+    "reflect"
+
+    "github.com/sarchlab/akita/v4/mem/mem"
+    "github.com/sarchlab/akita/v4/sim"
+    "github.com/sarchlab/akita/v4/tracing"
+)
+
+// memMiddleware handles data-path requests using tick-driven countdown.
+type memMiddleware struct { *Comp }
+
+func (m *memMiddleware) Tick() bool {
+    made := false
+    made = m.takeNewReqs() || made
+    made = m.progressInflight() || made
+    return made
+}
+
+func (m *memMiddleware) takeNewReqs() bool {
+    if m.State.Mode != ModeEnabled { // do not take new in PAUSE or DRAIN
+        return false
+    }
+    made := false
+    for i := 0; i < m.Spec.Width; i++ {
+        msg := m.IO.Top.RetrieveIncoming()
+        if msg == nil {
+            break
+        }
+        switch req := msg.(type) {
+        case *mem.ReadReq:
+            m.State.Inflight = append(m.State.Inflight, Txn{
+                IsRead:    true,
+                Addr:      m.toInternalAddr(req.Address),
+                Size:      req.AccessByteSize,
+                Remaining: m.Spec.LatencyCycles,
+                Src:       req.Src,
+                RspTo:     req.ID,
+            })
+        case *mem.WriteReq:
+            // Clone data to keep Txn pure
+            dataCopy := make([]byte, len(req.Data))
+            copy(dataCopy, req.Data)
+            var maskCopy []bool
+            if req.DirtyMask != nil {
+                maskCopy = make([]bool, len(req.DirtyMask))
+                copy(maskCopy, req.DirtyMask)
+            }
+            m.State.Inflight = append(m.State.Inflight, Txn{
+                IsRead:    false,
+                Addr:      m.toInternalAddr(req.Address),
+                Data:      dataCopy,
+                DirtyMask: maskCopy,
+                Remaining: m.Spec.LatencyCycles,
+                Src:       req.Src,
+                RspTo:     req.ID,
+            })
+        default:
+            log.Panicf("idealmemcontrollerv5: unsupported msg %s", reflect.TypeOf(msg))
+        }
+        tracing.TraceReqReceive(msg, m)
+        made = true
+    }
+    return made
+}
+
+func (m *memMiddleware) progressInflight() bool {
+    made := false
+
+    if m.State.Mode == ModePaused {
+        return false
+    }
+
+    // Countdown
+    for i := range m.State.Inflight {
+        if m.State.Inflight[i].Remaining > 0 {
+            m.State.Inflight[i].Remaining--
+            made = true
+        }
+    }
+
+    // Respond any ready transactions; rebuild list keeping those not sent
+    if len(m.State.Inflight) == 0 {
+        // If draining and empty after processing, ctrl middleware will respond.
+        return made
+    }
+
+    kept := m.State.Inflight[:0]
+    for _, t := range m.State.Inflight {
+        if t.Remaining > 0 {
+            kept = append(kept, t)
+            continue
+        }
+
+        if t.IsRead {
+            // Perform read now
+            data, err := m.Storage.Read(t.Addr, t.Size)
+            if err != nil { log.Panic(err) }
+            rsp := mem.DataReadyRspBuilder{}.
+                WithSrc(m.IO.Top.AsRemote()).
+                WithDst(t.Src).
+                WithRspTo(t.RspTo).
+                WithData(data).
+                Build()
+            if err2 := m.IO.Top.Send(rsp); err2 != nil {
+                // Cannot send now; keep it ready to retry next tick
+                // Keep Remaining at 0 to retry soon.
+                kept = append(kept, t)
+                continue
+            }
+            tracing.TraceReqComplete(rsp, m) // trace completion via rsp
+            made = true
+        } else {
+            // Write
+            if t.DirtyMask == nil {
+                if err := m.Storage.Write(t.Addr, t.Data); err != nil { log.Panic(err) }
+            } else {
+                // Read-modify-write
+                data, err := m.Storage.Read(t.Addr, uint64(len(t.Data)))
+                if err != nil { log.Panic(err) }
+                for i := 0; i < len(t.Data); i++ {
+                    if t.DirtyMask[i] { data[i] = t.Data[i] }
+                }
+                if err := m.Storage.Write(t.Addr, data); err != nil { log.Panic(err) }
+            }
+            rsp := mem.WriteDoneRspBuilder{}.
+                WithSrc(m.IO.Top.AsRemote()).
+                WithDst(t.Src).
+                WithRspTo(t.RspTo).
+                Build()
+            if err2 := m.IO.Top.Send(rsp); err2 != nil {
+                kept = append(kept, t)
+                continue
+            }
+            tracing.TraceReqComplete(rsp, m)
+            made = true
+        }
+    }
+    // Update inflight with remaining
+    if len(kept) != len(m.State.Inflight) { m.State.Inflight = kept }
+
+    return made
+}
+
+func (m *memMiddleware) toInternalAddr(addr uint64) uint64 {
+    if m.AddressConverter == nil { return addr }
+    return m.AddressConverter.ConvertExternalToInternal(addr)
+}
+
+// Satisfy sim.Handler for tick events forwarded by TickingComponent.
+func (m *memMiddleware) Handle(e sim.Event) error {
+    switch e := e.(type) {
+    case sim.TickEvent:
+        return m.TickingComponent.Handle(e)
+    default:
+        // ignore
+    }
+    return nil
+}

--- a/mem/idealmemcontrollerv5/mem_middleware.go
+++ b/mem/idealmemcontrollerv5/mem_middleware.go
@@ -13,7 +13,7 @@ import (
 // memMiddleware handles data-path requests using tick-driven countdown.
 type memMiddleware struct {
     *Comp
-    emu        *simv5.EmuStateRegistry
+    sim        *simv5.Simulation
     storageRef string
     stor       *mem.Storage
 }
@@ -171,10 +171,10 @@ func (m *memMiddleware) Handle(e sim.Event) error {
 
 func (m *memMiddleware) storage() *mem.Storage {
     if m.stor != nil { return m.stor }
-    if m.emu == nil {
+    if m.sim == nil {
         log.Panic("emu registry not provided; cannot resolve storage")
     }
-    v, ok := m.emu.Get(m.storageRef)
+    v, ok := m.sim.GetState(m.storageRef)
     if !ok {
         log.Panicf("storage ref %q not found in emu registry", m.storageRef)
     }

--- a/mem/idealmemcontrollerv5/spec.go
+++ b/mem/idealmemcontrollerv5/spec.go
@@ -1,0 +1,54 @@
+package idealmemcontrollerv5
+
+import (
+    "fmt"
+    "github.com/sarchlab/akita/v4/mem/mem"
+    "github.com/sarchlab/akita/v4/sim"
+)
+
+// Spec holds immutable configuration values for the controller.
+type Spec struct {
+    // Core behavior
+    Width         int     // Max new reqs consumed per tick
+    LatencyCycles int     // Fixed cycles to complete a req
+    Freq          sim.Freq
+
+    // Ports
+    TopBufSize  int
+    CtrlBufSize int
+
+    // Storage
+    CapacityBytes uint64 // If Storage is nil, a new storage is created
+    UnitSize      uint64 // Optional, 0 to use mem.NewStorage default unit size
+}
+
+func (s Spec) Validate() error {
+    if s.Width <= 0 {
+        return fmt.Errorf("width must be > 0")
+    }
+    if s.LatencyCycles < 0 {
+        return fmt.Errorf("latency cycles must be >= 0")
+    }
+    if s.Freq <= 0 {
+        return fmt.Errorf("freq must be > 0")
+    }
+    if s.TopBufSize <= 0 || s.CtrlBufSize <= 0 {
+        return fmt.Errorf("port buffer sizes must be > 0")
+    }
+    // CapacityBytes can be 0 if external storage is provided by builder.
+    return nil
+}
+
+// Defaults returns a Spec with sane defaults.
+func Defaults() Spec {
+    return Spec{
+        Width:         1,
+        LatencyCycles: 100,
+        Freq:          1 * sim.GHz,
+        TopBufSize:    16,
+        CtrlBufSize:   4,
+        CapacityBytes: 4 * mem.GB,
+        UnitSize:      0,
+    }
+}
+

--- a/mem/idealmemcontrollerv5/spec.go
+++ b/mem/idealmemcontrollerv5/spec.go
@@ -2,7 +2,6 @@ package idealmemcontrollerv5
 
 import (
     "fmt"
-    "github.com/sarchlab/akita/v4/mem/mem"
     "github.com/sarchlab/akita/v4/sim"
 )
 
@@ -14,8 +13,7 @@ type Spec struct {
     Freq          sim.Freq
 
     // Storage
-    CapacityBytes uint64 // If Storage is nil, a new storage is created
-    UnitSize      uint64 // Optional, 0 to use mem.NewStorage default unit size
+    StorageRef    string // ID in the EmuStateRegistry
 }
 
 func (s Spec) validate() error {
@@ -28,7 +26,9 @@ func (s Spec) validate() error {
     if s.Freq <= 0 {
         return fmt.Errorf("freq must be > 0")
     }
-    // CapacityBytes can be 0 if external storage is provided by builder.
+    if s.StorageRef == "" {
+        return fmt.Errorf("storage ref must be provided")
+    }
     return nil
 }
 
@@ -38,7 +38,6 @@ func defaults() Spec {
         Width:         1,
         LatencyCycles: 100,
         Freq:          1 * sim.GHz,
-        CapacityBytes: 4 * mem.GB,
-        UnitSize:      0,
+        StorageRef:    "",
     }
 }

--- a/mem/idealmemcontrollerv5/spec.go
+++ b/mem/idealmemcontrollerv5/spec.go
@@ -14,6 +14,9 @@ type Spec struct {
 
     // Storage
     StorageRef    string // ID in the EmuStateRegistry
+
+    // Address conversion strategy spec (primitive-only)
+    AddrConv AddressConvSpec
 }
 
 func (s Spec) validate() error {
@@ -39,5 +42,12 @@ func defaults() Spec {
         LatencyCycles: 100,
         Freq:          1 * sim.GHz,
         StorageRef:    "",
+        AddrConv:      AddressConvSpec{Kind: "identity", Params: map[string]uint64{}},
     }
+}
+
+// AddressConvSpec describes an address conversion strategy using primitives.
+type AddressConvSpec struct {
+    Kind   string
+    Params map[string]uint64
 }

--- a/mem/idealmemcontrollerv5/spec.go
+++ b/mem/idealmemcontrollerv5/spec.go
@@ -13,10 +13,6 @@ type Spec struct {
     LatencyCycles int     // Fixed cycles to complete a req
     Freq          sim.Freq
 
-    // Ports
-    TopBufSize  int
-    CtrlBufSize int
-
     // Storage
     CapacityBytes uint64 // If Storage is nil, a new storage is created
     UnitSize      uint64 // Optional, 0 to use mem.NewStorage default unit size
@@ -32,9 +28,6 @@ func (s Spec) Validate() error {
     if s.Freq <= 0 {
         return fmt.Errorf("freq must be > 0")
     }
-    if s.TopBufSize <= 0 || s.CtrlBufSize <= 0 {
-        return fmt.Errorf("port buffer sizes must be > 0")
-    }
     // CapacityBytes can be 0 if external storage is provided by builder.
     return nil
 }
@@ -45,10 +38,7 @@ func Defaults() Spec {
         Width:         1,
         LatencyCycles: 100,
         Freq:          1 * sim.GHz,
-        TopBufSize:    16,
-        CtrlBufSize:   4,
         CapacityBytes: 4 * mem.GB,
         UnitSize:      0,
     }
 }
-

--- a/mem/idealmemcontrollerv5/spec.go
+++ b/mem/idealmemcontrollerv5/spec.go
@@ -18,7 +18,7 @@ type Spec struct {
     UnitSize      uint64 // Optional, 0 to use mem.NewStorage default unit size
 }
 
-func (s Spec) Validate() error {
+func (s Spec) validate() error {
     if s.Width <= 0 {
         return fmt.Errorf("width must be > 0")
     }
@@ -33,7 +33,7 @@ func (s Spec) Validate() error {
 }
 
 // Defaults returns a Spec with sane defaults.
-func Defaults() Spec {
+func defaults() Spec {
     return Spec{
         Width:         1,
         LatencyCycles: 100,

--- a/mem/idealmemcontrollerv5/state.go
+++ b/mem/idealmemcontrollerv5/state.go
@@ -4,17 +4,17 @@ import (
     "github.com/sarchlab/akita/v4/sim"
 )
 
-// Mode indicates the controller's high-level mode.
-type Mode int
+// mode indicates the controller's high-level mode.
+type mode int
 
 const (
-    ModeEnabled Mode = iota
-    ModePaused
-    ModeDraining
+    modeEnabled mode = iota
+    modePaused
+    modeDraining
 )
 
-// Txn captures an in-flight read/write in pure data.
-type Txn struct {
+// txn captures an in-flight read/write in pure data.
+type txn struct {
     IsRead    bool
     Addr      uint64
     Size      uint64   // for reads
@@ -25,14 +25,13 @@ type Txn struct {
     RspTo     string
 }
 
-// State is the mutable runtime data of the controller.
-type State struct {
-    Mode     Mode
-    Inflight []Txn
+// state is the mutable runtime data of the controller.
+type state struct {
+    Mode     mode
+    Inflight []txn
 
     // If a drain command is pending response when Inflight becomes empty,
     // drainPending is true. We intentionally do not store the original
     // ControlMsg pointer in State to keep State purely serializable.
     DrainPending bool
 }
-

--- a/mem/idealmemcontrollerv5/state.go
+++ b/mem/idealmemcontrollerv5/state.go
@@ -1,0 +1,38 @@
+package idealmemcontrollerv5
+
+import (
+    "github.com/sarchlab/akita/v4/sim"
+)
+
+// Mode indicates the controller's high-level mode.
+type Mode int
+
+const (
+    ModeEnabled Mode = iota
+    ModePaused
+    ModeDraining
+)
+
+// Txn captures an in-flight read/write in pure data.
+type Txn struct {
+    IsRead    bool
+    Addr      uint64
+    Size      uint64   // for reads
+    Data      []byte   // for writes
+    DirtyMask []bool   // optional for writes
+    Remaining int      // countdown in cycles
+    Src       sim.RemotePort
+    RspTo     string
+}
+
+// State is the mutable runtime data of the controller.
+type State struct {
+    Mode     Mode
+    Inflight []Txn
+
+    // If a drain command is pending response when Inflight becomes empty,
+    // drainPending is true. We intentionally do not store the original
+    // ControlMsg pointer in State to keep State purely serializable.
+    DrainPending bool
+}
+

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -1,1 +1,82 @@
 # Migration Guide
+
+## Defining Components in V5: Philosophy and Patterns
+
+V5 unifies how components are modeled and wired. Each component is a single struct composed of four orthogonal parts: Spec, State, Ports, and Middlewares. The goals are: declarative configuration, local and serializable runtime state, explicit wiring, testability, and deterministic snapshot/restore.
+
+### Core Principles
+
+1. Spec (immutable configuration)
+   - Describes behavior and dependencies using only primitives (bool, number, string) and primitive maps/slices.
+   - Strategy dependencies are expressed as small primitive "sub‑specs" (e.g., `{ Kind: "interleaving", Params: { ... } }`).
+   - No pointers or live objects in Spec. Keep it JSON/YAML‑friendly and hashable.
+   - Validation and defaults are part of the component package (e.g., `validate()` + `defaults()`).
+
+2. State (mutable runtime data)
+   - Pure data only: scalars and slices/maps of primitives or simple structs thereof.
+   - No live handles, functions, channels, or ports in State.
+   - All cross‑references use stable identifiers (IDs), never in‑memory pointers.
+   - Snapshot/restore uses deep copies of State so checkpoints are immutable.
+
+3. Ports (externally injected)
+   - Components never construct or own connections. Ports are created/injected during wiring and registered via `AddPort(name, port)`.
+   - Components access ports by name via `GetPortByName("...")` to avoid compile‑time coupling.
+
+4. Middlewares (ordered, stateless over the component)
+   - Implement the per‑tick pipeline. Each middleware operates on the component’s State and interacts with Ports.
+   - Keep middlewares stateless wrt external dependencies; resolve them at build time and pass the resolved handles in.
+   - Prefer tick‑driven countdowns/backpressure over ad‑hoc scheduled events for simpler snapshots and determinism.
+
+### Dependency Injection and Shared State
+
+- Strategy injection (e.g., address conversion)
+  - Keep in Spec as a primitive descriptor (`Kind`, `Params`), not as a live object.
+  - Resolve to concrete implementations locally in the component builder and inject into middlewares.
+  - On restore, reconstruct from Spec; never serialize strategy objects.
+
+- Emulation state (e.g., memory storage)
+  - Treat as shared state separate from timing logic. Store only an ID (e.g., `StorageRef`) in Spec/State.
+  - Keep a per‑simulation state registry; components resolve handles by ID at runtime.
+  - Snapshot/restore orchestrates shared state once per ID (outside components); components snapshot only their own State.
+
+### Build and Wire (two stages)
+
+1. Build from Spec
+   - `Builder.WithSpec(spec).WithSimulation(sim).Build(name)` constructs the component with defaults and resolved strategies.
+   - Do not create or connect ports here.
+
+2. Wire topology
+   - Create ports and connections, then inject ports via `AddPort("...", port)`.
+   - Use names consistently so components and tooling can introspect topology.
+
+### Determinism and Introspection
+
+- Determinism: avoid non‑deterministic IDs or iteration order; snapshot ID generators; canonicalize map iteration by sorting.
+- Introspection: provide methods to inspect effective Spec (with defaults) and to dump State for debugging.
+- Tracing/metrics: attach as middlewares or hooks; avoid embedding tracing in business logic.
+
+### Testing and Mocks
+
+- Favor local interfaces inside the component package to reduce external coupling (e.g., `Storage`, `AddressConverter`, `StateAccessor`).
+- Generate mocks from local interfaces for unit tests; avoid importing remote mocks.
+- Drive behavior via ticks and ports; avoid requiring real engines or networks in unit tests.
+
+### Example: Ideal Memory Controller (V5)
+
+- Spec
+  - Timing: `Width`, `LatencyCycles`, `Freq`.
+  - Shared emulation: `StorageRef` (ID in simulation state registry).
+  - Strategy: `AddrConv` as `{ Kind, Params }` (e.g., identity/interleaving).
+
+- State
+  - Pure data transactions with countdowns; no ports or live pointers.
+  - Drain/enable mode as a small enum; deep‑copied for snapshots.
+
+- Ports
+  - `Top`, `Control` injected during wiring; accessed via name lookups.
+
+- Middlewares
+  - Data path: tick‑driven; consumes from `Top`, counts down latency, responds when ready; uses storage resolved via state registry by `StorageRef`.
+  - Control path: processes enable/pause/drain; replies only when safe (e.g., after drain completes).
+
+This pattern generalizes to other components: keep Spec primitive and declarative, keep State pure and serializable, inject Ports, and implement behavior as pipelines of middlewares with minimal, explicit dependencies.

--- a/simv5/builder.go
+++ b/simv5/builder.go
@@ -48,6 +48,7 @@ func (b Builder) Build() *Simulation {
         compNameIndex: make(map[string]int),
         portNameIndex: make(map[string]int),
         state:         newStateRegistry(),
+        conv:          newConverterRegistry(),
     }
 
     s.id = xid.New().String()

--- a/simv5/builder.go
+++ b/simv5/builder.go
@@ -47,7 +47,7 @@ func (b Builder) Build() *Simulation {
     s := &Simulation{
         compNameIndex: make(map[string]int),
         portNameIndex: make(map[string]int),
-        emu:           NewEmuStateRegistry(),
+        state:         newStateRegistry(),
     }
 
     s.id = xid.New().String()
@@ -73,4 +73,3 @@ func (b Builder) Build() *Simulation {
 
     return s
 }
-

--- a/simv5/builder.go
+++ b/simv5/builder.go
@@ -1,0 +1,76 @@
+package simv5
+
+import (
+    "github.com/rs/xid"
+    "github.com/sarchlab/akita/v4/datarecording"
+    "github.com/sarchlab/akita/v4/monitoring"
+    "github.com/sarchlab/akita/v4/sim"
+    "github.com/sarchlab/akita/v4/tracing"
+)
+
+// Builder can be used to build a v5 simulation. It mirrors simulation.Builder
+// and additionally initializes the EmuStateRegistry.
+type Builder struct {
+    parallelEngine bool
+    monitorOn      bool
+    outputFileName string
+}
+
+// MakeBuilder creates a new builder.
+func MakeBuilder() Builder {
+    return Builder{
+        parallelEngine: false,
+        monitorOn:      true,
+    }
+}
+
+// WithParallelEngine sets the simulation to use a parallel engine.
+func (b Builder) WithParallelEngine() Builder {
+    b.parallelEngine = true
+    return b
+}
+
+// WithoutMonitoring sets the simulation to not use monitoring.
+func (b Builder) WithoutMonitoring() Builder {
+    b.monitorOn = false
+    return b
+}
+
+// WithOutputFileName sets the custom output file name for the data recorder.
+func (b Builder) WithOutputFileName(filename string) Builder {
+    b.outputFileName = filename
+    return b
+}
+
+// Build builds the v5 simulation.
+func (b Builder) Build() *Simulation {
+    s := &Simulation{
+        compNameIndex: make(map[string]int),
+        portNameIndex: make(map[string]int),
+        emu:           NewEmuStateRegistry(),
+    }
+
+    s.id = xid.New().String()
+
+    outputPath := b.outputFileName
+    if outputPath == "" {
+        outputPath = "akita_sim_" + s.id
+    }
+    s.dataRecorder = datarecording.NewDataRecorder(outputPath)
+
+    s.engine = sim.NewSerialEngine()
+    if b.parallelEngine {
+        s.engine = sim.NewParallelEngine()
+    }
+
+    if b.monitorOn {
+        s.monitor = monitoring.NewMonitor()
+        s.monitor.RegisterEngine(s.engine)
+        s.monitor.StartServer()
+    }
+
+    s.visTracer = tracing.NewDBTracer(s.engine, s.dataRecorder)
+
+    return s
+}
+

--- a/simv5/builder.go
+++ b/simv5/builder.go
@@ -48,7 +48,6 @@ func (b Builder) Build() *Simulation {
         compNameIndex: make(map[string]int),
         portNameIndex: make(map[string]int),
         state:         newStateRegistry(),
-        conv:          newConverterRegistry(),
     }
 
     s.id = xid.New().String()

--- a/simv5/doc.go
+++ b/simv5/doc.go
@@ -1,0 +1,5 @@
+// Package simv5 provides v5 simulation scaffolding, including a shared
+// emulation state registry and a container struct that bundles an engine
+// with registries.
+package simv5
+

--- a/simv5/simulation.go
+++ b/simv5/simulation.go
@@ -4,26 +4,110 @@ import (
     "fmt"
     "sync"
 
+    "github.com/rs/xid"
+    "github.com/sarchlab/akita/v4/datarecording"
+    "github.com/sarchlab/akita/v4/monitoring"
     "github.com/sarchlab/akita/v4/sim"
+    "github.com/sarchlab/akita/v4/tracing"
 )
 
-// Simulation is the root object for a v5-style simulator. It carries the
-// discrete-event Engine and registries for shared emulation states.
+// Simulation mirrors the mature Simulation in the simulation package and adds
+// an emulation state registry for V5 components.
 type Simulation struct {
-    Engine sim.Engine
-    emu    *EmuStateRegistry
+    id           string
+    engine       sim.Engine
+    dataRecorder datarecording.DataRecorder
+    monitor      *monitoring.Monitor
+    visTracer    *tracing.DBTracer
+
+    components    []sim.Component
+    compNameIndex map[string]int
+    ports         []sim.Port
+    portNameIndex map[string]int
+
+    emu *EmuStateRegistry
 }
 
-// NewSimulation creates a Simulation wrapping the given engine.
+// NewSimulation wraps an engine into a Simulation with defaults.
 func NewSimulation(engine sim.Engine) *Simulation {
-    return &Simulation{Engine: engine, emu: NewEmuStateRegistry()}
+    s := &Simulation{
+        engine:        engine,
+        id:            xid.New().String(),
+        compNameIndex: make(map[string]int),
+        portNameIndex: make(map[string]int),
+        emu:           NewEmuStateRegistry(),
+    }
+    // Minimal default data recorder and tracer; monitoring can be added via builder.
+    s.dataRecorder = datarecording.NewDataRecorder("akita_sim_" + s.id)
+    s.visTracer = tracing.NewDBTracer(s.engine, s.dataRecorder)
+    return s
+}
+
+// ID returns the simulation ID.
+func (s *Simulation) ID() string { return s.id }
+
+// GetEngine returns the engine used in the simulation.
+func (s *Simulation) GetEngine() sim.Engine { return s.engine }
+
+// GetDataRecorder returns the data recorder.
+func (s *Simulation) GetDataRecorder() datarecording.DataRecorder { return s.dataRecorder }
+
+// GetMonitor returns the monitor used in the simulation.
+func (s *Simulation) GetMonitor() *monitoring.Monitor { return s.monitor }
+
+// GetVisTracer returns the tracer used in the simulation.
+func (s *Simulation) GetVisTracer() *tracing.DBTracer { return s.visTracer }
+
+// Components returns all the components registered in the simulation.
+func (s *Simulation) Components() []sim.Component { return s.components }
+
+// RegisterComponent registers a component with the simulation.
+func (s *Simulation) RegisterComponent(c sim.Component) {
+    compName := c.Name()
+    if s.compNameIndex[compName] != 0 {
+        panic("component " + compName + " already registered")
+    }
+    s.components = append(s.components, c)
+    s.compNameIndex[compName] = len(s.components) - 1
+    if s.monitor != nil {
+        s.monitor.RegisterComponent(c)
+    }
+    for _, p := range c.Ports() {
+        s.registerPort(p)
+    }
+}
+
+func (s *Simulation) registerPort(p sim.Port) {
+    portName := p.Name()
+    if s.portNameIndex[portName] != 0 {
+        panic("port " + portName + " already registered")
+    }
+    s.ports = append(s.ports, p)
+    s.portNameIndex[portName] = len(s.ports) - 1
+}
+
+// GetComponentByName returns the component with the given name.
+func (s *Simulation) GetComponentByName(name string) sim.Component {
+    return s.components[s.compNameIndex[name]]
+}
+
+// GetPortByName returns the port with the given name.
+func (s *Simulation) GetPortByName(name string) sim.Port {
+    return s.ports[s.portNameIndex[name]]
+}
+
+// Terminate terminates the simulation.
+func (s *Simulation) Terminate() {
+    s.dataRecorder.Close()
+    if s.monitor != nil {
+        s.monitor.StopServer()
+    }
 }
 
 // Emu returns the emulation state registry.
 func (s *Simulation) Emu() *EmuStateRegistry { return s.emu }
 
-// EmuStateRegistry is a threadsafe registry for shared emulation states
-// (e.g., memory/storage images) keyed by ID.
+// EmuStateRegistry is a threadsafe registry for shared emulation states.
 type EmuStateRegistry struct {
     mu    sync.RWMutex
     items map[string]interface{}
@@ -66,4 +150,3 @@ func (r *EmuStateRegistry) Delete(id string) {
     delete(r.items, id)
     r.mu.Unlock()
 }
-

--- a/simv5/simulation.go
+++ b/simv5/simulation.go
@@ -1,0 +1,69 @@
+package simv5
+
+import (
+    "fmt"
+    "sync"
+
+    "github.com/sarchlab/akita/v4/sim"
+)
+
+// Simulation is the root object for a v5-style simulator. It carries the
+// discrete-event Engine and registries for shared emulation states.
+type Simulation struct {
+    Engine sim.Engine
+    emu    *EmuStateRegistry
+}
+
+// NewSimulation creates a Simulation wrapping the given engine.
+func NewSimulation(engine sim.Engine) *Simulation {
+    return &Simulation{Engine: engine, emu: NewEmuStateRegistry()}
+}
+
+// Emu returns the emulation state registry.
+func (s *Simulation) Emu() *EmuStateRegistry { return s.emu }
+
+// EmuStateRegistry is a threadsafe registry for shared emulation states
+// (e.g., memory/storage images) keyed by ID.
+type EmuStateRegistry struct {
+    mu    sync.RWMutex
+    items map[string]interface{}
+}
+
+// NewEmuStateRegistry creates an empty registry.
+func NewEmuStateRegistry() *EmuStateRegistry {
+    return &EmuStateRegistry{items: make(map[string]interface{})}
+}
+
+// Register associates an ID with a value. Returns error if ID already exists.
+func (r *EmuStateRegistry) Register(id string, v interface{}) error {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    if _, exists := r.items[id]; exists {
+        return fmt.Errorf("emu state id already registered: %s", id)
+    }
+    r.items[id] = v
+    return nil
+}
+
+// Put sets an ID with a value, overwriting any existing value.
+func (r *EmuStateRegistry) Put(id string, v interface{}) {
+    r.mu.Lock()
+    r.items[id] = v
+    r.mu.Unlock()
+}
+
+// Get returns the raw value and whether it exists.
+func (r *EmuStateRegistry) Get(id string) (interface{}, bool) {
+    r.mu.RLock()
+    v, ok := r.items[id]
+    r.mu.RUnlock()
+    return v, ok
+}
+
+// Delete removes an item.
+func (r *EmuStateRegistry) Delete(id string) {
+    r.mu.Lock()
+    delete(r.items, id)
+    r.mu.Unlock()
+}
+

--- a/simv5/simulation.go
+++ b/simv5/simulation.go
@@ -7,7 +7,6 @@ import (
     "github.com/rs/xid"
     "github.com/sarchlab/akita/v4/datarecording"
     "github.com/sarchlab/akita/v4/monitoring"
-    "github.com/sarchlab/akita/v4/mem/mem"
     "github.com/sarchlab/akita/v4/sim"
     "github.com/sarchlab/akita/v4/tracing"
 )
@@ -27,7 +26,6 @@ type Simulation struct {
     portNameIndex map[string]int
 
     state *stateRegistry
-    conv  *converterRegistry
 }
 
 // NewSimulation wraps an engine into a Simulation with defaults.
@@ -38,7 +36,6 @@ func NewSimulation(engine sim.Engine) *Simulation {
         compNameIndex: make(map[string]int),
         portNameIndex: make(map[string]int),
         state:         newStateRegistry(),
-        conv:          newConverterRegistry(),
     }
     // Minimal default data recorder and tracer; monitoring can be added via builder.
     s.dataRecorder = datarecording.NewDataRecorder("akita_sim_" + s.id)
@@ -164,61 +161,3 @@ func (s *Simulation) GetState(id string) (interface{}, bool) { return s.state.ge
 
 // DeleteState removes a shared emulation state by ID.
 func (s *Simulation) DeleteState(id string) { s.state.delete(id) }
-
-// Address converter DI -------------------------------------------------------
-
-// AddressConverterFactory builds a mem.AddressConverter from primitive params.
-type AddressConverterFactory func(params map[string]uint64) (mem.AddressConverter, error)
-
-type converterRegistry struct {
-    mu    sync.RWMutex
-    items map[string]AddressConverterFactory
-}
-
-func newConverterRegistry() *converterRegistry {
-    return &converterRegistry{items: make(map[string]AddressConverterFactory)}
-}
-
-// RegisterAddressConverter registers a factory for a given kind.
-func (s *Simulation) RegisterAddressConverter(kind string, f AddressConverterFactory) error {
-    s.conv.mu.Lock()
-    defer s.conv.mu.Unlock()
-    if _, ok := s.conv.items[kind]; ok {
-        return fmt.Errorf("address converter kind already registered: %s", kind)
-    }
-    s.conv.items[kind] = f
-    return nil
-}
-
-// BuildAddressConverter resolves a converter by kind/params. Provides built-in
-// defaults for "identity" and "interleaving" if not registered.
-func (s *Simulation) BuildAddressConverter(kind string, params map[string]uint64) (mem.AddressConverter, error) {
-    if kind == "" || kind == "identity" {
-        return identityConverter{}, nil
-    }
-
-    s.conv.mu.RLock()
-    f, ok := s.conv.items[kind]
-    s.conv.mu.RUnlock()
-    if ok {
-        return f(params)
-    }
-
-    switch kind {
-    case "interleaving":
-        var c mem.InterleavingConverter
-        if v, ok := params["InterleavingSize"]; ok { c.InterleavingSize = v } else { return nil, fmt.Errorf("missing InterleavingSize") }
-        if v, ok := params["TotalNumOfElements"]; ok { c.TotalNumOfElements = int(v) } else { return nil, fmt.Errorf("missing TotalNumOfElements") }
-        if v, ok := params["CurrentElementIndex"]; ok { c.CurrentElementIndex = int(v) } else { return nil, fmt.Errorf("missing CurrentElementIndex") }
-        if v, ok := params["Offset"]; ok { c.Offset = v } else { c.Offset = 0 }
-        return c, nil
-    default:
-        return nil, fmt.Errorf("unknown address converter kind: %s", kind)
-    }
-}
-
-// identityConverter implements mem.AddressConverter as a no-op.
-type identityConverter struct{}
-
-func (identityConverter) ConvertExternalToInternal(external uint64) uint64 { return external }
-func (identityConverter) ConvertInternalToExternal(internal uint64) uint64 { return internal }


### PR DESCRIPTION
This PR adds a V5-style Ideal Memory Controller:

- Spec: immutable config with defaults/validation (width, latency cycles, freq, buffers, capacity, unit size)
- State: pure-data Mode/Txn/State with in-flight tracking; snapshot/restore entry points
- Ports: explicit Top and Control ports, created in builder
- Middlewares: ctrl + mem middlewares; ordered pipeline
- Tick-driven: removes ad-hoc respond events; uses countdown and port backpressure retries
- Tests: basic read, write, control drain flow

Notes:
- Drain response after snapshot: pending drain ControlMsg pointer is not in State; across snapshots, the controller will finish draining and transition to paused without re-emitting the missed response; can be extended by persisting a response template if needed.

Package path: mem/idealmemcontrollerv5
