### PR TITLE
fix(writeback): do not reuse transaction slots with in-flight bottom-port transactions

### DIFF
--- a/mem/cache/writeback/comp.go
+++ b/mem/cache/writeback/comp.go
@@ -108,12 +108,54 @@ func (s *State) allocTransaction(t transactionState) int {
 			continue
 		}
 
+		// Do not reuse a slot still referenced by an in-flight bottom-port
+		// transaction. Eviction write-backs and line fetches are matched to
+		// their lower-memory responses by the request ID stored in the
+		// transaction slot; overwriting the slot before the response returns
+		// makes that response an unrecognized "orphan" (silently dropped) and
+		// leaves the eviction/fetch permanently in the in-flight list, so a
+		// later Flush/Drain never reaches quiescence and the simulation
+		// deadlocks. A slot can be both Removed and in-flight: e.g.
+		// writeBufferEvictAndWrite reuses one transaction for a bank write-hit
+		// (which marks it Removed) and the victim write-back (which stays in
+		// InflightEvictionIndices until its WriteDoneRsp lands).
+		if s.indexHasInflightBottomTransaction(i) {
+			continue
+		}
+
 		s.Transactions[i] = t
 		return i
 	}
 
 	s.Transactions = append(s.Transactions, t)
 	return len(s.Transactions) - 1
+}
+
+// indexHasInflightBottomTransaction reports whether transaction slot i is still
+// referenced by a pending or in-flight bottom-port transaction (an eviction
+// write-back or a line fetch). Such slots must not be reused, because the
+// matching bottom-port response is correlated by the request ID held in the
+// slot.
+func (s *State) indexHasInflightBottomTransaction(i int) bool {
+	for _, idx := range s.InflightEvictionIndices {
+		if idx == i {
+			return true
+		}
+	}
+
+	for _, idx := range s.PendingEvictionIndices {
+		if idx == i {
+			return true
+		}
+	}
+
+	for _, idx := range s.InflightFetchIndices {
+		if idx == i {
+			return true
+		}
+	}
+
+	return false
 }
 
 // flushReqState is a serializable representation of a flush control request.


### PR DESCRIPTION
## Summary

Fixes a lost-progress / deadlock bug in the v5 write-back cache (`mem/cache/writeback`). It surfaced as a hang in MGPUSim's GCN3 single-GPU timing acceptance test (`matrixtranspose`), but the root cause is entirely in Akita and is reproducible whenever an eviction or fetch is in flight while its transaction slot gets recycled.

## Root cause

The write-back cache stores all transactions in a single `State.Transactions []transactionState` slice. Completed transactions are marked `Removed` but never deleted (other stages and the MSHR hold stable indices into the slice), and `allocTransaction` reuses any `Removed` slot to keep the slice bounded.

Bottom-port responses are correlated to their transaction **by the request ID stored in the slot**:

- `processWriteDoneRsp` matches `e.EvictionWriteReqMeta.ID == msg.RspTo`
- `findInflightFetchIdxByFetchReadReqID` matches `t.FetchReadReqMeta.ID == id`

`allocTransaction` previously only protected the `ProcessingMSHREntryIdx` slot. The gap: **a slot can be `Removed` while still referenced by an in-flight bottom-port transaction.** Concretely, `processWriteBufferEvictAndWrite` reuses one transaction index for both a bank write-hit *and* the victim write-back:

1. The bank write-hit completes → `finalizeWriteHit` sets `trans.Removed = true`.
2. The same index is still in `InflightEvictionIndices`, holding the `EvictionWriteReqMeta.ID` needed to match the lower-memory `WriteDoneRsp`.

Once `Removed`, a later top request could grab that slot and overwrite the eviction's request ID. The real `WriteDoneRsp` then matched nothing → silently dropped as an orphan → the eviction stayed in `InflightEvictionIndices` forever → a later `Flush`/`Drain` never reached quiescence → deadlock.

## Fix

Add an `indexHasInflightBottomTransaction(i)` guard so `allocTransaction` also skips slots referenced by the `InflightEviction` / `PendingEviction` / `InflightFetch` indices, mirroring the existing `ProcessingMSHREntryIdx` guard.

## Verification

- `go build ./mem/...`
- `go test ./mem/cache/writeback/...` — pass
- `gofmt` / `go vet` clean

Downstream: MGPUSim PR #266 currently vendors this fix in-tree as a stopgap. Once this lands and is tagged, the MGPUSim vendoring can be dropped and the dependency bumped.

https://claude.ai/code/session_015rhjwSfBdAFfArBLZi69ig

---
_Generated by [Claude Code](https://claude.ai/code/session_015rhjwSfBdAFfArBLZi69ig)_