### PR TITLE
Add Domain back to the modeling package

### DIFF
--- a/modeling/README.md
+++ b/modeling/README.md
@@ -78,6 +78,22 @@ Wakeups are scheduled via:
 Port notifications (`NotifyRecv`, `NotifyPortFree`) automatically schedule
 wakeups.
 
+### Domain
+
+A named bundle of components that exposes selected internal ports at its
+boundary. Domains nest — components form a domain (e.g., a shader array),
+and domains compose into larger domains (e.g., a GPU) — with hierarchical
+names following the `Domain.Domain.Component` convention.
+
+```go
+gpu := modeling.NewDomain("GPU[0]")
+gpu.DeclarePort("Top")
+gpu.AssignPort("Top", commandProcessor.GetPortByName("ToDriver"))
+
+// Outside code addresses the domain, not its internals.
+port := gpu.GetPortByName("Top")
+```
+
 ## Builder Pattern
 
 | Builder | Creates | Key Settings |

--- a/modeling/doc.go
+++ b/modeling/doc.go
@@ -7,6 +7,7 @@
 //   - Middleware pipeline for tick-based components
 //   - EventDrivenComponent[S, T] for event-driven components
 //   - Validation helpers for Spec and State types
+//   - Domain for bundling components and exposing ports at a boundary
 //
 // The timing package provides the simulation kernel. The messaging package
 // provides ports and connections. The modeling package provides the

--- a/modeling/domain.go
+++ b/modeling/domain.go
@@ -1,0 +1,37 @@
+package modeling
+
+import (
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/naming"
+)
+
+// Domain is a named bundle of components. It exposes a subset of its internal
+// components' ports at the domain boundary, so the outside world communicates
+// with the domain without knowing its internal structure. Domains nest:
+// components form a domain (e.g., a shader array), and domains compose into
+// larger domains (e.g., a GPU), with hierarchical names following the
+// "Domain.Domain.Component" convention.
+//
+// A domain declares its boundary ports with DeclarePort and exposes an
+// internal component's port with AssignPort, following the same declare/assign
+// idiom as components.
+type Domain struct {
+	*messaging.PortOwnerBase
+
+	name string
+}
+
+// NewDomain creates a new Domain with the given hierarchical name.
+func NewDomain(name string) *Domain {
+	naming.MustBeValid(name)
+
+	return &Domain{
+		PortOwnerBase: messaging.NewPortOwnerBase(),
+		name:          name,
+	}
+}
+
+// Name returns the name of the domain.
+func (d *Domain) Name() string {
+	return d.name
+}

--- a/modeling/domain_test.go
+++ b/modeling/domain_test.go
@@ -1,0 +1,59 @@
+package modeling_test
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+)
+
+func TestDomainName(t *testing.T) {
+	d := modeling.NewDomain("GPU[0]")
+
+	if d.Name() != "GPU[0]" {
+		t.Errorf("expected name %q, got %q", "GPU[0]", d.Name())
+	}
+}
+
+func TestDomainNameMustBeValid(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected NewDomain to panic on an invalid name")
+		}
+	}()
+
+	modeling.NewDomain("invalid_name")
+}
+
+func TestDomainExposesPorts(t *testing.T) {
+	d := modeling.NewDomain("GPU")
+	port := messaging.NewPort(nil, 1, 1, "GPU.Driver.ToGPU")
+
+	d.DeclarePort("Top")
+	d.AssignPort("Top", port)
+
+	if d.GetPortByName("Top") != port {
+		t.Error("expected GetPortByName to return the assigned port")
+	}
+
+	ports := d.Ports()
+	if len(ports) != 1 || ports[0] != port {
+		t.Error("expected Ports to list the assigned port")
+	}
+}
+
+func TestDomainNesting(t *testing.T) {
+	gpu := modeling.NewDomain("GPU[0]")
+	sa := modeling.NewDomain("GPU[0].SA[1]")
+	port := messaging.NewPort(nil, 1, 1, "GPU[0].SA[1].L1Cache.Top")
+
+	sa.DeclarePort("Top")
+	sa.AssignPort("Top", port)
+
+	gpu.DeclarePort("Mem")
+	gpu.AssignPort("Mem", sa.GetPortByName("Top"))
+
+	if gpu.GetPortByName("Mem") != port {
+		t.Error("expected the nested domain's port to be exposed by the outer domain")
+	}
+}


### PR DESCRIPTION
## Summary

- Re-add the `Domain` concept from v4 (`sim/domain.go`) to the v5 `modeling` package. A Domain is a named bundle of components that exposes selected internal ports at its boundary, so the outside world communicates with the domain without knowing its internal structure.
- Adapted to v5 idioms: embeds `messaging.PortOwnerBase` (declare/assign ports) and validates its hierarchical name with `naming.MustBeValid`. Domains nest — components form a domain (e.g., a shader array), domains compose into larger domains (e.g., a GPU) — with hierarchical `Domain.Domain.Component` names.
- Add tests covering naming, name validation, port exposure, and nested domains; document Domain in `modeling/doc.go` and the modeling README.

## Test plan

- `go build ./...`
- `go test ./modeling/ ./messaging/`
- `golangci-lint run ./modeling/` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)