### PR TITLE
Remove obsolete V5 Development section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,5 @@ across a handful of runnable examples. Start with [Your First
 Component](https://akitasim.dev/docs/akita/tutorial/components/what_is_a_component)
 or browse [`examples/`](examples/) directly.
 
-## V5 Development
-
-Akita v5 is being developed alongside v4. V5 packages are being added to the
-v4 codebase for now, and v4 users can safely ignore these packages since
-they maintain full backward compatibility. For v5 plans and progress, see
-[issue #304](https://github.com/sarchlab/akita/issues/304) and the
-[v5 milestone](https://github.com/sarchlab/akita/milestone).
-
 For migration between versions, see the
-[Migration Guide](doc/core/migration.md).
+[Migration Guide](doc/tutorial/migration.md).


### PR DESCRIPTION
Now that main is v5 (v5.0.0-beta.2), the README section describing v5 as being developed alongside v4 is no longer valid. This removes that section.

Also fixes the Migration Guide link, which pointed to `doc/core/migration.md` — the file actually lives at `doc/tutorial/migration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)