### PR TITLE
fix(mem/cache): reuse removed transaction slots to bound Transactions slice

### DIFF
--- a/mem/cache/writeback/comp.go
+++ b/mem/cache/writeback/comp.go
@@ -93,10 +93,23 @@ type State struct {
 // instead of growing with every request ever issued.
 func (s *State) allocTransaction(t transactionState) int {
 	for i := range s.Transactions {
-		if s.Transactions[i].Removed {
-			s.Transactions[i] = t
-			return i
+		if !s.Transactions[i].Removed {
+			continue
 		}
+
+		// The MSHR stage drains the waiter list of the transaction at
+		// ProcessingMSHREntryIdx across multiple ticks. That owner
+		// transaction is itself one of its waiters, so it is commonly marked
+		// Removed before the list is fully drained — yet its
+		// MSHRTransactionIndices must stay intact until the stage releases it.
+		// Skip its slot so a later top request in the same tick (topParser
+		// runs after mshrStage) cannot overwrite the pending waiter list.
+		if s.HasProcessingMSHREntry && i == s.ProcessingMSHREntryIdx {
+			continue
+		}
+
+		s.Transactions[i] = t
+		return i
 	}
 
 	s.Transactions = append(s.Transactions, t)

--- a/mem/cache/writeback/comp.go
+++ b/mem/cache/writeback/comp.go
@@ -85,6 +85,24 @@ type State struct {
 	ProcessingFlush         flushReqState `json:"processing_flush"`
 }
 
+// allocTransaction stores t in the Transactions slice and returns its index.
+// Completed transactions are marked Removed but their slots are never deleted
+// (other stages hold indices into the slice via the various buffers and the
+// MSHR, so indices must stay stable). Reuse a Removed slot when one is
+// available so the slice stays bounded by the number of active transactions
+// instead of growing with every request ever issued.
+func (s *State) allocTransaction(t transactionState) int {
+	for i := range s.Transactions {
+		if s.Transactions[i].Removed {
+			s.Transactions[i] = t
+			return i
+		}
+	}
+
+	s.Transactions = append(s.Transactions, t)
+	return len(s.Transactions) - 1
+}
+
 // flushReqState is a serializable representation of a flush control request.
 type flushReqState struct {
 	MsgMeta messaging.MsgMeta `json:"msg_meta"`

--- a/mem/cache/writeback/comp_test.go
+++ b/mem/cache/writeback/comp_test.go
@@ -1,0 +1,75 @@
+package writeback
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("State allocTransaction", func() {
+	var state *State
+
+	BeforeEach(func() {
+		state = &State{}
+	})
+
+	It("should append when no Removed slot is available", func() {
+		idx0 := state.allocTransaction(transactionState{ID: 1})
+		idx1 := state.allocTransaction(transactionState{ID: 2})
+
+		Expect(idx0).To(Equal(0))
+		Expect(idx1).To(Equal(1))
+		Expect(state.Transactions).To(HaveLen(2))
+	})
+
+	It("should reuse a Removed slot instead of growing the slice", func() {
+		state.allocTransaction(transactionState{ID: 1})
+		idx1 := state.allocTransaction(transactionState{ID: 2})
+		state.allocTransaction(transactionState{ID: 3})
+
+		state.Transactions[idx1].Removed = true
+
+		reusedIdx := state.allocTransaction(transactionState{ID: 4})
+
+		Expect(reusedIdx).To(Equal(idx1))
+		Expect(state.Transactions).To(HaveLen(3))
+		Expect(state.Transactions[reusedIdx].ID).To(Equal(uint64(4)))
+		Expect(state.Transactions[reusedIdx].Removed).To(BeFalse())
+	})
+
+	It("should keep the slice bounded by the active transaction count", func() {
+		for i := 0; i < 1000; i++ {
+			idx := state.allocTransaction(transactionState{ID: uint64(i)})
+			state.Transactions[idx].Removed = true
+		}
+
+		Expect(state.Transactions).To(HaveLen(1))
+	})
+
+	It("should not reuse the in-flight MSHR owner slot even if Removed", func() {
+		// The MSHR stage owns ProcessingMSHREntryIdx across ticks, draining its
+		// waiter list. That owner is commonly marked Removed before the list is
+		// drained; reusing its slot would clobber MSHRTransactionIndices and
+		// strand the remaining coalesced requests.
+		ownerIdx := state.allocTransaction(transactionState{
+			ID:                     1,
+			MSHRTransactionIndices: []int{0, 2},
+		})
+		state.allocTransaction(transactionState{ID: 2})
+
+		state.Transactions[ownerIdx].Removed = true
+		state.HasProcessingMSHREntry = true
+		state.ProcessingMSHREntryIdx = ownerIdx
+
+		newIdx := state.allocTransaction(transactionState{ID: 3})
+
+		Expect(newIdx).NotTo(Equal(ownerIdx))
+		Expect(state.Transactions[ownerIdx].ID).To(Equal(uint64(1)))
+		Expect(state.Transactions[ownerIdx].MSHRTransactionIndices).
+			To(Equal([]int{0, 2}))
+
+		// Once the stage releases the owner, its slot becomes reusable.
+		state.HasProcessingMSHREntry = false
+		reusedIdx := state.allocTransaction(transactionState{ID: 4})
+		Expect(reusedIdx).To(Equal(ownerIdx))
+	})
+})

--- a/mem/cache/writeback/flusher.go
+++ b/mem/cache/writeback/flusher.go
@@ -146,8 +146,7 @@ func (f *flusher) processFlush() bool {
 		HasBlock:           true,
 	}
 
-	next.Transactions = append(next.Transactions, trans)
-	transIdx := len(next.Transactions) - 1
+	transIdx := next.allocTransaction(trans)
 	bankBuf.PushTyped(transIdx)
 
 	next.FlusherBlockToEvictRefs = next.FlusherBlockToEvictRefs[1:]

--- a/mem/cache/writeback/topparser.go
+++ b/mem/cache/writeback/topparser.go
@@ -46,9 +46,7 @@ func (p *topParser) Tick() bool {
 		trans.WritePID = msg.PID
 	}
 
-	next.Transactions = append(next.Transactions, trans)
-
-	idx := len(next.Transactions) - 1
+	idx := next.allocTransaction(trans)
 	next.DirStageBuf.PushTyped(idx)
 
 	tracing.TraceReqReceive(p.cache.comp, msg)

--- a/mem/cache/writethroughcache/intake.go
+++ b/mem/cache/writethroughcache/intake.go
@@ -110,6 +110,23 @@ func (s *intake) createTransaction(msg messaging.Msg) int {
 		return -1
 	}
 
+	return s.allocTransaction(next, t)
+}
+
+// allocTransaction stores t in the Transactions slice and returns its index.
+// Completed transactions are marked Removed but their slots are never deleted
+// (other stages hold indices into the slice via DirBuf/BankBufs/MSHR, so
+// indices must stay stable). Reuse a Removed slot when one is available so the
+// slice stays bounded by the number of active transactions instead of growing
+// with every request ever issued.
+func (s *intake) allocTransaction(next *State, t transactionState) int {
+	for i := range next.Transactions {
+		if next.Transactions[i].Removed {
+			next.Transactions[i] = t
+			return i
+		}
+	}
+
 	next.Transactions = append(next.Transactions, t)
 	return len(next.Transactions) - 1
 }

--- a/mem/cache/writethroughcache/intake_test.go
+++ b/mem/cache/writethroughcache/intake_test.go
@@ -1,0 +1,55 @@
+package writethroughcache
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Intake allocTransaction", func() {
+	var (
+		s    *intake
+		next *State
+	)
+
+	BeforeEach(func() {
+		s = &intake{}
+		next = &State{}
+	})
+
+	It("should append when no Removed slot is available", func() {
+		idx0 := s.allocTransaction(next, transactionState{ID: 1})
+		idx1 := s.allocTransaction(next, transactionState{ID: 2})
+
+		Expect(idx0).To(Equal(0))
+		Expect(idx1).To(Equal(1))
+		Expect(next.Transactions).To(HaveLen(2))
+	})
+
+	It("should reuse a Removed slot instead of growing the slice", func() {
+		s.allocTransaction(next, transactionState{ID: 1})
+		idx1 := s.allocTransaction(next, transactionState{ID: 2})
+		s.allocTransaction(next, transactionState{ID: 3})
+
+		// Complete the middle transaction.
+		next.Transactions[idx1].Removed = true
+
+		reusedIdx := s.allocTransaction(next, transactionState{ID: 4})
+
+		Expect(reusedIdx).To(Equal(idx1))
+		Expect(next.Transactions).To(HaveLen(3))
+		Expect(next.Transactions[reusedIdx].ID).To(Equal(uint64(4)))
+		Expect(next.Transactions[reusedIdx].Removed).To(BeFalse())
+	})
+
+	It("should keep the slice bounded by the active transaction count", func() {
+		// Repeatedly allocate then complete a transaction. With slot reuse the
+		// slice must never grow beyond the peak number of active transactions
+		// (one here), regardless of how many requests are processed.
+		for i := 0; i < 1000; i++ {
+			idx := s.allocTransaction(next, transactionState{ID: uint64(i)})
+			next.Transactions[idx].Removed = true
+		}
+
+		Expect(next.Transactions).To(HaveLen(1))
+	})
+})


### PR DESCRIPTION
The per-component State.Transactions slice in writethroughcache and
writeback was append-only during normal operation. Completed transactions
were only marked Removed and the slice was cleared solely by a full
CmdReset, which normal kernel execution never triggers. Stages that scan
the entire slice every tick (respondStage.Tick, intake.countActive,
bottomparser, bankstage, directory) therefore grew O(N) per tick, making
the cache effectively O(N^2) for sustained memory-heavy workloads.

Reuse a Removed slot when allocating a new transaction instead of always
appending. Other stages hold indices into the slice (DirBuf/BankBufs/MSHR),
so slots are reused rather than deleted to keep indices stable. This bounds
the slice by the active transaction count.

The writethroughcache reproduction (num-access=15000) drops from ~153s to
~2s. The same structural fix is applied to writeback, which shares the
pattern.

Fixes #377