### PR TITLE
fix(noc/switching): carry original message across switching network (#386)

### DIFF
--- a/.github/workflows/akita_test.yml
+++ b/.github/workflows/akita_test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   daisen2_compile:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
         run: npm run build
 
   monitoring2_compile:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
         run: npm run build
 
   akita_build_lint_test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
         run: ginkgo -r
 
   noc_acceptance_test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [akita_build_lint_test]
     steps:
@@ -87,7 +87,7 @@ jobs:
         run: python3 acceptance_test.py
 
   mem_acceptance_test:
-    runs-on: self-hosted
+    runs-on: Github-Large-1
     timeout-minutes: 60
     needs: [akita_build_lint_test]
     steps:

--- a/internal/codec/registry.go
+++ b/internal/codec/registry.go
@@ -150,6 +150,36 @@ func (r *Registry[T]) DecodeSlice(data json.RawMessage) ([]T, error) {
 	return out, nil
 }
 
+// Encode encodes a single polymorphic value into a typed payload: a type tag
+// plus the JSON encoding of the concrete value. It is the single-value
+// counterpart to EncodeSlice, for callers that carry one value of T inside an
+// otherwise plain-JSON structure. Encoding needs no prior registration;
+// Decode does.
+func (r *Registry[T]) Encode(v T) (json.RawMessage, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("codec: encode %s %T: %w", r.label, v, err)
+	}
+
+	return json.Marshal(typedPayload{
+		Type:    tagOf(reflect.TypeOf(v)),
+		Payload: raw,
+	})
+}
+
+// Decode decodes a single typed payload produced by Encode back into a concrete
+// value of its registered type, in the same value or pointer form its type was
+// registered as.
+func (r *Registry[T]) Decode(data json.RawMessage) (T, error) {
+	var tp typedPayload
+	if err := json.Unmarshal(data, &tp); err != nil {
+		var zero T
+		return zero, fmt.Errorf("codec: decode %s: %w", r.label, err)
+	}
+
+	return r.decodeOne(tp)
+}
+
 func (r *Registry[T]) decodeOne(tp typedPayload) (T, error) {
 	var zero T
 

--- a/internal/codec/registry.go
+++ b/internal/codec/registry.go
@@ -110,23 +110,84 @@ func (r *Registry[T]) Tags() []string {
 	return tags
 }
 
-// EncodeSlice encodes a slice of T into a JSON array of typed payloads. Encoding
-// needs no prior registration: each element is tagged with its concrete type and
-// marshalled with the default JSON encoding.
-func (r *Registry[T]) EncodeSlice(vs []T) (json.RawMessage, error) {
+// Encode encodes a single value of T into one typed payload: a type tag plus
+// the JSON encoding of the concrete value. Encoding is registration-free and
+// stateless — only decoding consults a Registry's type map — so Encode is a
+// plain generic function, not a Registry method. EncodeSlice is the same
+// operation over many values.
+//
+// A nil value (an absent optional payload, e.g. a flit that carries no message)
+// encodes as JSON null, and Decode maps null back to the zero T. This policy
+// lives here rather than in the messaging/timing wrappers because an optional
+// polymorphic value is common to every interface the codec serves. Only this
+// single-value path is nil-tolerant; see EncodeSlice.
+func Encode[T any](v T) (json.RawMessage, error) {
+	if any(v) == nil {
+		return json.RawMessage("null"), nil
+	}
+
+	tp, err := encodeOne(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(tp)
+}
+
+// EncodeSlice encodes a slice of T into a JSON array of typed payloads. Like
+// Encode it needs no Registry: each element is tagged with its concrete type and
+// marshalled with the default JSON encoding. Unlike Encode it does not
+// special-case a nil element; the collections it serializes (port buffers, the
+// event queue) never contain one.
+func EncodeSlice[T any](vs []T) (json.RawMessage, error) {
 	payloads := make([]typedPayload, len(vs))
 	for i, v := range vs {
-		raw, err := json.Marshal(v)
+		tp, err := encodeOne(v)
 		if err != nil {
-			return nil, fmt.Errorf("codec: encode %s %T: %w", r.label, v, err)
+			return nil, err
 		}
-		payloads[i] = typedPayload{
-			Type:    tagOf(reflect.TypeOf(v)),
-			Payload: raw,
-		}
+		payloads[i] = tp
 	}
 
 	return json.Marshal(payloads)
+}
+
+// encodeOne builds the typed payload for a single value: the concrete type's tag
+// plus its JSON. Encode and EncodeSlice both build on it, so the per-element wire
+// format is defined in exactly one place.
+func encodeOne[T any](v T) (typedPayload, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return typedPayload{}, fmt.Errorf("codec: encode %T: %w", v, err)
+	}
+
+	return typedPayload{
+		Type:    tagOf(reflect.TypeOf(v)),
+		Payload: raw,
+	}, nil
+}
+
+// Decode decodes a single typed payload produced by Encode back into a concrete
+// value of its registered type, in the same value or pointer form its type was
+// registered as. Unlike Encode it is a Registry method: decoding resolves the
+// type tag through the registry's map. It is the single-value counterpart to
+// DecodeSlice; both build on decodeOne.
+//
+// Reversing Encode's nil policy, a null or empty payload is an absent optional
+// value and decodes to the zero T (nil for an interface type).
+func (r *Registry[T]) Decode(data json.RawMessage) (T, error) {
+	var zero T
+
+	if len(data) == 0 || string(data) == "null" {
+		return zero, nil
+	}
+
+	var tp typedPayload
+	if err := json.Unmarshal(data, &tp); err != nil {
+		return zero, fmt.Errorf("codec: decode %s: %w", r.label, err)
+	}
+
+	return r.decodeOne(tp)
 }
 
 // DecodeSlice decodes a JSON array produced by EncodeSlice back into concrete
@@ -193,7 +254,7 @@ func (r *Registry[T]) decodeOne(tp typedPayload) (T, error) {
 // the same concrete type. It is a test aid for confirming a type is registered
 // and serializes losslessly; it is not used on the checkpoint hot path.
 func (r *Registry[T]) CheckRoundTrip(v T) error {
-	encoded, err := r.EncodeSlice([]T{v})
+	encoded, err := EncodeSlice([]T{v})
 	if err != nil {
 		return err
 	}

--- a/internal/codec/registry.go
+++ b/internal/codec/registry.go
@@ -150,36 +150,6 @@ func (r *Registry[T]) DecodeSlice(data json.RawMessage) ([]T, error) {
 	return out, nil
 }
 
-// Encode encodes a single polymorphic value into a typed payload: a type tag
-// plus the JSON encoding of the concrete value. It is the single-value
-// counterpart to EncodeSlice, for callers that carry one value of T inside an
-// otherwise plain-JSON structure. Encoding needs no prior registration;
-// Decode does.
-func (r *Registry[T]) Encode(v T) (json.RawMessage, error) {
-	raw, err := json.Marshal(v)
-	if err != nil {
-		return nil, fmt.Errorf("codec: encode %s %T: %w", r.label, v, err)
-	}
-
-	return json.Marshal(typedPayload{
-		Type:    tagOf(reflect.TypeOf(v)),
-		Payload: raw,
-	})
-}
-
-// Decode decodes a single typed payload produced by Encode back into a concrete
-// value of its registered type, in the same value or pointer form its type was
-// registered as.
-func (r *Registry[T]) Decode(data json.RawMessage) (T, error) {
-	var tp typedPayload
-	if err := json.Unmarshal(data, &tp); err != nil {
-		var zero T
-		return zero, fmt.Errorf("codec: decode %s: %w", r.label, err)
-	}
-
-	return r.decodeOne(tp)
-}
-
 func (r *Registry[T]) decodeOne(tp typedPayload) (T, error) {
 	var zero T
 

--- a/internal/codec/registry_test.go
+++ b/internal/codec/registry_test.go
@@ -75,6 +75,48 @@ func TestRegistry_EmptySliceRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRegistry_SingleValueRoundTrip(t *testing.T) {
+	r := NewRegistry[shape]("shape")
+	r.Register(square{})
+	r.Register(&rect{})
+
+	encodedVal, err := r.Encode(square{Side: 3})
+	if err != nil {
+		t.Fatalf("Encode(value): %v", err)
+	}
+	gotVal, err := r.Decode(encodedVal)
+	if err != nil {
+		t.Fatalf("Decode(value): %v", err)
+	}
+	if _, ok := gotVal.(square); !ok {
+		t.Fatalf("decoded %T, want square (value form preserved)", gotVal)
+	}
+	if gotVal.area() != 9 {
+		t.Fatalf("area = %d, want 9", gotVal.area())
+	}
+
+	encodedPtr, err := r.Encode(&rect{W: 2, H: 5})
+	if err != nil {
+		t.Fatalf("Encode(pointer): %v", err)
+	}
+	gotPtr, err := r.Decode(encodedPtr)
+	if err != nil {
+		t.Fatalf("Decode(pointer): %v", err)
+	}
+	if _, ok := gotPtr.(*rect); !ok {
+		t.Fatalf("decoded %T, want *rect (pointer form preserved)", gotPtr)
+	}
+}
+
+func TestRegistry_DecodeUnknownSingleType(t *testing.T) {
+	r := NewRegistry[shape]("shape")
+
+	_, err := r.Decode(json.RawMessage(`{"type":"codec.square","payload":{}}`))
+	if err == nil || !strings.Contains(err.Error(), "unknown shape type") {
+		t.Fatalf("expected unknown-type error, got %v", err)
+	}
+}
+
 func TestRegistry_UnknownType(t *testing.T) {
 	r := NewRegistry[shape]("shape")
 

--- a/internal/codec/registry_test.go
+++ b/internal/codec/registry_test.go
@@ -75,48 +75,6 @@ func TestRegistry_EmptySliceRoundTrip(t *testing.T) {
 	}
 }
 
-func TestRegistry_SingleValueRoundTrip(t *testing.T) {
-	r := NewRegistry[shape]("shape")
-	r.Register(square{})
-	r.Register(&rect{})
-
-	encodedVal, err := r.Encode(square{Side: 3})
-	if err != nil {
-		t.Fatalf("Encode(value): %v", err)
-	}
-	gotVal, err := r.Decode(encodedVal)
-	if err != nil {
-		t.Fatalf("Decode(value): %v", err)
-	}
-	if _, ok := gotVal.(square); !ok {
-		t.Fatalf("decoded %T, want square (value form preserved)", gotVal)
-	}
-	if gotVal.area() != 9 {
-		t.Fatalf("area = %d, want 9", gotVal.area())
-	}
-
-	encodedPtr, err := r.Encode(&rect{W: 2, H: 5})
-	if err != nil {
-		t.Fatalf("Encode(pointer): %v", err)
-	}
-	gotPtr, err := r.Decode(encodedPtr)
-	if err != nil {
-		t.Fatalf("Decode(pointer): %v", err)
-	}
-	if _, ok := gotPtr.(*rect); !ok {
-		t.Fatalf("decoded %T, want *rect (pointer form preserved)", gotPtr)
-	}
-}
-
-func TestRegistry_DecodeUnknownSingleType(t *testing.T) {
-	r := NewRegistry[shape]("shape")
-
-	_, err := r.Decode(json.RawMessage(`{"type":"codec.square","payload":{}}`))
-	if err == nil || !strings.Contains(err.Error(), "unknown shape type") {
-		t.Fatalf("expected unknown-type error, got %v", err)
-	}
-}
-
 func TestRegistry_UnknownType(t *testing.T) {
 	r := NewRegistry[shape]("shape")
 

--- a/internal/codec/registry_test.go
+++ b/internal/codec/registry_test.go
@@ -30,7 +30,7 @@ func TestRegistry_ValueAndPointerRoundTrip(t *testing.T) {
 
 	in := []shape{square{Side: 3}, &rect{W: 2, H: 5}}
 
-	encoded, err := r.EncodeSlice(in)
+	encoded, err := EncodeSlice(in)
 	if err != nil {
 		t.Fatalf("EncodeSlice: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestRegistry_ValueAndPointerRoundTrip(t *testing.T) {
 func TestRegistry_EmptySliceRoundTrip(t *testing.T) {
 	r := NewRegistry[shape]("shape")
 
-	encoded, err := r.EncodeSlice(nil)
+	encoded, err := EncodeSlice[shape](nil)
 	if err != nil {
 		t.Fatalf("EncodeSlice(nil): %v", err)
 	}
@@ -72,6 +72,105 @@ func TestRegistry_EmptySliceRoundTrip(t *testing.T) {
 	}
 	if len(out) != 0 {
 		t.Fatalf("decoded %d, want 0", len(out))
+	}
+}
+
+func TestRegistry_SingleValueRoundTrip(t *testing.T) {
+	r := NewRegistry[shape]("shape")
+	r.Register(square{})
+	r.Register(&rect{})
+
+	encodedVal, err := Encode(square{Side: 3})
+	if err != nil {
+		t.Fatalf("Encode(value): %v", err)
+	}
+	gotVal, err := r.Decode(encodedVal)
+	if err != nil {
+		t.Fatalf("Decode(value): %v", err)
+	}
+	if _, ok := gotVal.(square); !ok {
+		t.Fatalf("decoded %T, want square (value form preserved)", gotVal)
+	}
+	if gotVal.area() != 9 {
+		t.Fatalf("area = %d, want 9", gotVal.area())
+	}
+
+	encodedPtr, err := Encode(&rect{W: 2, H: 5})
+	if err != nil {
+		t.Fatalf("Encode(pointer): %v", err)
+	}
+	gotPtr, err := r.Decode(encodedPtr)
+	if err != nil {
+		t.Fatalf("Decode(pointer): %v", err)
+	}
+	if _, ok := gotPtr.(*rect); !ok {
+		t.Fatalf("decoded %T, want *rect (pointer form preserved)", gotPtr)
+	}
+}
+
+// TestRegistry_NilRoundTrip locks the single-value nil policy: a nil value
+// encodes as JSON null and decodes back to a nil T, so an absent optional
+// payload (e.g. a flit with no message) survives a checkpoint without each
+// caller guarding nil itself.
+func TestRegistry_NilRoundTrip(t *testing.T) {
+	r := NewRegistry[shape]("shape")
+
+	encoded, err := Encode[shape](nil)
+	if err != nil {
+		t.Fatalf("Encode(nil): %v", err)
+	}
+	if string(encoded) != "null" {
+		t.Fatalf("Encode(nil) = %q, want null", encoded)
+	}
+
+	got, err := r.Decode(encoded)
+	if err != nil {
+		t.Fatalf("Decode(null): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Decode(null) = %v, want nil", got)
+	}
+
+	// An empty payload (an absent field) is treated the same as null.
+	got, err = r.Decode(nil)
+	if err != nil {
+		t.Fatalf("Decode(empty): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Decode(empty) = %v, want nil", got)
+	}
+}
+
+// TestRegistry_EncodeIsSliceElement guards the invariant that Encode and
+// EncodeSlice share one per-element wire format: a single Encode must equal the
+// lone element of the corresponding one-element EncodeSlice.
+func TestRegistry_EncodeIsSliceElement(t *testing.T) {
+	// Encode needs no registry — encoding is registration-free — so this calls
+	// the free functions directly, without constructing a Registry.
+	single, err := Encode[shape](square{Side: 4})
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	slice, err := EncodeSlice([]shape{square{Side: 4}})
+	if err != nil {
+		t.Fatalf("EncodeSlice: %v", err)
+	}
+
+	// The slice form is a JSON array whose single element is the single form.
+	want := "[" + string(single) + "]"
+	if string(slice) != want {
+		t.Fatalf("EncodeSlice = %s, want %s (single must be the slice element)",
+			slice, want)
+	}
+}
+
+func TestRegistry_DecodeUnknownSingleType(t *testing.T) {
+	r := NewRegistry[shape]("shape")
+
+	_, err := r.Decode(json.RawMessage(`{"type":"codec.square","payload":{}}`))
+	if err == nil || !strings.Contains(err.Error(), "unknown shape type") {
+		t.Fatalf("expected unknown-type error, got %v", err)
 	}
 }
 

--- a/messaging/msg.go
+++ b/messaging/msg.go
@@ -13,11 +13,12 @@ type Msg interface {
 // MsgMeta contains routing and identification metadata. All fields are set at
 // construction time and must not change once the message is in flight.
 type MsgMeta struct {
-	ID           uint64
-	Src, Dst     RemotePort
-	TrafficClass string
-	TrafficBytes int
-	RspTo        uint64
+	ID           uint64     `json:"id"`
+	Src          RemotePort `json:"src"`
+	Dst          RemotePort `json:"dst"`
+	TrafficClass string     `json:"traffic_class"`
+	TrafficBytes int        `json:"traffic_bytes"`
+	RspTo        uint64     `json:"rsp_to"`
 }
 
 // Meta returns the message metadata.

--- a/messaging/msgcodec.go
+++ b/messaging/msgcodec.go
@@ -12,39 +12,24 @@ import (
 var msgCodec = codec.NewRegistry[Msg]("message")
 
 // EncodeMsg encodes a single message into a self-describing JSON payload that
-// preserves its concrete type, so DecodeMsg can reconstruct it. A nil message
-// encodes as JSON null. It is a thin single-value wrapper over the same
-// type-tagged slice encoding used for port-buffer checkpoints (a present
-// message encodes as a one-element list), for callers that carry one
-// polymorphic message inside an otherwise plain-JSON structure (e.g. a flit
-// payload, or an endpoint's reassembly state). The concrete type must be
-// registered (see RegisterMsg / DefineProtocol) for DecodeMsg to restore it.
+// preserves its concrete type, so DecodeMsg can reconstruct it. It is the public
+// entry point for callers that carry one polymorphic message inside an otherwise
+// plain-JSON structure (e.g. a flit payload, or an endpoint's reassembly state),
+// so they need not depend on package codec directly. A nil message encodes as
+// JSON null; that policy lives in codec.Encode, shared by every interface, so
+// this is a thin delegate. The concrete type must be registered (see RegisterMsg
+// / DefineProtocol) for DecodeMsg to restore it.
 func EncodeMsg(msg Msg) (json.RawMessage, error) {
-	if msg == nil {
-		return json.RawMessage("null"), nil
-	}
-
-	return msgCodec.EncodeSlice([]Msg{msg})
+	return codec.Encode(msg)
 }
 
-// DecodeMsg reverses EncodeMsg. A null or empty payload decodes to a nil
-// message. A payload whose concrete type was never registered fails loudly with
-// an unknown-message-type error, matching the port-buffer checkpoint path.
+// DecodeMsg reverses EncodeMsg, resolving the message's concrete type through the
+// message registry — which is why, unlike EncodeMsg, it cannot be a free
+// function. A null or empty payload decodes to a nil message. A payload whose
+// concrete type was never registered fails loudly with an unknown-message-type
+// error, matching the port-buffer checkpoint path.
 func DecodeMsg(data json.RawMessage) (Msg, error) {
-	if len(data) == 0 || string(data) == "null" {
-		return nil, nil
-	}
-
-	msgs, err := msgCodec.DecodeSlice(data)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(msgs) == 0 {
-		return nil, nil
-	}
-
-	return msgs[0], nil
+	return msgCodec.Decode(data)
 }
 
 // RegisterMsg registers a concrete message type so a checkpoint that captured it

--- a/messaging/msgcodec.go
+++ b/messaging/msgcodec.go
@@ -1,11 +1,41 @@
 package messaging
 
-import "github.com/sarchlab/akita/v5/internal/codec"
+import (
+	"encoding/json"
+
+	"github.com/sarchlab/akita/v5/internal/codec"
+)
 
 // msgCodec decodes the polymorphic messages held in port buffers across a
 // checkpoint. Each concrete message type is registered with RegisterMsg; the
 // wire format and reflection machinery live in package codec.
 var msgCodec = codec.NewRegistry[Msg]("message")
+
+// EncodeMsg encodes a single message into a self-describing JSON payload tagged
+// with the message's concrete type, so DecodeMsg can reconstruct it. A nil
+// message encodes as JSON null. It is the single-value counterpart to the slice
+// encoding used for port-buffer checkpoints, for callers that carry one
+// polymorphic message inside an otherwise plain-JSON structure (e.g. a flit
+// payload, or an endpoint's reassembly state). The concrete type must be
+// registered (see RegisterMsg / DefineProtocol) for DecodeMsg to restore it.
+func EncodeMsg(msg Msg) (json.RawMessage, error) {
+	if msg == nil {
+		return json.RawMessage("null"), nil
+	}
+
+	return msgCodec.Encode(msg)
+}
+
+// DecodeMsg reverses EncodeMsg. A null or empty payload decodes to a nil
+// message. A payload whose concrete type was never registered fails loudly with
+// an unknown-message-type error, matching the port-buffer checkpoint path.
+func DecodeMsg(data json.RawMessage) (Msg, error) {
+	if len(data) == 0 || string(data) == "null" {
+		return nil, nil
+	}
+
+	return msgCodec.Decode(data)
+}
 
 // RegisterMsg registers a concrete message type so a checkpoint that captured it
 // in a port buffer can be decoded. It is the low-level primitive behind

--- a/messaging/msgcodec.go
+++ b/messaging/msgcodec.go
@@ -11,10 +11,11 @@ import (
 // wire format and reflection machinery live in package codec.
 var msgCodec = codec.NewRegistry[Msg]("message")
 
-// EncodeMsg encodes a single message into a self-describing JSON payload tagged
-// with the message's concrete type, so DecodeMsg can reconstruct it. A nil
-// message encodes as JSON null. It is the single-value counterpart to the slice
-// encoding used for port-buffer checkpoints, for callers that carry one
+// EncodeMsg encodes a single message into a self-describing JSON payload that
+// preserves its concrete type, so DecodeMsg can reconstruct it. A nil message
+// encodes as JSON null. It is a thin single-value wrapper over the same
+// type-tagged slice encoding used for port-buffer checkpoints (a present
+// message encodes as a one-element list), for callers that carry one
 // polymorphic message inside an otherwise plain-JSON structure (e.g. a flit
 // payload, or an endpoint's reassembly state). The concrete type must be
 // registered (see RegisterMsg / DefineProtocol) for DecodeMsg to restore it.
@@ -23,7 +24,7 @@ func EncodeMsg(msg Msg) (json.RawMessage, error) {
 		return json.RawMessage("null"), nil
 	}
 
-	return msgCodec.Encode(msg)
+	return msgCodec.EncodeSlice([]Msg{msg})
 }
 
 // DecodeMsg reverses EncodeMsg. A null or empty payload decodes to a nil
@@ -34,7 +35,16 @@ func DecodeMsg(data json.RawMessage) (Msg, error) {
 		return nil, nil
 	}
 
-	return msgCodec.Decode(data)
+	msgs, err := msgCodec.DecodeSlice(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(msgs) == 0 {
+		return nil, nil
+	}
+
+	return msgs[0], nil
 }
 
 // RegisterMsg registers a concrete message type so a checkpoint that captured it

--- a/messaging/port_checkpoint.go
+++ b/messaging/port_checkpoint.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/sarchlab/akita/v5/internal/codec"
 	"github.com/sarchlab/akita/v5/queueing"
 )
 
@@ -70,7 +71,7 @@ func (p *defaultPort) LoadCheckpoint(r io.Reader) error {
 func saveBuffer(
 	buf *queueing.Buffer[Msg], portName, label string,
 ) (bufferCheckpoint, error) {
-	elements, err := msgCodec.EncodeSlice(buf.Elements())
+	elements, err := codec.EncodeSlice(buf.Elements())
 	if err != nil {
 		return bufferCheckpoint{}, fmt.Errorf(
 			"messaging: port %q %s: %w", portName, label, err)

--- a/noc/networking/switching/endpoint/README.md
+++ b/noc/networking/switching/endpoint/README.md
@@ -29,7 +29,10 @@ type Resources struct {
 ```
 
 `State` holds the message-out buffer, the flits queued for sending, and the
-per-message reassembly records (`AssemblingMsgs`, `AssembledMsgs`).
+per-message reassembly records (`AssemblingMsgs`, `AssembledMsgs`). The
+message-bearing buffers carry the concrete messages (wrapped in a small
+codec-backed holder so they checkpoint), so a payload-bearing protocol survives
+the network crossing rather than being reduced to its metadata.
 
 `Comp` implements `messaging.Connection`: device ports use the endpoint as their
 connection (`PlugIn` calls `SetConnection`), and `NotifySend`/`NotifyAvailable`
@@ -44,11 +47,12 @@ wake the component. Key methods:
 Each tick two middlewares run. The outgoing path (`device → network`) retrieves
 messages from device ports, converts each into one or more `packetization.Flit`
 values — flit count derived from `TrafficBytes`, `EncodingOverhead`, and
-`FlitByteSize` — and sends them out the network port with `Dst` set to the
-default switch. The incoming path (`network → device`) receives flits, groups
-them by message ID, and once `NumFlitInMsg` flits have arrived, reassembles the
-`messaging.MsgMeta` and delivers it to the matching device port. Buffers apply
-backpressure to keep the serializable state bounded.
+`FlitByteSize`, with the original message attached to the final flit as its
+`Payload` — and sends them out the network port with `Dst` set to the default
+switch. The incoming path (`network → device`) receives flits, groups them by
+message ID, and once `NumFlitInMsg` flits have arrived, delivers the carried
+original message to the matching device port. Buffers apply backpressure to keep
+the serializable state bounded.
 
 ## Builder Pattern
 

--- a/noc/networking/switching/endpoint/comp.go
+++ b/noc/networking/switching/endpoint/comp.go
@@ -24,25 +24,50 @@ type Resources struct {
 	DevicePorts []messaging.Port `json:"-"`
 }
 
-// assemblingMsgState is a serializable representation of a message being
-// assembled from flits.
-type assemblingMsgState struct {
-	MsgID           uint64               `json:"msg_id"`
-	Src             messaging.RemotePort `json:"src"`
-	Dst             messaging.RemotePort `json:"dst"`
-	RspTo           uint64               `json:"rsp_to"`
-	TrafficClass    string               `json:"traffic_class"`
-	TrafficBytes    int                  `json:"traffic_bytes"`
-	NumFlitRequired int                  `json:"num_flit_required"`
-	NumFlitArrived  int                  `json:"num_flit_arrived"`
+// msgHolder carries one polymorphic messaging.Msg inside the endpoint's
+// otherwise plain-JSON State. A bare interface field cannot be checkpointed —
+// the JSON decoder cannot reconstruct the concrete type — so the holder encodes
+// the message through the message codec (the same machinery that checkpoints
+// in-flight messages in port buffers). A nil message round-trips as nil.
+type msgHolder struct {
+	Msg messaging.Msg
 }
 
-// State contains mutable runtime data for the endpoint.
+// MarshalJSON encodes the held message through the message codec.
+func (h msgHolder) MarshalJSON() ([]byte, error) {
+	return messaging.EncodeMsg(h.Msg)
+}
+
+// UnmarshalJSON decodes the held message through the message codec.
+func (h *msgHolder) UnmarshalJSON(data []byte) error {
+	msg, err := messaging.DecodeMsg(data)
+	if err != nil {
+		return err
+	}
+
+	h.Msg = msg
+
+	return nil
+}
+
+// assemblingMsgState is a serializable record of a message being reassembled
+// from flits. Arrival progress is tracked by message ID; the carried concrete
+// message is captured once the flit bearing it (the final flit) arrives.
+type assemblingMsgState struct {
+	MsgID           uint64    `json:"msg_id"`
+	NumFlitRequired int       `json:"num_flit_required"`
+	NumFlitArrived  int       `json:"num_flit_arrived"`
+	Payload         msgHolder `json:"payload"`
+}
+
+// State contains mutable runtime data for the endpoint. The message-bearing
+// buffers carry concrete messages (wrapped in msgHolder so they checkpoint),
+// so a payload-bearing protocol survives the network crossing.
 type State struct {
-	MsgOutBuf      []messaging.MsgMeta  `json:"msg_out_buf"`
+	MsgOutBuf      []msgHolder          `json:"msg_out_buf"`
 	FlitsToSend    []packetization.Flit `json:"flits_to_send"`
 	AssemblingMsgs []assemblingMsgState `json:"assembling_msgs"`
-	AssembledMsgs  []messaging.MsgMeta  `json:"assembled_msgs"`
+	AssembledMsgs  []msgHolder          `json:"assembled_msgs"`
 }
 
 // Comp is an akita component(Endpoint) that delegates sending and receiving

--- a/noc/networking/switching/endpoint/endpoint_test.go
+++ b/noc/networking/switching/endpoint/endpoint_test.go
@@ -126,13 +126,16 @@ var _ = Describe("End Point", func() {
 		flit1.SeqID = 1
 		flit1.NumFlitInMsg = 2
 		flit1.Msg = msg
+		// The concrete message rides on the final flit; the endpoint delivers it
+		// intact rather than a metadata-only stand-in.
+		flit1.Payload = msg
 
 		networkPort.EXPECT().PeekIncoming().Return(flit0)
 		networkPort.EXPECT().PeekIncoming().Return(flit1)
 		networkPort.EXPECT().PeekIncoming().Return(nil).Times(3)
 		networkPort.EXPECT().RetrieveIncoming().Times(2)
 		devicePort.EXPECT().CanDeliver().Return(true)
-		devicePort.EXPECT().Deliver(packetization.AssembledMsg{MsgMeta: msg})
+		devicePort.EXPECT().Deliver(msg)
 		devicePort.EXPECT().PeekOutgoing().Return(nil).AnyTimes()
 
 		madeProgress := endPoint.Tick()

--- a/noc/networking/switching/endpoint/incomingmw.go
+++ b/noc/networking/switching/endpoint/incomingmw.go
@@ -47,11 +47,11 @@ func (m *incomingMW) recv() bool {
 		}
 
 		flit := receivedI.(packetization.Flit)
-		msg := &flit.Msg
+		meta := &flit.Msg
 
 		var assemblingIdx int = -1
 		for j, a := range state.AssemblingMsgs {
-			if a.MsgID == msg.ID {
+			if a.MsgID == meta.ID {
 				assemblingIdx = j
 				break
 			}
@@ -59,17 +59,19 @@ func (m *incomingMW) recv() bool {
 
 		if assemblingIdx < 0 {
 			state.AssemblingMsgs = append(state.AssemblingMsgs, assemblingMsgState{
-				MsgID:           msg.ID,
-				Src:             msg.Src,
-				Dst:             msg.Dst,
-				RspTo:           msg.RspTo,
-				TrafficClass:    msg.TrafficClass,
-				TrafficBytes:    msg.TrafficBytes,
+				MsgID:           meta.ID,
 				NumFlitRequired: flit.NumFlitInMsg,
 				NumFlitArrived:  1,
+				Payload:         msgHolder{Msg: flit.Payload},
 			})
 		} else {
-			state.AssemblingMsgs[assemblingIdx].NumFlitArrived++
+			a := &state.AssemblingMsgs[assemblingIdx]
+			a.NumFlitArrived++
+			// The concrete message rides on a single flit; capture it whenever
+			// that flit is the one arriving, regardless of flit order.
+			if flit.Payload != nil {
+				a.Payload = msgHolder{Msg: flit.Payload}
+			}
 		}
 
 		m.networkPort().RetrieveIncoming()
@@ -103,15 +105,12 @@ func (m *incomingMW) assemble() bool {
 			continue
 		}
 
-		assembled := messaging.MsgMeta{
-			ID:           a.MsgID,
-			Src:          a.Src,
-			Dst:          a.Dst,
-			RspTo:        a.RspTo,
-			TrafficClass: a.TrafficClass,
-			TrafficBytes: a.TrafficBytes,
+		if a.Payload.Msg == nil {
+			panic(fmt.Sprintf(
+				"message %d reassembled without a payload-bearing flit", a.MsgID))
 		}
-		state.AssembledMsgs = append(state.AssembledMsgs, assembled)
+
+		state.AssembledMsgs = append(state.AssembledMsgs, a.Payload)
 		madeProgress = true
 	}
 
@@ -127,8 +126,8 @@ func (m *incomingMW) tryDeliver() bool {
 	numDelivered := 0
 
 	for i := 0; i < len(state.AssembledMsgs); i++ {
-		meta := state.AssembledMsgs[i]
-		dst := meta.Dst
+		msg := state.AssembledMsgs[i].Msg
+		dst := msg.Meta().Dst
 
 		var dstPort messaging.Port
 
@@ -142,8 +141,6 @@ func (m *incomingMW) tryDeliver() bool {
 		if dstPort == nil {
 			panic(fmt.Sprintf("no dst port found for %s", dst))
 		}
-
-		msg := packetization.AssembledMsg{MsgMeta: meta}
 
 		if !dstPort.CanDeliver() {
 			break

--- a/noc/networking/switching/endpoint/outgoingmw.go
+++ b/noc/networking/switching/endpoint/outgoingmw.go
@@ -9,16 +9,22 @@ import (
 	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 
-	// msgMetaToFlits converts a MsgMeta into a slice of packetization.Flit entries.
 	"github.com/sarchlab/akita/v5/messaging"
 )
 
-func msgMetaToFlits(
-	meta messaging.MsgMeta,
+// msgToFlits splits a message into the flits that carry it across the network.
+// The flit count is derived from the message's TrafficBytes (so traffic and
+// timing are modeled), every flit carries the message's routing metadata in
+// Msg, and the concrete message itself rides on the final flit so it is carried
+// exactly once and delivered intact on reassembly.
+func msgToFlits(
+	msg messaging.Msg,
 	spec Spec,
 	networkPortRemote messaging.RemotePort,
 	defaultSwitchDst messaging.RemotePort,
 ) []packetization.Flit {
+	meta := msg.Meta()
+
 	numFlit := 1
 	if meta.TrafficBytes > 0 {
 		trafficByte := meta.TrafficBytes
@@ -37,16 +43,11 @@ func msgMetaToFlits(
 			},
 			SeqID:        i,
 			NumFlitInMsg: numFlit,
-			Msg: messaging.MsgMeta{
-				ID:           meta.ID,
-				Src:          meta.Src,
-				Dst:          meta.Dst,
-				RspTo:        meta.RspTo,
-				TrafficClass: meta.TrafficClass,
-				TrafficBytes: meta.TrafficBytes,
-			},
+			Msg:          meta,
 		}
 	}
+
+	flits[numFlit-1].Payload = msg
 
 	return flits
 }
@@ -134,7 +135,7 @@ func (m *outgoingMW) prepareMsg() bool {
 		}
 
 		msg := port.RetrieveOutgoing()
-		state.MsgOutBuf = append(state.MsgOutBuf, msg.Meta())
+		state.MsgOutBuf = append(state.MsgOutBuf, msgHolder{Msg: msg})
 
 		madeProgress = true
 	}
@@ -163,9 +164,10 @@ func (m *outgoingMW) prepareFlits() bool {
 			return madeProgress
 		}
 
-		meta := state.MsgOutBuf[0]
+		msg := state.MsgOutBuf[0].Msg
 		state.MsgOutBuf = state.MsgOutBuf[1:]
-		flits := msgMetaToFlits(meta, spec, networkPortRemote, m.defaultSwitchDst)
+		meta := msg.Meta()
+		flits := msgToFlits(msg, spec, networkPortRemote, m.defaultSwitchDst)
 
 		state.FlitsToSend = append(state.FlitsToSend, flits...)
 

--- a/noc/networking/switching/endpoint/serialization_test.go
+++ b/noc/networking/switching/endpoint/serialization_test.go
@@ -1,0 +1,103 @@
+package endpoint
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/noc/packetization"
+)
+
+// fakeEndpointMsg is a registered concrete message used to verify that the
+// endpoint's State round-trips the concrete messages it now carries.
+type fakeEndpointMsg struct {
+	messaging.MsgMeta
+	Data string `json:"data"`
+}
+
+func init() {
+	messaging.RegisterMsg(fakeEndpointMsg{})
+}
+
+func TestMsgHolderRoundTrips(t *testing.T) {
+	t.Run("with message", func(t *testing.T) {
+		h := msgHolder{Msg: fakeEndpointMsg{
+			MsgMeta: messaging.MsgMeta{ID: 5, Src: "a", Dst: "b"},
+			Data:    "payload",
+		}}
+
+		data, err := json.Marshal(h)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		var got msgHolder
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if !reflect.DeepEqual(h, got) {
+			t.Fatalf("round trip mismatch:\n got %+v\nwant %+v", got, h)
+		}
+	})
+
+	t.Run("nil message", func(t *testing.T) {
+		data, err := json.Marshal(msgHolder{})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		var got msgHolder
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if got.Msg != nil {
+			t.Fatalf("expected nil message, got %+v", got.Msg)
+		}
+	})
+}
+
+// TestStateRoundTrips checkpoints a populated endpoint State, exercising every
+// message-bearing buffer: an outgoing message, an in-flight flit carrying its
+// payload, a partially-assembled record whose payload flit has not yet arrived
+// (nil payload), and a fully-assembled message ready for delivery.
+func TestStateRoundTrips(t *testing.T) {
+	msg := fakeEndpointMsg{
+		MsgMeta: messaging.MsgMeta{ID: 42, Src: "dev", Dst: "peer", TrafficBytes: 64},
+		Data:    "hello",
+	}
+
+	state := State{
+		MsgOutBuf: []msgHolder{{Msg: msg}},
+		FlitsToSend: []packetization.Flit{{
+			MsgMeta:      messaging.MsgMeta{ID: 1, Src: "ep", Dst: "sw"},
+			SeqID:        0,
+			NumFlitInMsg: 1,
+			Msg:          msg.Meta(),
+			Payload:      msg,
+		}},
+		AssemblingMsgs: []assemblingMsgState{{
+			MsgID:           7,
+			NumFlitRequired: 2,
+			NumFlitArrived:  1,
+			Payload:         msgHolder{}, // payload-bearing flit not yet arrived
+		}},
+		AssembledMsgs: []msgHolder{{Msg: msg}},
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got State
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !reflect.DeepEqual(state, got) {
+		t.Fatalf("round trip mismatch:\n got %+v\nwant %+v", got, state)
+	}
+}

--- a/noc/packetization/README.md
+++ b/noc/packetization/README.md
@@ -4,8 +4,8 @@ Package `packetization` provides packetization primitives for the Akita
 simulation framework. Within the `noc` networking stack, messages do not travel
 across the network whole: endpoints split each message into fixed-size flits,
 the smallest unit that moves between switch ports, and reassemble the flits back
-into a message at the receiving endpoint. This package defines the flit type
-shared by the `endpoint` and `switches` packages.
+into the original message at the receiving endpoint. This package defines the
+flit type shared by the `endpoint` and `switches` packages.
 
 ## Key Types
 
@@ -21,6 +21,7 @@ type Flit struct {
     SeqID        int               // index of this flit within its message
     NumFlitInMsg int               // total flits the message was split into
     Msg          messaging.MsgMeta // metadata of the carried message
+    Payload      messaging.Msg     // the carried message itself (final flit only)
 }
 ```
 
@@ -28,15 +29,30 @@ type Flit struct {
   which describes the current hop between an endpoint and a switch port — not
   the final endpoints.
 - `Msg` carries the original message's metadata (true `Src`/`Dst`, traffic
-  class, byte size), which the receiving endpoint uses to rebuild the message.
+  class, byte size). Every flit carries it, so each switch can route the flit
+  independently and the receiving endpoint can group flits by message ID.
+- `Payload` carries the original concrete message. It rides on the **final**
+  flit (and is `nil` on the others), so the message is carried exactly once. The
+  receiving endpoint delivers this concrete message — not a metadata-only
+  stand-in — so payload-bearing protocols (PCIe `mem.WriteReq`, kernel-launch
+  requests, RDMA data, …) survive the network crossing intact.
 - `SeqID` and `NumFlitInMsg` let the receiving endpoint know when every flit of
   a message has arrived and reassembly can complete.
+
+Because `Payload` is a polymorphic `messaging.Msg`, `Flit` implements custom
+`MarshalJSON`/`UnmarshalJSON` that encode the payload through the message codec
+(the same machinery that checkpoints in-flight messages in port buffers), so a
+flit held in a port buffer or in switch State round-trips across a checkpoint
+with its concrete payload type preserved.
 
 ## How It Works
 
 An `endpoint` computes how many flits a message needs from its `TrafficBytes`,
 flit byte size, and encoding overhead, then emits that many `Flit` values with a
-shared `Msg` payload and increasing `SeqID`. Switches forward each flit
-independently using its hop-level `Dst`; the destination endpoint counts
-arriving flits per message ID and, once `NumFlitInMsg` flits are in, delivers
-the reassembled message to the device port.
+shared `Msg` metadata and increasing `SeqID`, attaching the original message to
+the last flit as its `Payload`. Switches forward each flit independently using
+its hop-level `Dst`; the destination endpoint counts arriving flits per message
+ID and, once `NumFlitInMsg` flits are in, delivers the carried `Payload` message
+to the device port. The flit count still models traffic and timing, while the
+payload makes the delivered message the real thing rather than a metadata
+envelope.

--- a/noc/packetization/flit.go
+++ b/noc/packetization/flit.go
@@ -1,40 +1,90 @@
 package packetization
 
 import (
+	"encoding/json"
+
 	"github.com/sarchlab/akita/v5/messaging"
 )
 
-// Protocol is the traffic-only transport protocol. On the link role,
-// endpoints and switches exchange flits over network links (symmetric link
-// traffic). On the delivery role, an endpoint delivers the reassembled
-// message to the destination device port. Defining the protocol registers
-// both message types with the checkpoint codec.
+// Protocol is the flit transport protocol. On the link role, endpoints and
+// switches exchange flits over network links (symmetric link traffic).
+// Defining the protocol registers the flit type with the checkpoint codec.
 var (
 	Protocol = messaging.DefineProtocol("packetization",
 		messaging.RoleDef{Name: "link",
 			Sends: []messaging.Msg{Flit{}}},
-		messaging.RoleDef{Name: "delivery",
-			Sends: []messaging.Msg{AssembledMsg{}}},
 	)
-	Link     = Protocol.Role("link")
-	Delivery = Protocol.Role("delivery")
+	Link = Protocol.Role("link")
 )
 
 // Flit is a concrete message representing the smallest transferring unit on a
-// network.
+// network. An endpoint splits each outgoing message into one or more flits
+// (count derived from the message's TrafficBytes) and the receiving endpoint
+// reassembles them.
+//
+// Every flit carries the original message's routing metadata in Msg, so each
+// switch can route a flit independently and the receiving endpoint can group
+// flits by message ID. The original concrete message itself rides on the final
+// flit, in Payload. The receiving endpoint delivers that concrete message — not
+// a metadata-only stand-in — so payload-bearing protocols survive the network
+// crossing while the flit count still models traffic and timing.
 type Flit struct {
 	messaging.MsgMeta
 	SeqID        int               `json:"seq_id"`
 	NumFlitInMsg int               `json:"num_flit_in_msg"`
-	Msg          messaging.MsgMeta `json:"msg"` // carried message metadata
+	Msg          messaging.MsgMeta `json:"msg"`     // carried message metadata (every flit)
+	Payload      messaging.Msg     `json:"payload"` // carried message (final flit only)
 }
 
-// AssembledMsg is what an endpoint delivers to a device port in place of the
-// original message. The network is a traffic-only model: the endpoint strips
-// an outgoing message down to its metadata, carries the metadata in flits,
-// and reassembles it at the far end. Receivers under this model only ever see
-// the metadata. Bare MsgMeta is the envelope and belongs to no protocol, so
-// the reassembled metadata is delivered in this concrete wrapper.
-type AssembledMsg struct {
-	messaging.MsgMeta
+// flitJSON is the serialized form of a Flit. Hop holds the flit's own
+// hop-routing metadata (the embedded MsgMeta); it is a named field rather than
+// an embedded one so flitJSON does not itself satisfy messaging.Msg. Payload is
+// encoded through the message codec so its concrete type survives a checkpoint.
+type flitJSON struct {
+	Hop          messaging.MsgMeta `json:"hop"`
+	SeqID        int               `json:"seq_id"`
+	NumFlitInMsg int               `json:"num_flit_in_msg"`
+	Msg          messaging.MsgMeta `json:"msg"`
+	Payload      json.RawMessage   `json:"payload"`
+}
+
+// MarshalJSON encodes the flit, carrying its Payload message through the message
+// codec so the concrete type can be restored on load. Flits are held in port
+// buffers and in switch State, both of which are checkpointed, so the polymorphic
+// Payload must round-trip rather than decode to a bare interface.
+func (f Flit) MarshalJSON() ([]byte, error) {
+	payload, err := messaging.EncodeMsg(f.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(flitJSON{
+		Hop:          f.MsgMeta,
+		SeqID:        f.SeqID,
+		NumFlitInMsg: f.NumFlitInMsg,
+		Msg:          f.Msg,
+		Payload:      payload,
+	})
+}
+
+// UnmarshalJSON restores a flit, decoding its Payload message through the
+// message codec.
+func (f *Flit) UnmarshalJSON(data []byte) error {
+	var dto flitJSON
+	if err := json.Unmarshal(data, &dto); err != nil {
+		return err
+	}
+
+	payload, err := messaging.DecodeMsg(dto.Payload)
+	if err != nil {
+		return err
+	}
+
+	f.MsgMeta = dto.Hop
+	f.SeqID = dto.SeqID
+	f.NumFlitInMsg = dto.NumFlitInMsg
+	f.Msg = dto.Msg
+	f.Payload = payload
+
+	return nil
 }

--- a/noc/packetization/flit_test.go
+++ b/noc/packetization/flit_test.go
@@ -1,0 +1,80 @@
+package packetization
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/sarchlab/akita/v5/messaging"
+)
+
+// fakePayload is a registered concrete message used to verify that a flit's
+// carried Payload survives JSON round-tripping through the message codec, the
+// way it must when a checkpoint captures a flit in a port buffer or switch
+// State.
+type fakePayload struct {
+	messaging.MsgMeta
+	Data string `json:"data"`
+}
+
+func init() {
+	messaging.RegisterMsg(fakePayload{})
+}
+
+func TestFlitWithPayloadRoundTrips(t *testing.T) {
+	original := Flit{
+		MsgMeta:      messaging.MsgMeta{ID: 7, Src: "ep0", Dst: "sw0"},
+		SeqID:        3,
+		NumFlitInMsg: 4,
+		Msg:          messaging.MsgMeta{ID: 42, Src: "a", Dst: "b", TrafficBytes: 128},
+		Payload: fakePayload{
+			MsgMeta: messaging.MsgMeta{ID: 42, Src: "a", Dst: "b", TrafficBytes: 128},
+			Data:    "hello",
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var restored Flit
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !reflect.DeepEqual(original, restored) {
+		t.Fatalf("round trip mismatch:\n got %+v\nwant %+v", restored, original)
+	}
+
+	if _, ok := restored.Payload.(fakePayload); !ok {
+		t.Fatalf("payload concrete type not preserved: got %T", restored.Payload)
+	}
+}
+
+func TestFlitWithoutPayloadRoundTrips(t *testing.T) {
+	original := Flit{
+		MsgMeta:      messaging.MsgMeta{ID: 1, Src: "ep0", Dst: "sw0"},
+		SeqID:        0,
+		NumFlitInMsg: 4,
+		Msg:          messaging.MsgMeta{ID: 42, Src: "a", Dst: "b"},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var restored Flit
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if restored.Payload != nil {
+		t.Fatalf("expected nil payload, got %+v", restored.Payload)
+	}
+
+	if !reflect.DeepEqual(original, restored) {
+		t.Fatalf("round trip mismatch:\n got %+v\nwant %+v", restored, original)
+	}
+}

--- a/timing/serialengine_checkpoint.go
+++ b/timing/serialengine_checkpoint.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/sarchlab/akita/v5/internal/codec"
 )
 
 // serialEngineCheckpoint is the serialized form of the engine: its current time
@@ -17,11 +19,11 @@ type serialEngineCheckpoint struct {
 
 // SaveCheckpoint writes the engine's current time and queued events.
 func (e *SerialEngine) SaveCheckpoint(w io.Writer) error {
-	primary, err := eventCodec.EncodeSlice(e.queue.snapshot())
+	primary, err := codec.EncodeSlice(e.queue.snapshot())
 	if err != nil {
 		return err
 	}
-	secondary, err := eventCodec.EncodeSlice(e.secondaryQueue.snapshot())
+	secondary, err := codec.EncodeSlice(e.secondaryQueue.snapshot())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Fixes #386. The v5 switching network (`noc/networking/switching`) was **traffic-only**: an endpoint packetized just a message's `MsgMeta`, discarded the concrete message at the sender, and delivered a metadata-only `packetization.AssembledMsg` at the receiver. As a result, no payload-bearing protocol could cross a switching network (PCIe included) — driver→GPU launch requests, `MemCopy` data, address translation, and inter-GPU RDMA all lost their payload, forcing downstream simulators onto `directconnection` (zero latency / infinite bandwidth) and dropping all network timing fidelity.

This implements **Option 1** from the issue: carry the original message end-to-end so payload-bearing protocols survive the crossing while flit counts still model traffic and timing.

## Changes

- **`packetization.Flit`** gains a `Payload messaging.Msg` field. Every flit still carries the message's `MsgMeta` (for independent per-hop routing and reassembly grouping); the original concrete message rides on the **final** flit, so it is carried exactly once. `Flit` now implements codec-backed `MarshalJSON`/`UnmarshalJSON` so the polymorphic payload round-trips across a checkpoint wherever a flit is held (port buffers, switch `State`).
- The metadata-only **`AssembledMsg`** type and the packetization **`delivery`** role are removed — they are now redundant.
- The **endpoint** stores, reassembles, and delivers the concrete message. Message-bearing `State` buffers wrap messages in a small codec-backed holder so `State` stays checkpoint-serializable (`ValidateState` otherwise rejects bare interface fields).
- New **single-value polymorphic serialization** helpers: `messaging.EncodeMsg`/`DecodeMsg` and `codec.Registry.Encode`/`Decode`, mirroring the existing slice path used for port-buffer checkpoints.

The switch is unchanged: it still routes on each flit's `Msg.Dst`.

## Why this is safe for checkpointing

Carrying the real message is feasible because the message codec already serializes arbitrary registered messages polymorphically — the same machinery that checkpoints in-flight messages in port buffers. Every payload type that can cross the network is already registered via its protocol's `DefineProtocol`, and the existing registration-coverage audit (`TestEveryMsgTypeIsRegistered`) enforces it.

## Testing

- New `noc/packetization/flit_test.go`: flit JSON round-trips with and without a payload, concrete payload type preserved.
- New `noc/networking/switching/endpoint/serialization_test.go`: `msgHolder` (nil + non-nil) and a full populated endpoint `State` round-trip.
- New `internal/codec` single-value `Encode`/`Decode` tests.
- Updated `endpoint_test.go` to assert delivery of the real message.
- Full suite green: `go test ./...` (incl. the messaging protocol audit, `noc` acceptance/mesh/networkconnector, and `simulation`/`modeling` checkpoint tests), plus `go vet` and `gofmt`.

https://claude.ai/code/session_017owfr1apifAJewwu1bBr6v

---
_Generated by [Claude Code](https://claude.ai/code/session_017owfr1apifAJewwu1bBr6v)_