### PR TITLE
Add minimal transactional state manager package

### DIFF
--- a/v5/sim/state/example_manager_test.go
+++ b/v5/sim/state/example_manager_test.go
@@ -1,0 +1,23 @@
+package state
+
+import "fmt"
+
+type ExampleState struct {
+	Items []string
+}
+
+// ExampleManager_round demonstrates a simple round-style workflow.
+func ExampleManager_round() {
+	manager := NewManager()
+	_ = manager.Register("queue", &ExampleState{Items: []string{"a"}})
+
+	staged, _ := manager.Stage("queue")
+	queue := staged.(*ExampleState)
+	queue.Items = append(queue.Items, "b")
+
+	manager.CommitAll()
+
+	loaded, _ := manager.Load("queue")
+	fmt.Println(loaded.(*ExampleState).Items)
+	// Output: [a b]
+}

--- a/v5/sim/state/manager.go
+++ b/v5/sim/state/manager.go
@@ -71,7 +71,8 @@ func (m *Manager) Load(key string) (any, error) {
 
 // Stage returns a mutable copy of the active value for the provided key. The
 // same staged value is returned on subsequent calls within the same staging
-// window.
+// window so that multiple callers coordinating within a round all edit the
+// identical staged state.
 func (m *Manager) Stage(key string) (any, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/v5/sim/state/manager.go
+++ b/v5/sim/state/manager.go
@@ -1,0 +1,177 @@
+package state
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// Manager owns named state objects and coordinates transactional updates.
+type Manager struct {
+	mu      sync.RWMutex
+	entries map[string]*entry
+}
+
+type entry struct {
+	typ       reflect.Type
+	active    any
+	staged    any
+	hasStaged bool
+}
+
+// NewManager constructs a Manager with no registered states.
+func NewManager() *Manager {
+	return &Manager{entries: make(map[string]*entry)}
+}
+
+// Register installs a new state value under the provided key.
+// The supplied value becomes the active value for that key and is deep copied
+// so that further mutations to the original value do not affect the manager.
+func (m *Manager) Register(key string, value any) error {
+	if key == "" {
+		return fmt.Errorf("state: key must be non-empty")
+	}
+	if value == nil {
+		return fmt.Errorf("state: value for %q must be non-nil", key)
+	}
+
+	copyVal, err := deepCopy(value)
+	if err != nil {
+		return fmt.Errorf("state: unable to copy value for %q: %w", key, err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.entries[key]; exists {
+		return fmt.Errorf("state: key %q already registered", key)
+	}
+
+	m.entries[key] = &entry{
+		typ:    reflect.TypeOf(value),
+		active: copyVal,
+	}
+
+	return nil
+}
+
+// Load returns a deep copy of the active value stored under key.
+func (m *Manager) Load(key string) (any, error) {
+	m.mu.RLock()
+	e, ok := m.entries[key]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("state: key %q is not registered", key)
+	}
+
+	return deepCopy(e.active)
+}
+
+// Stage returns a mutable copy of the active value for the provided key. The
+// same staged value is returned on subsequent calls within the same staging
+// window.
+func (m *Manager) Stage(key string) (any, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	e, ok := m.entries[key]
+	if !ok {
+		return nil, fmt.Errorf("state: key %q is not registered", key)
+	}
+
+	if e.hasStaged {
+		return e.staged, nil
+	}
+
+	copyVal, err := deepCopy(e.active)
+	if err != nil {
+		return nil, fmt.Errorf("state: unable to copy value for %q: %w", key, err)
+	}
+
+	e.staged = copyVal
+	e.hasStaged = true
+	return e.staged, nil
+}
+
+// Commit writes the staged value for key into the active slot. It is an error
+// to call Commit when there is no staged value.
+func (m *Manager) Commit(key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	e, ok := m.entries[key]
+	if !ok {
+		return fmt.Errorf("state: key %q is not registered", key)
+	}
+	if !e.hasStaged {
+		return fmt.Errorf("state: key %q has no staged value", key)
+	}
+
+	e.active = e.staged
+	e.staged = nil
+	e.hasStaged = false
+	return nil
+}
+
+// CommitAll applies all staged values to their corresponding active entries.
+func (m *Manager) CommitAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, e := range m.entries {
+		if e.hasStaged {
+			e.active = e.staged
+			e.staged = nil
+			e.hasStaged = false
+		}
+	}
+}
+
+// DiscardAll forgets every staged value without committing it.
+func (m *Manager) DiscardAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, e := range m.entries {
+		e.staged = nil
+		e.hasStaged = false
+	}
+}
+
+func deepCopy(value any) (any, error) {
+	registerGobType(value)
+
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(value); err != nil {
+		return nil, err
+	}
+
+	typ := reflect.TypeOf(value)
+	var target reflect.Value
+	if typ.Kind() == reflect.Ptr {
+		target = reflect.New(typ.Elem())
+	} else {
+		target = reflect.New(typ)
+	}
+
+	dec := gob.NewDecoder(&buf)
+	if err := dec.Decode(target.Interface()); err != nil {
+		return nil, err
+	}
+
+	if typ.Kind() == reflect.Ptr {
+		return target.Interface(), nil
+	}
+	return target.Elem().Interface(), nil
+}
+
+func registerGobType(value any) {
+	typ := reflect.TypeOf(value)
+	gob.Register(value)
+	if typ.Kind() != reflect.Ptr {
+		gob.Register(reflect.New(typ).Interface())
+	}
+}

--- a/v5/sim/state/manager_test.go
+++ b/v5/sim/state/manager_test.go
@@ -1,0 +1,89 @@
+package state
+
+import "testing"
+
+type counterState struct {
+	Counter int
+}
+
+type pointerState struct {
+	Values []int
+}
+
+func TestManagerStageAndCommit(t *testing.T) {
+	m := NewManager()
+
+	if err := m.Register("counter", &counterState{Counter: 1}); err != nil {
+		t.Fatalf("register counter: %v", err)
+	}
+
+	staged, err := m.Stage("counter")
+	if err != nil {
+		t.Fatalf("stage counter: %v", err)
+	}
+
+	counter := staged.(*counterState)
+	counter.Counter++
+
+	if err := m.Commit("counter"); err != nil {
+		t.Fatalf("commit counter: %v", err)
+	}
+
+	loaded, err := m.Load("counter")
+	if err != nil {
+		t.Fatalf("load counter: %v", err)
+	}
+
+	if loaded.(*counterState).Counter != 2 {
+		t.Fatalf("expected counter to be 2, got %d", loaded.(*counterState).Counter)
+	}
+
+	if err := m.Register("counter", &counterState{}); err == nil {
+		t.Fatalf("expected duplicate key error")
+	}
+}
+
+func TestManagerCommitAllAndDiscard(t *testing.T) {
+	m := NewManager()
+
+	if err := m.Register("ptr", &pointerState{Values: []int{1, 2}}); err != nil {
+		t.Fatalf("register ptr: %v", err)
+	}
+
+	staged, err := m.Stage("ptr")
+	if err != nil {
+		t.Fatalf("stage ptr: %v", err)
+	}
+
+	ptr := staged.(*pointerState)
+	ptr.Values = append(ptr.Values, 3)
+
+	m.DiscardAll()
+
+	loaded, err := m.Load("ptr")
+	if err != nil {
+		t.Fatalf("load ptr: %v", err)
+	}
+
+	if len(loaded.(*pointerState).Values) != 2 {
+		t.Fatalf("discard should have removed staged update")
+	}
+
+	staged, err = m.Stage("ptr")
+	if err != nil {
+		t.Fatalf("stage ptr second time: %v", err)
+	}
+	ptr = staged.(*pointerState)
+	ptr.Values = append(ptr.Values, 4)
+
+	m.CommitAll()
+
+	loaded, err = m.Load("ptr")
+	if err != nil {
+		t.Fatalf("load ptr after commit: %v", err)
+	}
+
+	if got := loaded.(*pointerState).Values; len(got) != 3 || got[2] != 4 {
+		t.Fatalf("commit all did not apply staged update, got %v", got)
+	}
+}

--- a/v5/sim/state_manager_integration.md
+++ b/v5/sim/state_manager_integration.md
@@ -1,0 +1,119 @@
+# State Manager Integration Guide
+
+This document elaborates on how the proposed v5 state manager cooperates with existing simulation components, the `Simulation` struct, and both execution engines.
+
+## Architectural Positioning
+
+The state manager becomes a core dependency of `sim.Simulation`. Instead of the current `stateRegistry` map, the simulation now owns a `state.Manager` instance responsible for registering component state, providing transactional access, and handling serialization. The simulation exposes thin wrappers that delegate to the manager so callers do not depend on the manager’s internals.
+
+```
+type Simulation struct {
+    ...
+    stateMgr *state.Manager
+}
+
+func (s *Simulation) RegisterState(id string, def state.Definition) error
+func (s *Simulation) LoadState(id string, dst any) error
+func (s *Simulation) StageState(id string) (state.Transaction, error)
+func (s *Simulation) BeginRound(ctx state.RoundContext) state.RoundGuard
+```
+
+The simulation also re-exports serialization helpers (`SaveState`, `LoadState`) so engines and orchestration tools can capture checkpoints without touching the manager directly.
+
+## Component Interaction Model
+
+Components already interact with the simulation through `sim.Component` and `sim.Driver` interfaces. The new manager preserves this contract by giving components two avenues for state access:
+
+1. **Registration at build time.** During `builder.Build`, each component calls `simulation.RegisterState` with a schema describing its internal data. Simple structs or slices pass validation automatically; complex structures supply an adapter implementing the `state.Adapter` interface (snapshot, delta, apply, marshal/unmarshal).
+2. **Per-cycle access through `StateAccessor`.** Replace the current `StateAccessor` with a richer interface that components receive during event processing:
+
+   ```
+   type StateAccessor interface {
+       Load(id string, dst any) error
+       Stage(id string) (state.Transaction, error)
+   }
+   ```
+
+   - `Load` returns a defensive snapshot (copy or adapter-backed view) suitable for read-only operations within the tick.
+   - `Stage` yields a `state.Transaction` handle that exposes mutation helpers prepared during registration. For simple structs the handle offers `Mutable() *T`, returning a copy-on-write pointer. For adapters, the handle exposes domain-specific methods such as `WriteRange`, `Push`, or `Pop`.
+
+Components continue to express their behavior in terms of simulation cycles; the transaction handle simply accumulates changes until the engine closes the round.
+
+## Round-Oriented Execution Model
+
+Both the serial and parallel engines group work into **rounds**. A round is the execution of all events scheduled at the same simulation timestamp. Transactions created through `Stage` are therefore round-scoped: they become visible to other events only after the entire round finishes and the engine commits the collected mutations. This mirrors the existing event semantics—events in the same timestep should observe the pre-round state—while giving the manager a well-defined boundary for commit/rollback.
+
+The manager tracks the currently active round via a `state.RoundContext` supplied by the engine. The context exposes:
+
+```go
+type RoundContext interface {
+    ID() uint64            // Monotonic per engine, useful for logging and debugging
+    Timestamp() sim.VTime  // Simulation time shared by all events in the round
+}
+```
+
+Each transaction records the `RoundContext` that spawned it. A commit request that does not match the active round is rejected, preventing accidental leakage across time boundaries.
+
+## Serial Engine Workflow
+
+The serial engine still processes one event at a time, but it wraps all events sharing the same timestamp into a single round:
+
+1. When the scheduler dequeues the first event for a timestamp, it calls `guard := stateMgr.BeginRound(ctx)` to create the round context and clear leftovers from the prior round.
+2. For every event in that timestamp:
+   - the engine provides a `StateAccessor` backed by the round context;
+   - the component uses `Load`/`Stage` exactly as before, with all staged updates tracked against the round ID.
+3. After the final event of the timestamp executes, the engine invokes `guard.FinishRound(ctx)`.
+   - Because execution is serial, the commit should never encounter conflicts; if it does, the engine can treat it as a fatal bug.
+4. The engine advances to the next timestamp, calling `BeginRound` again if more events exist.
+
+`FinishRound` flushes every staged transaction atomically, ensuring that no event in the same round observes another event’s writes prematurely.
+
+## Parallel Engine Workflow
+
+Parallel engines schedule multiple components concurrently but still execute in rounds. The manager provides a `state.RoundGuard` to the engine when `BeginRound` is called:
+
+```go
+type RoundGuard interface {
+    BeginTransaction(workerID string) state.CycleTxn
+    StageTransaction(tx state.CycleTxn) error
+    FinishRound(ctx RoundContext) error
+    AbortRound(ctx RoundContext)
+}
+```
+
+- `BeginRound` clears previous state, initializes bookkeeping for conflict detection, and returns a guard the engine must use for the remainder of the round.
+- Each worker handling an event in the round calls `BeginTransaction` to obtain a `CycleTxn` bound to the round. The transaction records the worker ID, the state keys it touches, and their base versions.
+- When a worker finishes, it submits the transaction via `StageTransaction`. The guard keeps the transaction pending until all workers finish or the engine determines the round should end early.
+- `FinishRound` atomically commits the staged transactions, applying only those that are mutually compatible. If conflicts appear (e.g., two workers wrote the same state entry), the guard rejects the commit and reports the conflicting transaction IDs.
+- The engine can retry conflicts by rescheduling the affected events in a subsequent round or, if progress is impossible, call `AbortRound` to discard all staged work for the timestamp.
+
+## Interfaces Summary
+
+- `Simulation`
+  - `RegisterState(id string, def state.Definition) error`
+  - `LoadState(id string, dst any) error`
+  - `StageState(id string) (state.Transaction, error)`
+  - `BeginRound(ctx state.RoundContext) state.RoundGuard`
+  - `SaveState(w io.Writer, format Format) error`
+  - `LoadState(r io.Reader, format Format) error`
+
+- `state.Transaction`
+  - `Mutable() any` for copy-on-write structs
+  - Adapter-specific methods via generated interfaces (e.g., `MemoryDelta`, `BufferDelta`)
+  - `Commit()`/`Discard()` handled internally by the manager; external callers only receive the handle.
+
+- `state.RoundContext`
+  - `ID() uint64`
+  - `Timestamp() sim.VTime`
+
+- `state.RoundGuard`
+  - `BeginTransaction(workerID string) state.CycleTxn`
+  - `StageTransaction(tx state.CycleTxn) error`
+  - `FinishRound(ctx RoundContext) error`
+  - `AbortRound(ctx RoundContext)`
+
+- `StateAccessor` (supplied to component handlers)
+  - `Load(id string, dst any) error`
+  - `Stage(id string) (state.Transaction, error)`
+
+This structure keeps existing component logic largely intact while centralizing state safety within the manager. Serial execution remains fast thanks to low-overhead staging, and parallel execution gains the conflict detection needed for deterministic commits.


### PR DESCRIPTION
## Summary
- introduce a v5/sim/state package with a basic Manager supporting register/load/stage/commit flows
- provide unit tests covering staging, commit, discard, and example usage for documentation

## Testing
- go test ./v5/sim/state

------
https://chatgpt.com/codex/tasks/task_e_68e5c31354388325af6f7546f3f549d8