### PR TITLE
fix(tracing): guard DBTracer task methods against post-Terminate nil-map panic

### DIFF
--- a/tracing/dbtracer.go
+++ b/tracing/dbtracer.go
@@ -94,6 +94,12 @@ func (t *DBTracer) StartTask(task TaskStart) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	// Ignore task activity after termination. Terminate() sets tracingTasks
+	// to nil, so writing to the map below would panic.
+	if t.terminated {
+		return
+	}
+
 	t.startingTaskMustBeValid(task)
 
 	// A task may first be mentioned by a tag or a milestone.
@@ -138,6 +144,10 @@ func (t *DBTracer) AddTaskTag(tag TaskTag) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	if t.terminated {
+		return
+	}
+
 	task, found := t.tracingTasks[tag.TaskID]
 	if !found {
 		task = &runningTask{}
@@ -152,6 +162,10 @@ func (t *DBTracer) AddTaskTag(tag TaskTag) {
 func (t *DBTracer) AddMilestone(milestone Milestone) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	if t.terminated {
+		return
+	}
 
 	task, found := t.tracingTasks[milestone.TaskID]
 	if !found {
@@ -182,6 +196,10 @@ func sameMilestone(a, b Milestone) bool {
 func (t *DBTracer) EndTask(task TaskEnd) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	if t.terminated {
+		return
+	}
 
 	originalTask, ok := t.tracingTasks[task.ID]
 	if !ok {

--- a/tracing/dbtracer_terminate_test.go
+++ b/tracing/dbtracer_terminate_test.go
@@ -1,0 +1,61 @@
+package tracing
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/sarchlab/akita/v5/datarecording"
+)
+
+var _ = Describe("DBTracer Termination", func() {
+	var (
+		timeTeller   *testTimeTeller
+		dataRecorder datarecording.DataRecorder
+		tracer       *DBTracer
+		dbPath       string
+	)
+
+	BeforeEach(func() {
+		timeTeller = &testTimeTeller{}
+		dbPath = "test_trace_terminate"
+		os.Remove(dbPath + ".sqlite3")
+		dataRecorder = datarecording.NewDataRecorder(dbPath)
+		tracer = NewDBTracer(timeTeller, dataRecorder)
+	})
+
+	AfterEach(func() {
+		if dataRecorder != nil {
+			dataRecorder.Close()
+			os.Remove(dbPath + ".sqlite3")
+		}
+	})
+
+	// Regression test: Terminate() sets tracingTasks to nil. Any task activity
+	// arriving afterwards (e.g. an in-flight request completing during teardown)
+	// must be ignored rather than panic with "assignment to entry in nil map".
+	It("should ignore task activity that arrives after Terminate", func() {
+		tracer.StartTracing()
+		tracer.Terminate()
+
+		Expect(func() {
+			tracer.StartTask(TaskStart{
+				ID:       1,
+				Kind:     "req",
+				What:     "read",
+				Location: "L1",
+				Time:     100,
+			})
+			tracer.AddTaskTag(TaskTag{ID: 2, TaskID: 1, What: "tag", Time: 100})
+			tracer.AddMilestone(Milestone{
+				ID:     3,
+				TaskID: 1,
+				Time:   100,
+				Kind:   MilestoneKindHardwareResource,
+				What:   "resource_acquired",
+			})
+			tracer.EndTask(TaskEnd{ID: 1, Time: 200})
+		}).ToNot(Panic())
+	})
+})


### PR DESCRIPTION
## Summary

`DBTracer.Terminate()` sets `t.tracingTasks = nil`. Any task-recording call that arrives **after** termination — e.g. an in-flight request completing during simulation teardown — then writes to the nil map and panics with `assignment to entry in nil map`.

This adds an early `if t.terminated { return }` guard to the four task-recording entry points (`StartTask`, `AddTaskTag`, `AddMilestone`, `EndTask`) so post-termination activity is ignored instead of crashing.

## The bug

- `Terminate()` sets `tracingTasks = nil`.
- `StartTask` / `AddTaskTag` / `AddMilestone` each do `t.tracingTasks[id] = ...` for a not-yet-seen task ID → write to a nil map → panic.
- `EndTask` only reads + `delete`s (both safe on a nil map), so it doesn't panic, but it's guarded too for consistency.

## Test

Adds `tracing/dbtracer_terminate_test.go` — a regression test that terminates a tracer and then issues `StartTask`/`AddTaskTag`/`AddMilestone`/`EndTask`, asserting no panic.

Confirmed it **fails without** the fix:

```
[FAILED] Expected not to panic, but panicked with
    assignment to entry in nil map
```

and **passes with** it (`go test ./tracing/` → 25 passed).

## Context

Found while reviewing local patches MGPUSim had applied to a vendored Akita V5 snapshot; the underlying bug is still present in current `main`, so the fix belongs upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
