### PR TITLE
mem: global storage for controllers; bank-selection conversion in simplebankedmemory

### DIFF
--- a/mem/dram/README.md
+++ b/mem/dram/README.md
@@ -143,7 +143,20 @@ topPort = ctrl.GetPortByName("Top")
 | `BusWidth` / `BurstLength` | Data bus width (bits) and burst transfer length |
 | `PagePolicy` | `PagePolicyOpen` or `PagePolicyClose` |
 | `TransactionQueueSize` / `CommandQueueCapacity` | Queue depths |
-| `HasAddrConverter` / `InterleavingSize` / ... | Address interleaving for multi-controller setups |
+| `ChannelPos`/`Mask`, `RankPos`/`Mask`, `BankPos`/`Mask`, `RowPos`/`Mask`, ... | Address-bit positions for channel/rank/bank/row/column decode — **computed by `Build` from the geometry** (`NumChannel`/`NumRank`/`NumBank`/`NumRow`/`NumCol`, bus/burst); values passed via `WithSpec` are overwritten |
+
+Storage is **global**: a request's address indexes the backing store directly,
+and `mapAddress` decodes that same global address into a channel/rank/bank/row/
+column location. There is no per-controller address conversion.
+
+The decode bit positions are derived from the geometry by `Build`, not set by
+the caller. As a result this model is intended for **standalone / single
+controller** use (all presets are standalone). It does not currently support
+being one of several finely-interleaved controllers over shared storage: decode
+runs on the global address with builder-derived positions, so an upstream
+inter-controller interleave finer than the decode layout would alias. For a
+multi-controller memory system, use `mem/simplebankedmemory` (whose bank
+selector has an explicit bank-selection address conversion).
 
 ## Statistics
 

--- a/mem/dram/address_ops.go
+++ b/mem/dram/address_ops.go
@@ -1,29 +1,10 @@
 package dram
 
-// convertExternalToInternal converts a global physical address to a
-// DRAM-internal physical address using interleaving parameters from Spec.
-func convertExternalToInternal(spec *Spec, addr uint64) uint64 {
-	if !spec.HasAddrConverter {
-		return addr
-	}
-
-	unitSize := spec.InterleavingSize
-	totalUnits := uint64(spec.TotalNumOfElements)
-	currentIdx := uint64(spec.CurrentElementIndex)
-	offset := spec.Offset
-
-	// InterleavingConverter logic:
-	// externalAddr = offset + highBits*totalUnits*unitSize + currentIdx*unitSize + lowBits
-	// internalAddr = highBits*unitSize + lowBits
-	addrAfterOffset := addr - offset
-	lowBits := addrAfterOffset % unitSize
-	highBits := (addrAfterOffset - currentIdx*unitSize - lowBits) / (totalUnits * unitSize)
-
-	return highBits*unitSize + lowBits
-}
-
-// mapAddress maps an internal address to a Location (channel, rank, etc.)
-// using the address mapping parameters in Spec.
+// mapAddress decomposes a global physical address into a Location (channel,
+// rank, bank group, bank, row, column) using the position/mask parameters in
+// Spec. Storage is global, so this operates directly on the request address;
+// when several controllers are interleaved, choose the channel/rank/bank bit
+// positions so they sit above the upstream controller-select bits.
 func mapAddress(spec *Spec, addr uint64) location {
 	l := location{}
 

--- a/mem/dram/comp.go
+++ b/mem/dram/comp.go
@@ -116,13 +116,6 @@ type Spec struct {
 	WriteHighWatermark int `json:"write_high_watermark"`
 	WriteLowWatermark  int `json:"write_low_watermark"`
 
-	// Address converter params
-	HasAddrConverter    bool   `json:"has_addr_converter"`
-	InterleavingSize    uint64 `json:"interleaving_size"`
-	TotalNumOfElements  int    `json:"total_num_of_elements"`
-	CurrentElementIndex int    `json:"current_element_index"`
-	Offset              uint64 `json:"offset"`
-
 	// Address mapping: position/mask pairs
 	ChannelPos    int    `json:"channel_pos"`
 	ChannelMask   uint64 `json:"channel_mask"`
@@ -262,7 +255,6 @@ type transactionState struct {
 	HasWrite        bool                 `json:"has_write"`
 	ReadMsg         memprotocol.ReadReq  `json:"read_msg"`
 	WriteMsg        memprotocol.WriteReq `json:"write_msg"`
-	InternalAddress uint64               `json:"internal_address"`
 	SubTransactions []subTransState      `json:"sub_transactions"`
 	ArrivalTick     uint64               `json:"arrival_tick"`
 }

--- a/mem/dram/memcontroller_test.go
+++ b/mem/dram/memcontroller_test.go
@@ -11,27 +11,6 @@ import (
 )
 
 var _ = Describe("Address Operations", func() {
-	It("should convert external to internal without converter", func() {
-		spec := &Spec{HasAddrConverter: false}
-		Expect(convertExternalToInternal(spec, 0x1000)).To(
-			Equal(uint64(0x1000)))
-	})
-
-	It("should convert external to internal with interleaving", func() {
-		spec := &Spec{
-			HasAddrConverter:    true,
-			InterleavingSize:    4096,
-			TotalNumOfElements:  8,
-			CurrentElementIndex: 3,
-			Offset:              0,
-		}
-		// addr = 0 + highBits*8*4096 + 3*4096 + lowBits
-		// For addr = 3*4096 = 12288: highBits=0, lowBits=0
-		// internal = 0*4096 + 0 = 0
-		Expect(convertExternalToInternal(spec, 3*4096)).To(
-			Equal(uint64(0)))
-	})
-
 	It("should map address", func() {
 		b := MakeBuilder()
 		spec := b.buildSpec()

--- a/mem/dram/parsetopmw.go
+++ b/mem/dram/parsetopmw.go
@@ -51,10 +51,6 @@ func (m *parseTopMW) parseTop(spec *Spec, next *State) bool {
 		panic(fmt.Sprintf("dram parseTop: unsupported message type %T", msgI))
 	}
 
-	// Assign internal address
-	globalAddr := transactionGlobalAddress(&ts)
-	ts.InternalAddress = convertExternalToInternal(spec, globalAddr)
-
 	// Split into sub-transactions
 	transIdx := len(next.Transactions)
 	splitTransaction(spec, &ts, transIdx)

--- a/mem/dram/respondmw.go
+++ b/mem/dram/respondmw.go
@@ -74,7 +74,8 @@ func (m *respondMW) finalizeWriteTrans(
 	t *transactionState,
 	i int,
 ) bool {
-	err := m.comp.Resources().Storage.Write(t.InternalAddress, t.WriteMsg.Data)
+	err := m.comp.Resources().Storage.Write(
+		transactionGlobalAddress(t), t.WriteMsg.Data)
 	if err != nil {
 		panic(err)
 	}
@@ -105,7 +106,7 @@ func (m *respondMW) finalizeReadTrans(
 	i int,
 ) bool {
 	data, err := m.comp.Resources().Storage.Read(
-		t.InternalAddress, t.ReadMsg.AccessByteSize)
+		transactionGlobalAddress(t), t.ReadMsg.AccessByteSize)
 	if err != nil {
 		panic(err)
 	}

--- a/mem/idealmemcontroller/README.md
+++ b/mem/idealmemcontroller/README.md
@@ -35,8 +35,7 @@ Two middlewares run each tick:
 ## Key Types
 
 - `Spec` — immutable configuration: frequency, latency, width, cache-line size,
-  capacity, and the address-conversion fields used for interleaved
-  multi-controller setups.
+  and capacity.
 - `State` — mutable runtime data: the list of inflight transactions and the
   current control state (`"enable"`, `"pause"`, or `"drain"`).
 - `Resources` — shared wiring; holds the backing `*mem.Storage`.
@@ -50,15 +49,14 @@ type Spec struct {
     CacheLineSize int         // Access granularity in bytes
     Capacity      uint64      // Backing-storage size when built internally
     StorageRef    string      // Storage resource name (set by Build)
-
-    // Address conversion for interleaved multi-controller setups.
-    AddrConvKind            string
-    AddrInterleavingSize    uint64
-    AddrTotalNumOfElements  int
-    AddrCurrentElementIndex int
-    AddrOffset              uint64
 }
 ```
+
+The controller uses **global storage**: a request's address indexes the backing
+store directly, with no per-controller address conversion. When several
+controllers are interleaved over one shared `mem.Storage`, the sender's
+destination map selects the controller; each controller simply reads and writes
+the shared store at the request's global address.
 
 ## Builder Pattern
 

--- a/mem/idealmemcontroller/comp.go
+++ b/mem/idealmemcontroller/comp.go
@@ -16,13 +16,6 @@ type Spec struct {
 	CacheLineSize int         `json:"cache_line_size"`
 	Capacity      uint64      `json:"capacity"`
 	StorageRef    string      `json:"storage_ref"`
-
-	AddrConvKind string `json:"addr_conv_kind"`
-
-	AddrInterleavingSize    uint64 `json:"addr_interleaving_size"`
-	AddrTotalNumOfElements  int    `json:"addr_total_num_of_elements"`
-	AddrCurrentElementIndex int    `json:"addr_current_element_index"`
-	AddrOffset              uint64 `json:"addr_offset"`
 }
 
 // inflightTransaction tracks an in-progress memory request with a countdown.

--- a/mem/idealmemcontroller/memmiddleware.go
+++ b/mem/idealmemcontroller/memmiddleware.go
@@ -3,7 +3,6 @@ package idealmemcontroller
 import (
 	"log"
 
-	"github.com/sarchlab/akita/v5/mem"
 	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
@@ -132,14 +131,7 @@ func (m *memMiddleware) sendResponse(tx *inflightTransaction) bool {
 }
 
 func (m *memMiddleware) sendReadResponse(tx *inflightTransaction) bool {
-	spec := m.comp.Spec()
-	addr := mem.ConvertAddress(
-		spec.AddrConvKind, spec.AddrOffset,
-		spec.AddrInterleavingSize, spec.AddrTotalNumOfElements,
-		spec.AddrCurrentElementIndex, tx.Address,
-	)
-
-	data, err := m.comp.Resources().Storage.Read(addr, tx.AccessByteSize)
+	data, err := m.comp.Resources().Storage.Read(tx.Address, tx.AccessByteSize)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -179,12 +171,7 @@ func (m *memMiddleware) sendWriteResponse(tx *inflightTransaction) bool {
 
 	m.topPort().Send(rsp)
 
-	spec := m.comp.Spec()
-	addr := mem.ConvertAddress(
-		spec.AddrConvKind, spec.AddrOffset,
-		spec.AddrInterleavingSize, spec.AddrTotalNumOfElements,
-		spec.AddrCurrentElementIndex, tx.Address,
-	)
+	addr := tx.Address
 
 	if tx.DirtyMask == nil {
 		err := m.comp.Resources().Storage.Write(addr, tx.Data)

--- a/mem/simplebankedmemory/README.md
+++ b/mem/simplebankedmemory/README.md
@@ -35,8 +35,7 @@ requests can occupy different banks while earlier ones are still in flight.
 ## Key Types
 
 - `Spec` — immutable configuration: frequency, bank geometry, pipeline shape,
-  post-pipeline buffer depth, capacity, bank-selection, and address-conversion
-  fields.
+  post-pipeline buffer depth, capacity, and bank selection.
 - `State` — mutable runtime data: the per-bank pipelines and post-pipeline
   buffers.
 - `Resources` — shared wiring; holds the backing `*mem.Storage`.
@@ -54,16 +53,22 @@ type Spec struct {
     StorageRef          string      // Storage resource name (set by Build)
 
     BankSelectorKind               string // "interleaved"
-    BankSelectorLog2InterleaveSize uint64 // log2 of the interleave stride
+    BankSelectorLog2InterleaveSize uint64 // log2 of the bank interleave stride
 
-    // Address conversion for interleaved multi-controller setups.
-    AddrConvKind            string
-    AddrInterleavingSize    uint64
-    AddrTotalNumOfElements  int
-    AddrCurrentElementIndex int
-    AddrOffset              uint64
+    // Optional bank-selection address conversion (bank selection only;
+    // storage is always global). Empty kind = identity. See "Bank selection
+    // across interleaved controllers" below.
+    BankAddrConvKind            string
+    BankAddrInterleavingSize    uint64
+    BankAddrTotalNumOfElements  int
+    BankAddrCurrentElementIndex int
+    BankAddrOffset              uint64
 }
 ```
+
+The memory uses **global storage**: a request's address indexes the backing
+store directly, with no storage address conversion. Bank selection, by default,
+also runs on the request's global address.
 
 ## Builder Pattern
 
@@ -124,6 +129,49 @@ topPort = memCtrl.GetPortByName("Top")
 | Post-pipeline buffer | 1 |
 | Storage capacity | 4 GB |
 | Bank selector | `"interleaved"`, 64 B stride (log2 = 6) |
+
+## Bank selection across interleaved controllers
+
+A common deployment places several of these controllers behind an interleaved
+address mapper (the sender's destination map), all sharing one global
+`mem.Storage`. Banking is then **two-level**: the upstream mapper selects the
+controller (level 1) and each controller's bank selector spreads its traffic
+across banks (level 2). Storage is global, so a request's address indexes the
+shared store directly regardless of which controller serves it.
+
+Every request reaching a controller carries the inter-controller interleave
+bits fixed to that controller's index. The bank selector is a contiguous-bit
+modulo, so running it on the **global** address makes those fixed bits overlap
+the bank-select bits: bank selection aliases and only a fraction of the banks
+is ever used (data stays correct; only timing is wrong, and silently so). For
+example, 16 controllers interleaved at 128 B feeding 16-bank memories with a
+64 B bank stride reach only 2 of the 16 banks per controller — an ~8× bandwidth
+loss.
+
+Fix it with the **bank-selection conversion**: set the `BankAddrConv*` fields to
+strip the inter-controller interleaving, so bank selection runs on a contiguous
+**controller-local** address and stripes finely across all banks. Storage stays
+global (these fields never affect storage):
+
+```go
+spec := simplebankedmemory.DefaultSpec()
+spec.NumBanks = 16
+spec.BankSelectorLog2InterleaveSize = 6 // 64 B bank stride
+
+// This controller is element i of 16, interleaved at 128 B. Strip that
+// interleaving for bank selection only.
+spec.BankAddrConvKind = "interleaving"
+spec.BankAddrInterleavingSize = 128
+spec.BankAddrTotalNumOfElements = 16
+spec.BankAddrCurrentElementIndex = i
+```
+
+Now consecutive controller-local cache lines land on consecutive banks: all 16
+banks are used, with full 64 B-granular striping (e.g. element-i lines that were
+the two halves of a 128 B block now hit different banks). Only needed when this
+memory is one of several interleaved controllers; a standalone memory leaves
+`BankAddrConvKind` empty and selects banks on the request address directly. Use
+`mem/dram` if you need detailed bank/row timing.
 
 ## Ports
 

--- a/mem/simplebankedmemory/bank_selection_test.go
+++ b/mem/simplebankedmemory/bank_selection_test.go
@@ -1,0 +1,180 @@
+package simplebankedmemory
+
+import (
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// These tests cover bank selection when the memory is one of several
+// interleaved controllers over a shared, globally-addressed storage. Storage is
+// always global; the optional bank-selection conversion strips the upstream
+// inter-controller interleaving so a contiguous bank selector can stripe finely
+// across all banks instead of aliasing on the strided global address.
+var _ = Describe("Bank selection across interleaved controllers", func() {
+	// Four controllers interleaved at 128 B; this memory is element 1. Within
+	// element 1 the visible addresses are 64-B lines inside every 4th 128-B
+	// block: 128, 192, 640, 704, 1152, 1216, ...
+	const (
+		numBanks      = 4
+		numElements   = 4
+		elementIndex  = 1
+		interleave    = 128 // upstream inter-controller stride (bytes)
+		bankLog2      = 6   // 64 B bank stride
+		roundSize     = interleave * numElements
+		numLinesToHit = 16
+	)
+
+	element1Addresses := func() []uint64 {
+		addrs := make([]uint64, 0, numLinesToHit)
+		for len(addrs) < numLinesToHit {
+			block := uint64(len(addrs)/2) * roundSize
+			base := block + elementIndex*interleave
+			addrs = append(addrs, base, base+64) // two 64-B lines per 128-B block
+		}
+		return addrs
+	}
+
+	distinctBanks := func(spec Spec, addrs []uint64) map[int]struct{} {
+		banks := map[int]struct{}{}
+		for _, a := range addrs {
+			banks[selectBank(spec, bankSelectionAddress(spec, a))] = struct{}{}
+		}
+		return banks
+	}
+
+	// withBankConv returns a spec whose bank selection strips the 128 B/4-way
+	// controller interleaving for element 1.
+	withBankConv := func() Spec {
+		spec := DefaultSpec()
+		spec.NumBanks = numBanks
+		spec.BankSelectorLog2InterleaveSize = bankLog2
+		spec.BankAddrConvKind = "interleaving"
+		spec.BankAddrInterleavingSize = interleave
+		spec.BankAddrTotalNumOfElements = numElements
+		spec.BankAddrCurrentElementIndex = elementIndex
+		return spec
+	}
+
+	It("collapses onto a fraction of banks without the bank conversion", func() {
+		spec := DefaultSpec()
+		spec.NumBanks = numBanks
+		spec.BankSelectorLog2InterleaveSize = bankLog2
+		// No bank conversion: selection runs on the strided global address.
+
+		banks := distinctBanks(spec, element1Addresses())
+
+		Expect(banks).To(HaveLen(2))
+	})
+
+	It("spreads finely across all banks with the bank conversion", func() {
+		banks := distinctBanks(withBankConv(), element1Addresses())
+
+		Expect(banks).To(HaveLen(numBanks))
+	})
+
+	It("places adjacent controller-local lines on different banks", func() {
+		spec := withBankConv()
+
+		// The two 64-B lines of element 1's first block (128 and 192) become
+		// controller-local 0 and 64, landing on different banks — the
+		// fine-grained striping that bit-placement alone cannot achieve.
+		Expect(bankSelectionAddress(spec, 128)).To(Equal(uint64(0)))
+		Expect(bankSelectionAddress(spec, 192)).To(Equal(uint64(64)))
+		Expect(selectBank(spec, bankSelectionAddress(spec, 128))).
+			NotTo(Equal(selectBank(spec, bankSelectionAddress(spec, 192))))
+	})
+
+	It("leaves storage addressing untouched (storage is global)", func() {
+		// The bank conversion does not affect storage: bankSelectionAddress is
+		// only ever fed to selectBank, never to the storage access (see
+		// tickFinalizeMW, which reads/writes at the request's raw address).
+		spec := withBankConv()
+		Expect(bankSelectionAddress(spec, 640)).To(Equal(uint64(128)))
+	})
+})
+
+// This integration test confirms that, with a global identity-addressed storage
+// and the bank conversion enabled, reads and writes hit the correct global
+// offset and exercise more than one bank.
+var _ = Describe("Bank selection data correctness with global storage", func() {
+	var (
+		engine  timing.Engine
+		memComp *Comp
+		agent   *testAgent
+		conn    *loopbackConnection
+	)
+
+	BeforeEach(func() {
+		engine = timing.NewSerialEngine()
+		reg := modeling.NewStandaloneRegistrar(engine)
+
+		spec := DefaultSpec()
+		spec.NumBanks = 4
+		spec.StageLatency = 2
+		spec.BankSelectorLog2InterleaveSize = 6
+		// Strip the 128 B/4-way controller interleave for bank selection.
+		spec.BankAddrConvKind = "interleaving"
+		spec.BankAddrInterleavingSize = 128
+		spec.BankAddrTotalNumOfElements = 4
+		spec.BankAddrCurrentElementIndex = 1
+
+		memComp = MakeBuilder().WithRegistrar(reg).WithSpec(spec).Build("MemBank")
+		assignPort(reg, memComp, "Top", 8)
+		assignPort(reg, memComp, "Control", 16)
+
+		agent = newTestAgent("AgentBank")
+		conn = newLoopbackConnection("ConnBank")
+		conn.PlugIn(memComp.GetPortByName("Top"))
+		conn.PlugIn(agent.port)
+	})
+
+	It("writes and reads back at the global address across banks", func() {
+		tp := memComp.GetPortByName("Top")
+
+		// Two element-1 lines that select different banks (local 0 and 64).
+		addrs := []uint64{128, 192}
+
+		spec := memComp.Spec()
+		Expect(selectBank(spec, bankSelectionAddress(spec, addrs[0]))).
+			NotTo(Equal(selectBank(spec, bankSelectionAddress(spec, addrs[1]))))
+
+		for i, a := range addrs {
+			w := memprotocol.WriteReq{}
+			w.ID = timing.GetIDGenerator().Generate()
+			w.Src = agent.port.AsRemote()
+			w.Dst = tp.AsRemote()
+			w.Address = a
+			w.Data = []byte{byte(i + 1), byte(i + 2), byte(i + 3), byte(i + 4)}
+			w.TrafficClass = "memprotocol.WriteReq"
+			agent.send(w)
+		}
+
+		for i := 0; i < 20; i++ {
+			memComp.Tick()
+		}
+
+		for i, a := range addrs {
+			r := memprotocol.ReadReq{}
+			r.ID = timing.GetIDGenerator().Generate()
+			r.Src = agent.port.AsRemote()
+			r.Dst = tp.AsRemote()
+			r.Address = a
+			r.AccessByteSize = 4
+			r.TrafficClass = "memprotocol.ReadReq"
+			agent.send(r)
+
+			for j := 0; j < 20; j++ {
+				memComp.Tick()
+			}
+
+			rsp, ok := agent.received[len(agent.received)-1].(memprotocol.DataReadyRsp)
+			Expect(ok).To(BeTrue())
+			Expect(rsp.Data).To(Equal(
+				[]byte{byte(i + 1), byte(i + 2), byte(i + 3), byte(i + 4)}))
+		}
+	})
+})

--- a/mem/simplebankedmemory/comp.go
+++ b/mem/simplebankedmemory/comp.go
@@ -21,12 +21,26 @@ type Spec struct {
 	Capacity                       uint64      `json:"capacity"`
 	BankSelectorKind               string      `json:"bank_selector_kind"`
 	BankSelectorLog2InterleaveSize uint64      `json:"bank_selector_log2_interleave_size"`
-	AddrConvKind                   string      `json:"addr_conv_kind"`
-	AddrInterleavingSize           uint64      `json:"addr_interleaving_size"`
-	AddrTotalNumOfElements         int         `json:"addr_total_num_of_elements"`
-	AddrCurrentElementIndex        int         `json:"addr_current_element_index"`
-	AddrOffset                     uint64      `json:"addr_offset"`
-	StorageRef                     string      `json:"storage_ref"`
+
+	// Bank-selection address conversion. Bank selection runs on this
+	// conversion of the request address; storage is always global, so this
+	// conversion affects bank selection only. With an empty BankAddrConvKind
+	// (the default) bank selection runs on the global address directly — fine
+	// for a standalone memory, or when the bank stride is coarser than any
+	// upstream inter-controller interleave. When this memory is one of several
+	// controllers interleaved at a finer granularity (e.g. 64 B banks behind a
+	// 128 B controller stride), the global address is strided and a contiguous
+	// bank selector cannot stripe finely on it. Set these fields (kind
+	// "interleaving" with this controller's element index) to strip the
+	// inter-controller interleaving so bank selection sees a contiguous
+	// controller-local address and stripes across all banks.
+	BankAddrConvKind            string `json:"bank_addr_conv_kind"`
+	BankAddrInterleavingSize    uint64 `json:"bank_addr_interleaving_size"`
+	BankAddrTotalNumOfElements  int    `json:"bank_addr_total_num_of_elements"`
+	BankAddrCurrentElementIndex int    `json:"bank_addr_current_element_index"`
+	BankAddrOffset              uint64 `json:"bank_addr_offset"`
+
+	StorageRef string `json:"storage_ref"`
 }
 
 // bankPipelineItemState is a serializable representation of a pipeline item.
@@ -105,6 +119,8 @@ func bufferPop(bank *bankState) {
 	bank.PostPipelineBuf.Pop()
 }
 
+// selectBank chooses the bank for a (bank-selection) address. Callers pass the
+// result of bankSelectionAddress, not the raw request address.
 func selectBank(spec Spec, addr uint64) int {
 	interleaveSize := uint64(1) << spec.BankSelectorLog2InterleaveSize
 	if interleaveSize == 0 {
@@ -112,4 +128,18 @@ func selectBank(spec Spec, addr uint64) int {
 	}
 
 	return int((addr / interleaveSize) % uint64(spec.NumBanks))
+}
+
+// bankSelectionAddress converts a request address to the address fed to
+// selectBank. Storage is global and is never converted; this conversion
+// affects bank selection only. With an empty BankAddrConvKind it is the
+// identity, so bank selection runs on the global address. Set the BankAddr*
+// fields to strip an upstream inter-controller interleaving so banks stripe on
+// the contiguous controller-local address. See the BankAddrConv* Spec fields.
+func bankSelectionAddress(spec Spec, addr uint64) uint64 {
+	return mem.ConvertAddress(
+		spec.BankAddrConvKind, spec.BankAddrOffset,
+		spec.BankAddrInterleavingSize, spec.BankAddrTotalNumOfElements,
+		spec.BankAddrCurrentElementIndex, addr,
+	)
 }

--- a/mem/simplebankedmemory/dispatchmw.go
+++ b/mem/simplebankedmemory/dispatchmw.go
@@ -3,7 +3,6 @@ package simplebankedmemory
 import (
 	"log"
 
-	"github.com/sarchlab/akita/v5/mem"
 	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
@@ -47,14 +46,7 @@ func (m *dispatchMW) dispatchFromTopPort() bool {
 			log.Panic("simplebankedmemory: no banks configured")
 		}
 
-		addr := msg.GetAddress()
-		addr = mem.ConvertAddress(
-			spec.AddrConvKind, spec.AddrOffset,
-			spec.AddrInterleavingSize, spec.AddrTotalNumOfElements,
-			spec.AddrCurrentElementIndex, addr,
-		)
-
-		bankID := selectBank(spec, addr)
+		bankID := selectBank(spec, bankSelectionAddress(spec, msg.GetAddress()))
 		if bankID < 0 || bankID >= spec.NumBanks {
 			log.Panicf("simplebankedmemory: bank selector returned %d", bankID)
 		}

--- a/mem/simplebankedmemory/doc.go
+++ b/mem/simplebankedmemory/doc.go
@@ -1,2 +1,9 @@
 // Package simplebankedmemory provides a configurable banked memory component.
+//
+// Storage is global: a request's address indexes the backing store directly.
+// When several instances are used as interleaved controllers over one shared
+// storage, set the bank-selection address conversion (the Spec.BankAddrConv*
+// fields) so bank selection operates on a controller-local address rather than
+// the strided global address; otherwise accesses alias onto a fraction of the
+// banks. The conversion affects bank selection only, never storage.
 package simplebankedmemory

--- a/mem/simplebankedmemory/simplebankedmemory_test.go
+++ b/mem/simplebankedmemory/simplebankedmemory_test.go
@@ -371,51 +371,45 @@ var _ = Describe("SimpleBankedMemory", func() {
 		Expect(committed).To(Equal(newData))
 	})
 
-	It("should use converted address for storage access", func() {
-		// Use the interleaving converter: InterleavingSize=256, 2 elements,
-		// index 0. External address 0x0 maps to internal address 0x0. External
-		// address 0x200 maps to internal address 0x100.
+	It("accesses storage at the global request address (identity)", func() {
+		// Storage is global: a request's address indexes the backing store
+		// directly, with no per-controller conversion.
 		spec := DefaultSpec()
 		spec.NumBanks = 2
 		spec.StageLatency = 2
-		spec.AddrConvKind = "interleaving"
-		spec.AddrInterleavingSize = 256
-		spec.AddrTotalNumOfElements = 2
-		spec.AddrCurrentElementIndex = 0
-		spec.AddrOffset = 0
 
 		reg := modeling.NewStandaloneRegistrar(engine)
 		memComp = MakeBuilder().
 			WithRegistrar(reg).
 			WithSpec(spec).
-			Build("MemConv")
+			Build("MemGlobal")
 
 		assignPort(reg, memComp, "Top", 4)
 		assignPort(reg, memComp, "Control", 16)
 
 		topPort := memComp.GetPortByName("Top")
-		agent = newTestAgent("AgentConv")
-		conn = newLoopbackConnection("ConnConv")
+		agent = newTestAgent("AgentGlobal")
+		conn = newLoopbackConnection("ConnGlobal")
 		conn.PlugIn(topPort)
 		conn.PlugIn(agent.port)
 
-		// Write 4 bytes at external address 0x0 → internal 0x0.
-		convWriteData := []byte{1, 2, 3, 4}
+		// Write 4 bytes at a non-zero global address.
+		writeData := []byte{1, 2, 3, 4}
 		write := memprotocol.WriteReq{}
 		write.ID = timing.GetIDGenerator().Generate()
 		write.Src = agent.port.AsRemote()
 		write.Dst = topPort.AsRemote()
-		write.Address = 0x0
-		write.Data = convWriteData
-		write.TrafficBytes = len(convWriteData) + 12
+		write.Address = 0x200
+		write.Data = writeData
+		write.TrafficBytes = len(writeData) + 12
 		write.TrafficClass = "memprotocol.WriteReq"
 
-		// Read 4 bytes at external address 0x0 → internal 0x0.
+		// Read the same global address back.
 		read := memprotocol.ReadReq{}
 		read.ID = timing.GetIDGenerator().Generate()
 		read.Src = agent.port.AsRemote()
 		read.Dst = topPort.AsRemote()
-		read.Address = 0x0
+		read.Address = 0x200
 		read.AccessByteSize = 4
 		read.TrafficBytes = 12
 		read.TrafficClass = "memprotocol.ReadReq"

--- a/mem/simplebankedmemory/tickfinalizemw.go
+++ b/mem/simplebankedmemory/tickfinalizemw.go
@@ -3,7 +3,6 @@ package simplebankedmemory
 import (
 	"log"
 
-	"github.com/sarchlab/akita/v5/mem"
 	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
@@ -65,17 +64,11 @@ func (m *tickFinalizeMW) finalizeRead(
 	b *bankState,
 	item *bankPipelineItemState,
 ) bool {
-	spec := m.comp.Spec()
 	readReq := &item.ReadMsg
 
 	if !item.Committed {
-		addr := mem.ConvertAddress(
-			spec.AddrConvKind, spec.AddrOffset,
-			spec.AddrInterleavingSize, spec.AddrTotalNumOfElements,
-			spec.AddrCurrentElementIndex, readReq.Address,
-		)
-
-		data, err := m.comp.Resources().Storage.Read(addr, readReq.AccessByteSize)
+		data, err := m.comp.Resources().Storage.Read(
+			readReq.Address, readReq.AccessByteSize)
 		if err != nil {
 			log.Panic(err)
 		}
@@ -113,15 +106,10 @@ func (m *tickFinalizeMW) finalizeWrite(
 	b *bankState,
 	item *bankPipelineItemState,
 ) bool {
-	spec := m.comp.Spec()
 	writeReq := &item.WriteMsg
 
 	if !item.Committed {
-		addr := mem.ConvertAddress(
-			spec.AddrConvKind, spec.AddrOffset,
-			spec.AddrInterleavingSize, spec.AddrTotalNumOfElements,
-			spec.AddrCurrentElementIndex, writeReq.Address,
-		)
+		addr := writeReq.Address
 
 		if writeReq.DirtyMask == nil {
 			if err := m.comp.Resources().Storage.Write(addr, writeReq.Data); err != nil {


### PR DESCRIPTION
## Summary

All three memory controllers — `idealmemcontroller`, `simplebankedmemory`, and `dram` — now back onto a **global, identity-addressed storage**: a request's address indexes the backing store directly, with no per-controller *storage* address conversion. `simplebankedmemory` additionally keeps a **bank-selection-only** address conversion so it can stripe finely across banks when used as one of several interleaved controllers.

This supersedes the earlier "drop *all* converters" iteration on this branch, which removed too much: as the review noted, `simplebankedmemory`'s contiguous-bit bank selector cannot stripe finer than the inter-controller stride when run on the global address, so a converter-free design serialized within-controller traffic (e.g. 64 B banks behind a 128 B controller stride). Keeping a bank-selection-only conversion restores fine-grained striping while storage stays global.

## Why

No production config used the old storage converter (DRAM presets are standalone; GPU configs share one global `mem.Storage`). Conflating storage addressing with bank/channel decomposition is what let `simplebankedmemory` silently collapse its banks behind an interleaved mapper with identity storage (16×128 B controllers + 16 banks at 64 B → only 2 banks per controller, ~8× bandwidth loss; data correct, timing silently wrong).

## The model

Two-level banking is expressed by combining the **sender's destination map** (which controller, level 1) with the **controller's bank selection** (which bank, level 2). Storage is global, so level 1 doesn't need to translate the address. For level 2, `simplebankedmemory`'s bank selector is a contiguous-bit modulo, so to stripe finer than the controller stride it must run on a **controller-local** address — hence the bank-selection conversion (it strips the upstream inter-controller interleave; storage is unaffected).

## Changes

- **simplebankedmemory** — remove the storage `AddrConv*` fields (storage = request address). Add `BankAddrConv*` fields used **only** by `selectBank`. Empty `BankAddrConvKind` = identity (default; standalone or coarse banking). Multi-controller setups set them to strip the controller interleave (e.g. `"interleaving"`, 128 B, 16 elements, this controller's index) → all banks, full 64 B-granular striping.
- **idealmemcontroller** — remove `AddrConv*`; storage uses the request address (no banking).
- **dram** — remove the converter (`HasAddrConverter` + interleaving fields) and the transaction `InternalAddress`; storage uses the transaction's global address. `mapAddress` already decoded the global address, so channel/rank/bank/row decomposition is unchanged. Decode positions are derived from the geometry by `Build`, so `dram` is for **standalone** use (all presets are standalone); the README points to `simplebankedmemory` for multi-controller systems.
- Tests updated (hazard without the conversion → bank collapse; fix with it → all banks + adjacent controller-local lines on different banks; storage stays global). Each README documents the global-storage contract; `simplebankedmemory`'s documents the bank-selection conversion, `dram`'s notes the standalone limitation.

## Review comments addressed

- *"Apply a bank-local address before selecting banks"* — done: `simplebankedmemory` converts to a controller-local address before `selectBank`, restoring fine-grained striping (the bit-placement workaround did serialize within-chunk traffic; that approach is gone).
- *"Preserve custom DRAM address positions before relying on them"* — the README no longer advises placing bit positions (they're computed by `Build` from the geometry); it documents `dram` as standalone-only and points multi-controller users to `simplebankedmemory`.

## Compatibility

Breaking Spec change (storage `AddrConv*` / DRAM converter fields removed; `simplebankedmemory` gains `BankAddrConv*`), made deliberately during **beta** before the v5 API freezes. No production config set the removed fields.

## Verification

`go build ./...` green; `go test ./mem/...` (incl. acceptance tests) pass; `gofmt` clean; project `golangci-lint` reports 0 issues.

## Downstream

Unblocks the MGPUSim v5 port: mi300a uses upstream `mem/simplebankedmemory` (no fork) with a `BankAddrConv*` stripping its 16×128 B controller interleave for 64 B bank striping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
