### PR TITLE
ci: disable setup-go dependency cache on self-hosted runners

### DIFF
--- a/.github/workflows/akita_test.yml
+++ b/.github/workflows/akita_test.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: 1.26.2
           # Self-hosted runner: GOMODCACHE/GOCACHE persist on local disk
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: 1.26.2
           # Self-hosted runner: GOMODCACHE/GOCACHE persist on local disk
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: 1.26.2
           # Self-hosted runner: GOMODCACHE/GOCACHE persist on local disk
@@ -127,7 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: 1.26.2
           # Self-hosted runner: GOMODCACHE/GOCACHE persist on local disk

--- a/.github/workflows/akita_test.yml
+++ b/.github/workflows/akita_test.yml
@@ -43,6 +43,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.26.2
+          # Self-hosted runner: GOMODCACHE/GOCACHE persist on local disk
+          # between jobs, so setup-go's dependency cache is redundant. It was
+          # also failing auth and burning ~20 min / ~2 GB restoring a stale
+          # archive at 1-2 MB/s. Disable it.
+          cache: false
       - name: Install mockgen
         run: go install go.uber.org/mock/mockgen@v0.6.0
       - name: Install ginkgo
@@ -72,6 +81,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.26.2
+          # Self-hosted runner: GOMODCACHE/GOCACHE persist on local disk
+          # between jobs, so setup-go's dependency cache is redundant. It was
+          # also failing auth and burning ~20 min / ~2 GB restoring a stale
+          # archive at 1-2 MB/s. Disable it.
+          cache: false
       - name: Run DRAM validation (Tiers 1-6)
         run: go test ./mem/dram/ -count=1
 
@@ -81,6 +99,15 @@ jobs:
     needs: [akita_build_lint_test]
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.26.2
+          # Self-hosted runner: GOMODCACHE/GOCACHE persist on local disk
+          # between jobs, so setup-go's dependency cache is redundant. It was
+          # also failing auth and burning ~20 min / ~2 GB restoring a stale
+          # archive at 1-2 MB/s. Disable it.
+          cache: false
       - name: Ensure Python3
         run: python3 --version || (sudo dnf install -y python3 || sudo apt-get install -y python3)
       - name: Install mockgen
@@ -99,6 +126,15 @@ jobs:
     needs: [akita_build_lint_test]
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.26.2
+          # Self-hosted runner: GOMODCACHE/GOCACHE persist on local disk
+          # between jobs, so setup-go's dependency cache is redundant. It was
+          # also failing auth and burning ~20 min / ~2 GB restoring a stale
+          # archive at 1-2 MB/s. Disable it.
+          cache: false
       - name: Ensure Python3
         run: python3 --version || (sudo dnf install -y python3 || sudo apt-get install -y python3)
       - name: Install mockgen

--- a/.github/workflows/akita_test.yml
+++ b/.github/workflows/akita_test.yml
@@ -43,10 +43,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.26.2
       - name: Install mockgen
         run: go install go.uber.org/mock/mockgen@v0.6.0
       - name: Install ginkgo
@@ -76,10 +72,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.26.2
       - name: Run DRAM validation (Tiers 1-6)
         run: go test ./mem/dram/ -count=1
 
@@ -89,10 +81,6 @@ jobs:
     needs: [akita_build_lint_test]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.26.2
       - name: Ensure Python3
         run: python3 --version || (sudo dnf install -y python3 || sudo apt-get install -y python3)
       - name: Install mockgen
@@ -111,10 +99,6 @@ jobs:
     needs: [akita_build_lint_test]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.26.2
       - name: Ensure Python3
         run: python3 --version || (sudo dnf install -y python3 || sudo apt-get install -y python3)
       - name: Install mockgen


### PR DESCRIPTION
## Problem

The `Set up Go` step was taking **~20 min per job** (the whole job was 20m31s; see run 27702227945, job `akita_build_lint_test`).

Installing the Go toolchain itself is instant:
```
Found in cache @ .../_tool/go/1.26.2/arm64
Successfully set up Go version 1.26.2
```
The time went into `setup-go@v4`'s default **`cache: true`**, which tried to restore a **~2 GB** Go module/build cache over the network at **1–2 MB/s**, then failed auth anyway:
```
Received 0 of 1986284743 (0.0%), 0.0 MBs/sec   # ~2 GB archive
Failed to restore: Server failed to authenticate the request
Failed to save: Unable to reserve cache ... another job may be creating this cache
```
So ~20 min and ~2 GB of bandwidth per job were burned on a cache that failed **and that we don't need**.

## Why we don't need it

These are **self-hosted** runners. The Go caches already persist on local disk between jobs:
- `GOMODCACHE = /home/yifan/go/pkg/mod`
- `GOCACHE = /home/yifan/.cache/go-build`

GitHub's Actions cache (`cache: true`) is for ephemeral cloud runners that get wiped each run. On a persistent self-hosted runner it's a redundant round-trip.

## Fix

Set `cache: false` on all four `setup-go` steps (`akita_build_lint_test`, `dram_validation`, `noc_acceptance_test`, `mem_acceptance_test`). Keeps the toolchain + version pin (instant), drops the slow/broken remote cache.

## Note

An earlier revision of this branch *removed* `setup-go` entirely — that broke with `go: command not found`, because the toolchain lives in `_tool/go/...` (added to PATH by setup-go), not on the system PATH. So the right fix is disabling the cache, not removing the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)