### PR TITLE
feat(mem/dram): PER_BANK command-queue structure (P1.2)

### DIFF
--- a/mem/dram/builder.go
+++ b/mem/dram/builder.go
@@ -120,7 +120,7 @@ func (b Builder) Build(name string) *Comp {
 			Entries: []subTransRef{},
 		},
 		CommandQueues: commandQueueState{
-			NumQueues: b.spec.NumChannel * b.spec.NumRank,
+			NumQueues: numCommandQueues(&b.spec),
 			Entries:   []queueEntry{},
 		},
 		BankStates: initBankStatesFlat(

--- a/mem/dram/comp.go
+++ b/mem/dram/comp.go
@@ -48,6 +48,12 @@ const (
 	PagePolicyOpen  PagePolicy = 1
 )
 
+// Command-queue structures. The empty string selects PER_RANK.
+const (
+	QueueStructurePerRank = "PER_RANK"
+	QueueStructurePerBank = "PER_BANK"
+)
+
 // Spec contains immutable configuration for the DRAM memory controller.
 type Spec struct {
 	// Frequency
@@ -112,6 +118,10 @@ type Spec struct {
 	// Queue sizes
 	TransactionQueueSize int `json:"transaction_queue_size"`
 	CommandQueueCapacity int `json:"command_queue_capacity"`
+
+	// Command-queue structure: "" / QueueStructurePerRank groups a rank's banks
+	// into one command queue; QueueStructurePerBank gives each bank its own.
+	QueueStructure string `json:"queue_structure"`
 
 	// Read/Write queue separation
 	ReadQueueSize      int `json:"read_queue_size"`

--- a/mem/dram/ctrlmiddleware.go
+++ b/mem/dram/ctrlmiddleware.go
@@ -125,7 +125,7 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 	state.Transactions = nil
 	state.SubTransQueue = subTransQueueState{Entries: []subTransRef{}}
 	state.CommandQueues = commandQueueState{
-		NumQueues: spec.NumChannel * spec.NumRank,
+		NumQueues: numCommandQueues(&spec),
 		Entries:   []queueEntry{},
 	}
 	state.BankStates = initBankStatesFlat(

--- a/mem/dram/memcontroller_test.go
+++ b/mem/dram/memcontroller_test.go
@@ -925,7 +925,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 				Location: location{Rank: 0, BankGroup: 0, Bank: uint64(i)},
 			}
 			Expect(canAcceptCommand(state, cmd, spec)).To(BeTrue())
-			acceptCommand(state, cmd)
+			acceptCommand(state, cmd, spec)
 		}
 
 		// One more write should be rejected
@@ -954,7 +954,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 				Location: location{Rank: 0, BankGroup: 0, Bank: uint64(i)},
 			}
 			Expect(canAcceptCommand(state, cmd, spec)).To(BeTrue())
-			acceptCommand(state, cmd)
+			acceptCommand(state, cmd, spec)
 		}
 
 		// One more read should be rejected
@@ -987,7 +987,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 				Location: location{Rank: 0, BankGroup: 0, Bank: 0},
 			}
 			Expect(canAcceptCommand(state, cmd, spec)).To(BeTrue())
-			acceptCommand(state, cmd)
+			acceptCommand(state, cmd, spec)
 		}
 
 		// Both reads and writes should be rejected
@@ -1029,7 +1029,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 			Kind:     int(cmdKindWritePrecharge),
 			Location: location{Rank: 0},
 		}
-		acceptCommand(state, writeCmd)
+		acceptCommand(state, writeCmd, spec)
 		Expect(state.CommandQueues.Entries[0].IsWrite).To(BeTrue())
 
 		readCmd := &commandState{
@@ -1037,7 +1037,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 			Kind:     int(cmdKindReadPrecharge),
 			Location: location{Rank: 0},
 		}
-		acceptCommand(state, readCmd)
+		acceptCommand(state, readCmd, spec)
 		Expect(state.CommandQueues.Entries[1].IsWrite).To(BeFalse())
 	})
 })

--- a/mem/dram/perbank_queue_test.go
+++ b/mem/dram/perbank_queue_test.go
@@ -1,0 +1,69 @@
+package dram
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// P1.2 — PER_BANK command-queue structure.
+//
+// Today the controller uses one command queue per rank (PER_RANK): all of a
+// rank's banks share a single queue of CommandQueueCapacity entries, so a burst
+// to one bank can starve the others. PER_BANK gives each bank its own queue,
+// which both references model. These specs capture the PER_BANK behavior and
+// are expected to FAIL until it is implemented (getQueueIndex / NumQueues).
+
+func cmdAt(rank, bankGroup, bank uint64) *commandState {
+	return &commandState{
+		Kind:     int(cmdKindRead),
+		Location: location{Rank: rank, BankGroup: bankGroup, Bank: bank},
+	}
+}
+
+var _ = Describe("P1.2: PER_BANK command queues", func() {
+	It("maps different banks of a rank to different queues (PER_BANK)", func() {
+		spec := DefaultSpec()
+		spec.QueueStructure = QueueStructurePerBank
+
+		// Two distinct banks in the same rank must land in distinct queues.
+		Expect(getQueueIndex(&spec, cmdAt(0, 0, 0))).
+			NotTo(Equal(getQueueIndex(&spec, cmdAt(0, 0, 1))))
+	})
+
+	It("isolates command-queue capacity per bank (PER_BANK)", func() {
+		spec := DefaultSpec()
+		spec.QueueStructure = QueueStructurePerBank
+		spec.CommandQueueCapacity = 2
+
+		state := &State{
+			CommandQueues: commandQueueState{Entries: []queueEntry{}},
+		}
+
+		// Fill bank (0,0,0)'s queue to capacity.
+		acceptCommand(state, cmdAt(0, 0, 0), &spec)
+		acceptCommand(state, cmdAt(0, 0, 0), &spec)
+
+		// A different bank in the same rank still has room — its own queue.
+		Expect(canAcceptCommand(state, cmdAt(0, 0, 1), &spec)).To(BeTrue())
+	})
+
+	It("builds one command queue per bank (PER_BANK)", func() {
+		spec := DDR4Spec
+		spec.QueueStructure = QueueStructurePerBank
+		spec.TransactionQueueSize = 32
+		spec.CommandQueueCapacity = 8
+
+		h := newP0Harness(spec)
+		banks := spec.NumRank * spec.NumBankGroup * spec.NumBank
+		Expect(h.dram.State.CommandQueues.NumQueues).To(Equal(banks))
+	})
+
+	It("groups a rank's banks into one queue under PER_RANK (default)", func() {
+		spec := DefaultSpec()
+		spec.QueueStructure = QueueStructurePerRank
+
+		// Same rank, different banks share the single per-rank queue.
+		Expect(getQueueIndex(&spec, cmdAt(0, 0, 0))).
+			To(Equal(getQueueIndex(&spec, cmdAt(0, 0, 1))))
+	})
+})

--- a/mem/dram/perbank_queue_test.go
+++ b/mem/dram/perbank_queue_test.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// P1.2 — PER_BANK command-queue structure.
+// PER_BANK command-queue structure.
 //
 // Today the controller uses one command queue per rank (PER_RANK): all of a
 // rank's banks share a single queue of CommandQueueCapacity entries, so a burst
@@ -20,7 +20,7 @@ func cmdAt(rank, bankGroup, bank uint64) *commandState {
 	}
 }
 
-var _ = Describe("P1.2: PER_BANK command queues", func() {
+var _ = Describe("PER_BANK command queues", func() {
 	It("maps different banks of a rank to different queues (PER_BANK)", func() {
 		spec := DefaultSpec()
 		spec.QueueStructure = QueueStructurePerBank
@@ -53,7 +53,7 @@ var _ = Describe("P1.2: PER_BANK command queues", func() {
 		spec.TransactionQueueSize = 32
 		spec.CommandQueueCapacity = 8
 
-		h := newP0Harness(spec)
+		h := newDramHarness(spec)
 		banks := spec.NumRank * spec.NumBankGroup * spec.NumBank
 		Expect(h.dram.State.CommandQueues.NumQueues).To(Equal(banks))
 	})

--- a/mem/dram/plugins.go
+++ b/mem/dram/plugins.go
@@ -176,7 +176,7 @@ func (c *controller) fillCommandQueue(spec *Spec, state *State) bool {
 		cmd := c.rowPolicy.CommandFor(spec, state, ref, loc)
 
 		if canAcceptCommand(state, cmd, spec) {
-			acceptCommand(state, cmd)
+			acceptCommand(state, cmd, spec)
 			state.SubTransQueue.Entries = append(
 				state.SubTransQueue.Entries[:i],
 				state.SubTransQueue.Entries[i+1:]...,

--- a/mem/dram/plugins_test.go
+++ b/mem/dram/plugins_test.go
@@ -30,7 +30,7 @@ func (t *cmdTracer) AddMilestone(m tracing.Milestone) {
 	t.byKind[m.What]++
 }
 
-var _ = Describe("P1: strategy selection", func() {
+var _ = Describe("strategy selection", func() {
 	It("selects the default strategies from a default spec", func() {
 		spec := DefaultSpec()
 		ctrl := newDefaultController(&spec)
@@ -62,20 +62,20 @@ var _ = Describe("P1: strategy selection", func() {
 	})
 })
 
-var _ = Describe("P1: command tracing", func() {
+var _ = Describe("command tracing", func() {
 	It("records command milestones without changing results", func() {
 		spec := DefaultSpec()
 		tracer := newCmdTracer()
 
 		// Same workload, with and without the tracer.
-		traced := newP0Harness(spec, tracer)
+		traced := newDramHarness(spec, tracer)
 		traced.src.Send(traced.write(0x40, []byte{1, 2, 3, 4}))
 		traced.engine.Run()
 		traced.src.Send(traced.read(0x40))
 		traced.engine.Run()
 		tracedReads, tracedWrites := traced.collect()
 
-		plain := newP0Harness(spec)
+		plain := newDramHarness(spec)
 		plain.src.Send(plain.write(0x40, []byte{1, 2, 3, 4}))
 		plain.engine.Run()
 		plain.src.Send(plain.read(0x40))

--- a/mem/dram/queue_ops.go
+++ b/mem/dram/queue_ops.go
@@ -94,13 +94,25 @@ func createOpenPageCommand(
 		spec, state, ref, mapAddress(spec, st.Address))
 }
 
-// getQueueIndex returns the command-queue index for a command. The mapping is
-// meant to depend on the configured queue structure (PER_RANK groups a rank's
-// banks into one queue; PER_BANK gives each bank its own queue), but only
-// PER_RANK is implemented so far — PER_BANK is the subject of the failing tests
-// in perbank_queue_test.go.
+// getQueueIndex returns the command-queue index for a command. PER_RANK (the
+// default) groups all of a rank's banks into one queue; PER_BANK gives each
+// bank its own queue, keyed by the bank's flat (rank, bank-group, bank) index.
 func getQueueIndex(spec *Spec, cmd *commandState) int {
-	return int(cmd.Location.Rank)
+	loc := cmd.Location
+	if spec.QueueStructure == QueueStructurePerBank {
+		return (int(loc.Rank)*spec.NumBankGroup+int(loc.BankGroup))*spec.NumBank +
+			int(loc.Bank)
+	}
+	return int(loc.Rank)
+}
+
+// numCommandQueues returns the number of command queues for the configured
+// queue structure: one per bank under PER_BANK, one per rank otherwise.
+func numCommandQueues(spec *Spec) int {
+	if spec.QueueStructure == QueueStructurePerBank {
+		return spec.NumRank * spec.NumBankGroup * spec.NumBank
+	}
+	return spec.NumChannel * spec.NumRank
 }
 
 // isWriteCommand returns true if the command is a write or write-precharge.

--- a/mem/dram/queue_ops.go
+++ b/mem/dram/queue_ops.go
@@ -94,8 +94,12 @@ func createOpenPageCommand(
 		spec, state, ref, mapAddress(spec, st.Address))
 }
 
-// getQueueIndex returns the command queue index for a command (by rank).
-func getQueueIndex(cmd *commandState) int {
+// getQueueIndex returns the command-queue index for a command. The mapping is
+// meant to depend on the configured queue structure (PER_RANK groups a rank's
+// banks into one queue; PER_BANK gives each bank its own queue), but only
+// PER_RANK is implemented so far — PER_BANK is the subject of the failing tests
+// in perbank_queue_test.go.
+func getQueueIndex(spec *Spec, cmd *commandState) int {
 	return int(cmd.Location.Rank)
 }
 
@@ -113,7 +117,7 @@ func canAcceptCommand(
 	cmd *commandState,
 	spec *Spec,
 ) bool {
-	queueIdx := getQueueIndex(cmd)
+	queueIdx := getQueueIndex(spec, cmd)
 	isWrite := isWriteCommand(cmd)
 
 	// If R/W queue separation is configured (sizes > 0), use separate limits
@@ -141,8 +145,8 @@ func canAcceptCommand(
 }
 
 // acceptCommand adds a command to the command queue.
-func acceptCommand(state *State, cmd *commandState) {
-	queueIdx := getQueueIndex(cmd)
+func acceptCommand(state *State, cmd *commandState, spec *Spec) {
+	queueIdx := getQueueIndex(spec, cmd)
 	state.CommandQueues.Entries = append(
 		state.CommandQueues.Entries,
 		queueEntry{

--- a/mem/dram/refreshmw.go
+++ b/mem/dram/refreshmw.go
@@ -12,8 +12,8 @@ import (
 // State.RefreshInProgress (the stall flag).
 //
 // Today it implements the fake global tRFC stall (deviation D2). Real refresh
-// (P2) is a different refresh middleware selected by config; the bank-tick
-// issue step does not change — it just honors the stall flag.
+// is a different refresh middleware selected by config; the bank-tick issue
+// step does not change — it just honors the stall flag.
 type refreshMiddleware struct {
 	comp *modeling.Component[Spec, State, Resources]
 }

--- a/mem/dram/regression_test.go
+++ b/mem/dram/regression_test.go
@@ -11,23 +11,23 @@ import (
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
-// p0Harness wires a DRAM controller to a source port through a direct
+// dramHarness wires a DRAM controller to a source port through a direct
 // connection so a test can drive requests and collect responses end-to-end.
-type p0Harness struct {
+type dramHarness struct {
 	engine timing.Engine
 	dram   *Comp
 	src    messaging.Port
 	top    messaging.Port
 }
 
-func newP0Harness(spec Spec, tracers ...tracing.Tracer) *p0Harness {
+func newDramHarness(spec Spec, tracers ...tracing.Tracer) *dramHarness {
 	engine := timing.NewSerialEngine()
 	reg := modeling.NewStandaloneRegistrar(engine)
 
 	dramComp := MakeBuilder().
 		WithRegistrar(reg).
 		WithSpec(spec).
-		Build("P0DRAM")
+		Build("TestDRAM")
 	for _, t := range tracers {
 		tracing.CollectTrace(dramComp, t)
 	}
@@ -50,10 +50,10 @@ func newP0Harness(spec Spec, tracers ...tracing.Tracer) *p0Harness {
 	conn.PlugIn(top)
 	conn.PlugIn(src)
 
-	return &p0Harness{engine: engine, dram: dramComp, src: src, top: top}
+	return &dramHarness{engine: engine, dram: dramComp, src: src, top: top}
 }
 
-func (h *p0Harness) read(addr uint64) memprotocol.ReadReq {
+func (h *dramHarness) read(addr uint64) memprotocol.ReadReq {
 	r := memprotocol.ReadReq{}
 	r.ID = timing.GetIDGenerator().Generate()
 	r.Address = addr
@@ -65,7 +65,7 @@ func (h *p0Harness) read(addr uint64) memprotocol.ReadReq {
 	return r
 }
 
-func (h *p0Harness) write(addr uint64, data []byte) memprotocol.WriteReq {
+func (h *dramHarness) write(addr uint64, data []byte) memprotocol.WriteReq {
 	w := memprotocol.WriteReq{}
 	w.ID = timing.GetIDGenerator().Generate()
 	w.Address = addr
@@ -77,7 +77,7 @@ func (h *p0Harness) write(addr uint64, data []byte) memprotocol.WriteReq {
 	return w
 }
 
-func (h *p0Harness) collect() (
+func (h *dramHarness) collect() (
 	reads []memprotocol.DataReadyRsp,
 	writes []memprotocol.WriteDoneRsp,
 ) {
@@ -102,7 +102,7 @@ func (h *p0Harness) collect() (
 // addresses that differ only in bits [6,12] hit the same bank+row, while a
 // change in bit [17] is a same-bank row conflict.
 
-var _ = Describe("P0: open-page panic regression", func() {
+var _ = Describe("open-page panic regression", func() {
 	openPageSpec := func() Spec {
 		spec := DefaultSpec()
 		spec.PagePolicy = PagePolicyOpen
@@ -110,7 +110,7 @@ var _ = Describe("P0: open-page panic regression", func() {
 	}
 
 	It("should not panic on back-to-back same-row reads (the original bug)", func() {
-		h := newP0Harness(openPageSpec())
+		h := newDramHarness(openPageSpec())
 
 		// Two reads to the same bank+row (columns 0x40 and 0x80). The second is
 		// a row-buffer hit issued while the first read's data is still in
@@ -126,7 +126,7 @@ var _ = Describe("P0: open-page panic regression", func() {
 	})
 
 	It("should handle same-bank row conflicts in open-page mode", func() {
-		h := newP0Harness(openPageSpec())
+		h := newDramHarness(openPageSpec())
 
 		// Same bank and rank, different rows (bit 17) → the controller must
 		// precharge and re-activate between the two reads.
@@ -140,7 +140,7 @@ var _ = Describe("P0: open-page panic regression", func() {
 	})
 
 	It("should pipeline many same-row reads without panic", func() {
-		h := newP0Harness(openPageSpec())
+		h := newDramHarness(openPageSpec())
 
 		const n = 8
 		for i := range n {
@@ -157,7 +157,7 @@ var _ = Describe("P0: open-page panic regression", func() {
 	})
 
 	It("should preserve write-then-read data in open-page mode", func() {
-		h := newP0Harness(openPageSpec())
+		h := newDramHarness(openPageSpec())
 
 		data := []byte{9, 8, 7, 6}
 
@@ -175,7 +175,7 @@ var _ = Describe("P0: open-page panic regression", func() {
 	})
 })
 
-var _ = Describe("P0: close-page completion latency", func() {
+var _ = Describe("close-page completion latency", func() {
 	// Regression for the auto-precharge completion bug: under the default
 	// close-page policy, reads/writes are emitted as ReadPrecharge/WritePrecharge.
 	// Their data/response must become ready after ReadDelay/WriteDelay (the data
@@ -218,7 +218,7 @@ var _ = Describe("P0: close-page completion latency", func() {
 	})
 })
 
-var _ = Describe("P0: channel guard", func() {
+var _ = Describe("channel guard", func() {
 	build := func(numChannel int) func() {
 		return func() {
 			engine := timing.NewSerialEngine()

--- a/mem/dram/validation/run_oracles.py
+++ b/mem/dram/validation/run_oracles.py
@@ -65,7 +65,7 @@ def _channel_size_mb():
 # activates == #ops and reads/writes == the obvious split, independent of
 # address mapping, so these are exact across all three simulators.
 
-# Refresh is a separate validation axis (roadmap P2) and a confound for command
+# Refresh is a separate validation axis and a confound for command
 # counts: DRAMSim3 idles for the full -c budget after the trace drains, firing
 # many refreshes (one boundary even adds a stray activate). For these
 # count-focused close-page scenarios we push refresh out of range so only
@@ -92,11 +92,11 @@ def build_ops(pattern):
 #  * Performance scenarios (open-page read streams at various strides):
 #    average read latency is compared against DRAMSim3 within 15% (Tier 6).
 #    These deliberately probe a feature Akita does NOT support — configurable
-#    address mapping (roadmap P3). When a stride serializes to a single bank
+#    address mapping. When a stride serializes to a single bank
 #    (0x40 sequential, 0x20000 same-bank) Akita matches DRAMSim3, so those are
 #    *enforced*. When bank parallelism depends on the address map (0x2000,
 #    0x4000) Akita's fixed map diverges 50-60% from DRAMSim3's `rochrababgco`;
-#    those are *known gaps* that the suite tracks until P3 lands.
+#    those are *known gaps* that the suite tracks until that feature lands.
 #
 # Each scenario carries a compact `pattern` (op/count/stride); ops are expanded
 # by build_ops. latency_check: "off"|"enforced"|"known_gap"; counts_check:
@@ -124,11 +124,11 @@ SCENARIOS = [
     {"name": "op_stride_8K",   "page_policy": "open",
      "pattern": {"op": "read", "count": 512, "stride": "0x2000"},
      "counts_check": "off", "latency_check": "known_gap",
-     "gap_reason": "configurable address mapping (roadmap P3)"},
+     "gap_reason": "configurable address mapping"},
     {"name": "op_stride_16K",  "page_policy": "open",
      "pattern": {"op": "read", "count": 512, "stride": "0x4000"},
      "counts_check": "off", "latency_check": "known_gap",
-     "gap_reason": "configurable address mapping (roadmap P3)"},
+     "gap_reason": "configurable address mapping"},
 ]
 
 # Expand ops once so the rest of the script can use scn["ops"] directly; the

--- a/mem/dram/validation/traces/scenarios.json
+++ b/mem/dram/validation/traces/scenarios.json
@@ -108,7 +108,7 @@
       },
       "counts_check": "off",
       "latency_check": "known_gap",
-      "gap_reason": "configurable address mapping (roadmap P3)"
+      "gap_reason": "configurable address mapping"
     },
     {
       "name": "op_stride_16K",
@@ -120,7 +120,7 @@
       },
       "counts_check": "off",
       "latency_check": "known_gap",
-      "gap_reason": "configurable address mapping (roadmap P3)"
+      "gap_reason": "configurable address mapping"
     }
   ]
 }

--- a/mem/dram/validation_tier5_test.go
+++ b/mem/dram/validation_tier5_test.go
@@ -24,12 +24,13 @@ import (
 //
 //   Tier 6 — average read latency, open-page stream scenarios, compared against
 //            DRAMSim3 within a 15% tolerance. Some of these deliberately probe a
-//            feature Akita does NOT support (configurable address mapping, P3):
+//            feature Akita does NOT support (configurable address mapping):
 //            when bank parallelism depends on the mapping, Akita's fixed map
 //            diverges far past 15%. Those scenarios are marked "known_gap" and
 //            the suite asserts the gap is *currently* large (a tracked,
-//            executable record). When P3 lands and the gap closes, the
-//            characterization assertion will fail — flip it to "enforced" then.
+//            executable record). When configurable address mapping lands and the
+//            gap closes, the characterization assertion will fail — flip it to
+//            "enforced" then.
 
 const (
 	tier5ScenariosPath = "validation/traces/scenarios.json"
@@ -96,7 +97,7 @@ func runAkita(scn tier5Scenario) akitaResult {
 	spec.CommandQueueCapacity = 8
 	spec.TREFI = 0 // refresh off, matching the oracle reference runs
 
-	h := newP0Harness(spec)
+	h := newDramHarness(spec)
 	data := []byte{1, 2, 3, 4}
 	for _, op := range scn.ops() {
 		if op[0] == 1 {


### PR DESCRIPTION
**Draft — TDD in progress.** This first commit is the **failing tests**; implementation follows.

## Goal (roadmap P1.2)

Add a command-queue structure option. Today the controller uses **one command queue per rank** (PER_RANK): all of a rank's banks share a single `CommandQueueCapacity`, so a burst to one bank can starve the others. **PER_BANK** gives each bank its own queue — the structure both DRAMSim3 and Ramulator2 model.

## This commit (red)

- Adds `Spec.QueueStructure` (`""` = `PER_RANK`; `QueueStructurePerBank`) and threads the spec through `getQueueIndex`/`acceptCommand` — **no behavior change yet** (`getQueueIndex` still returns the rank index).
- `perbank_queue_test.go` captures the intended PER_BANK behavior and **fails** until implemented:
  - distinct queue per bank,
  - per-bank capacity isolation (a full queue on one bank doesn't block another),
  - one command queue per bank (`NumQueues`).
  - (+ a passing PER_RANK-default regression guard.)

State: **183 pass, 3 fail** (the PER_BANK specs); whole repo builds; lint clean. CI will be red until the implementation commit lands.

## Next

Implement PER_BANK in `getQueueIndex` (bank flat index) and the queue-count wiring, turning the 3 specs green. Then consider a Tier-6 differential scenario showing the per-bank parallelism benefit vs DRAMSim3.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DniW9QR3dzeZxuFy7aVAje)_