### PR TITLE
DaisenBot Phase 3: record simulator source into the trace and let the agent search/read it

### DIFF
--- a/daisen2/docs/daisenbot-agent-plan.md
+++ b/daisen2/docs/daisenbot-agent-plan.md
@@ -1,6 +1,6 @@
 # DaisenBot Agentic Upgrade — Design & Implementation Plan
 
-**Status:** Phases 1–2 merged (#387, #392) · Phase 5 (viz perception) merged with #392 · **Phase 3 in progress — Workstreams A (source recording), B (daisen2 reader), C/D (`code_search`/`code_read` tools) implemented; E (system-prompt update) pending — §8** · **Last updated:** 2026-06-17
+**Status:** Phases 1–2 merged (#387, #392) · Phase 5 (viz perception) merged with #392 · **Phase 3 complete — Workstreams A (source recording), B (daisen2 reader), C/D (`code_search`/`code_read` tools), E (embedded system prompt) all implemented. Follow-up: the tutorial/component-doc recommendation for `WithSourceFS` (decision #2). — §8** · **Last updated:** 2026-06-17
 
 This document captures the design decisions and phased plan for turning DaisenBot
 from a single-shot Q&A proxy into a tool-using agent that can *investigate* an
@@ -719,6 +719,22 @@ the same interface without touching the tools.
   mock-provider end-to-end `TestAgentCodeToolsSSE` that scripts `code_search` → `code_read` →
   final answer and asserts the SSE `step` → `observation` → `message` sequence — deterministic,
   **no API key**.
+
+**Status (2026-06-18): implemented.** (Loop wiring landed with C/D; verification noted there.)
+- The system prompt is now authored as markdown in `daisen2/internal/httpapi/prompts/agent_system.md`
+  and **embedded via `//go:embed`** (`prompt.go`), replacing the hardcoded Go `const` — so the
+  prompt can use real markdown (code spans, lists) and is edited without touching Go. The Go
+  raw-string `const` couldn't even contain backticks.
+- It documents all five tools (`data_query`, `code_search`, `code_read`, `screenshot_current_view`,
+  `daisen_view`), the front door, the **"read the source before guessing"** rule, the source map
+  (paths are module-prefixed, e.g. `github.com/sarchlab/akita/v5/mem/cache/…`), the seed bottleneck
+  catalog, and an **evidence policy**: when proving a hypothesis, *attempt* to corroborate it from
+  all three sources (trace data + source code + a visualization), proceeding honestly and naming the
+  missing leg when one isn't available (e.g. no recorded source). Per-trace availability is
+  tool-reported (no runtime prompt templating), per the §8 decision.
+- Verified: `TestAgentSystemPromptEmbedded` (embed wired; all five tools documented); the existing
+  agent SSE tests now run against the embedded prompt; `go build ./...`, `daisen2/internal/httpapi`
+  suite, gofmt, vet green.
 
 ### (Optional) skills
 

--- a/daisen2/docs/daisenbot-agent-plan.md
+++ b/daisen2/docs/daisenbot-agent-plan.md
@@ -1,6 +1,6 @@
 # DaisenBot Agentic Upgrade — Design & Implementation Plan
 
-**Status:** Phase 1 merged (#387) · Phase 2 in progress (agent loop + `data_query`, §7) · **Last updated:** 2026-06-15
+**Status:** Phases 1–2 merged (#387, #392) · Phase 5 (viz perception) merged with #392 · **Phase 3 in progress — Workstream A (source recording) implemented; query tools (B–E) pending — §8** · **Last updated:** 2026-06-17
 
 This document captures the design decisions and phased plan for turning DaisenBot
 from a single-shot Q&A proxy into a tool-using agent that can *investigate* an
@@ -72,7 +72,7 @@ a fallback.
 | Tool | Executes in | Returns | Guardrails |
 |---|---|---|---|
 | `data_query(sql, limit)` | backend (read-only SQLite) | capped rows / counts / stats | SELECT-only · forced `LIMIT` · row+byte cap · statement timeout · block `ATTACH`/`PRAGMA`/writes |
-| `code_search` / `code_read` | backend | Akita source text | scoped to the akita repo · version-matched to the trace's commit if recorded · reuses the existing SSRF-guarded fetch |
+| `code_search` / `code_read` | backend | Akita (+ opt-in sim) source text | reads source **recorded into the trace** (akita by default; component author opts in) · read-only `fs.FS` · result byte/line/match caps · see §8 |
 | `run_python(code)` | backend sandbox | stdout summary (+ emitted artifacts) | isolated runtime · read-only trace handle · library allowlist · no network · CPU/mem/wall limits |
 | `daisen_view(url)` | **frontend** (off-screen) | rendered PNG observation + user-facing link | URL validated/normalized against the view schema · render-ready gate before capture |
 
@@ -266,7 +266,7 @@ detailed in §6.
 |---|---|---|---|
 | **1** | View-URL contract + render-ready signal | Make every view losslessly reconstructable from its URL, and expose a programmatic "view is fully rendered" signal. Renderer-agnostic; independently useful as better link-sharing. | — |
 | **2** | Agent-loop skeleton + tool-calling + `data` tool | Turn `httpChatProxy` into a streamed multi-step tool-calling loop; land the guarded read-only `data_query`; add capability-gating with single-shot fallback. Includes the front door + Orient→Hypothesize→Test loop (§4) and a first failure-mode catalog. A working "agent that can query the trace" — the biggest single value jump. | — |
-| **3** | `code` tool | `code_search` + `code_read` over Akita source so the agent can interpret Kinds/milestones. | 2 |
+| **3** | `code` tool | `code_search` + `code_read` over source **recorded into the trace** (akita by default; component author opts in) so the agent can interpret Kinds/milestones. Detailed in §8. | 2 |
 | **4** | Python sandbox tool | Sandboxed `run_python` for summarizing data without shipping raw rows. Isolated as its own phase for the runtime/isolation decision. | 2 |
 | **5** | Viz-perception tool + visual tour | `daisen_view`: frontend off-screen render → image observation; clickable links + thumbnails. Extends gating to require a vision model. | 1, 2 |
 | **6** | Hardening | Loop bounds (max iters / wall-clock), cross-tool context budgeting/pagination, graceful-degradation matrix (model caps × installed runtimes), answer-quality eval harness. | 2–5 |
@@ -368,7 +368,7 @@ All single-value params; the existing names (`name`, `taskid`, `starttime`,
    agent's natural single-chart perception unit for `daisen_view` (§3.2), and it is
    also user-shareable. A per-widget "focus" affordance sets the param. ✅
 
-This **resolves open questions #1, #3, and #5** (see §8).
+This **resolves open questions #1, #3, and #5** (see §9).
 
 ### Workstream B — Canonical URL schema (the contract)
 
@@ -516,7 +516,7 @@ failure-mode catalog, multi-agent, the off-screen capture.
   statement, injected/clamped `LIMIT`, per-query timeout, and a byte cap on the
   serialized result.
 - Execute via `traceReader.QueryContext`; format as compact rows + a row-count /
-  truncation note. (Review note §8: returns *capped* rows — bulk summarization is the
+  truncation note. (Review note §9: returns *capped* rows — bulk summarization is the
   Phase 4 Python tool; the guarantee here is "no *bulk* raw data".)
 
 ### Workstream C — Endpoint + SSE streaming
@@ -563,7 +563,162 @@ failure-mode catalog, multi-agent, the off-screen capture.
 
 ---
 
-## 8. Open questions / to audit
+## 8. Phase 3 — detailed
+
+**Goal:** give the agent `code_search` + `code_read` over the Akita (and, opt-in, the
+downstream simulator's) source, so it can interpret what a `Kind`, `milestone`, `What`
+type, or component actually *means* in the simulator — turning opaque trace labels into
+architecturally-grounded explanations instead of guesses. Outcome: *"an agent that can
+read the code that produced the trace."*
+
+**Builds on:** the Phase 2 agent-loop / tool-dispatch seam (`agentloop.go`; a tool is just
+an `agentTool` entry in the `runAgentSSE` tool slice, dispatched by `runToolCalls`) and the
+`datarecording` writer (`CreateTable`/`InsertData`/`Flush`) that already records `exec_info`
+(`simulation/meta_recorder.go`).
+
+**Non-goals (Phase 3):** the Python sandbox (Phase 4); symbol-level / semantic indexing
+(`go/packages`) — plain regex search is v1; remote source fetch from GitHub.
+
+### Source provenance — the key decision (accepted 2026-06-17)
+
+daisen2 is **offline replay** (`daisen2 -sqlite <file>`, `cmd/daisen2/main.go`): by the time
+it runs, the simulator process has exited, so a `//go:embed` *in the sim binary* is
+unreachable. Also `//go:embed` only reaches a package's own subtree, and `daisen2/` is a
+*sibling* of `mem/`, `tracing/`, `noc/`, … so daisen2 cannot embed akita's source directly
+either. Therefore the source must **travel in the trace**: it is recorded at generation time
+and read back by daisen2.
+
+- **akita's own source — recorded by default, read from disk at record time.** The recorder
+  locates akita's source on disk (the Go module cache, a `replace` path, or the working tree
+  when akita is the main module) via the compiled-in path of an akita source file, and writes
+  it into the trace automatically; the library user does nothing. **Disk-read is the default
+  because Daisen's user iterates on a concrete simulator** — edit, rebuild, run — and Go
+  requires a rebuild to run changed code, so the source on disk *is* what the binary was built
+  from. No generated/embedded artifact to regenerate, and the recorded source always matches
+  the run.
+- **The component author's source — recommended, opt-in.** A simulator built on akita registers
+  its own tree with `sim.WithSourceFS(root, fsys)` (typically a `//go:embed`); the recorder
+  folds it into the same source table. **Documented as a recommendation in the tutorial and
+  component-authoring docs** so authors opt in. If they don't, DaisenBot has akita-only source
+  and *says so* for unknown components (graceful degradation, per §3.4) — it never fabricates.
+- **Transport:** source lives **in the SQLite trace** (gzipped-tar per root, base64 in a row),
+  one self-contained artifact per simulation, so it can never get separated from the trace.
+- **Degradation:** when akita source is *not* on disk — a `-trimpath` build, or a prebuilt
+  binary moved to a source-less machine — the recorder records nothing for akita (no guessing);
+  daisen2 then reports no source and the agent says so. The iterative local developer (plain
+  `go build`/`go run`/`go test`) always has it.
+
+This **supersedes** the §3.2 sketch ("scoped to the akita repo · version-matched to the
+trace's commit · SSRF-guarded remote fetch"). `code_search` / `code_read` operate over a
+`codeSource` `fs.FS` materialized from the recorded source; the tool surface is identical
+regardless of provenance, so a future live/in-process mode or `--code-root` override can feed
+the same interface without touching the tools.
+
+### Workstream A — disk source locator + recorder
+
+- `sourcefs` locates akita's source on disk from the compiled-in path of its own file
+  (`runtime.Caller` → walk up to the `go.mod` declaring the akita module), so it resolves akita
+  as a module-cache dependency, a `replace` target, or the main module. It also serializes a
+  directory or an `fs.FS` to a gzip-tar (non-test `.go` + `go.mod`, pruning
+  `.git`/`.claude`/`vendor`/`node_modules`/`testdata`/`dist`).
+- The simulation recorder writes a `source` table, akita-source by default (from disk);
+  `sim.WithSourceFS(root, fsys)` adds author roots. Reuses `datarecording`
+  (`CreateTable`/`InsertData`/`Flush`). `WithoutSourceRecording()` opts out.
+
+**Status (2026-06-18): implemented (disk-based).**
+- `sourcefs` package: `AkitaSourceDir()` (disk locator), `ArchiveDir`/`ArchiveFS` +
+  `WriteArchive`/`ReadArchive` (the gzip-tar format, shared with daisen2's future reader). No
+  `//go:embed`, no generated blob, no `go generate` — so nothing to keep in sync.
+- `simulation` records a `source(Root, Format, Content)` table — one row per source root.
+  `Content` is **base64(gzip-tar)** stored as TEXT: the data recorder accepts only scalar
+  struct fields (`isAllowedType` rejects `[]byte`), so no BLOB column is available (~+33% over
+  raw gzip; a later `datarecording` BLOB column could drop it).
+- Builder: `WithSourceFS(root, fs)` adds author roots (opt-in), `WithoutSourceRecording()`
+  opts out. Recording is **gated on `WithVisTracingOnStart`** so only traces meant for DaisenBot
+  carry source; untraced sim DBs stay minimal.
+- Verified: a traced virtualmem run records akita source from disk (1.31 MB → ~1.61 MB,
+  **+~292 KB**); the row base64-decodes → gunzips → untars to real source (268 files incl.
+  `mem/mshr/mshr.go`, `tracing/tracer.go`), and the sim binary carries **no** embedded blob.
+  Unit tests: archive round-trip/determinism, `ArchiveFS`, `AkitaSourceDir`, `ArchiveDir`
+  filtering; `recordSourceArchives` akita-from-disk + author rows. `simulation` +
+  `datarecording` suites green.
+- **Next (Workstream B):** daisen2 reads the `source` table into a `codeSource` `fs.FS` (reusing
+  `sourcefs.ReadArchive`).
+
+### Workstream B — daisen2 reads source from the trace
+
+- On load, daisen2 reads the recorded source blob from the SQLite trace and exposes it as an
+  in-memory **read-only** `fs.FS` (`codeSource`). Absent ⇒ empty `codeSource` with a clear
+  "no source recorded for this trace" capability note surfaced to the agent (and the tools are
+  still offered but report the gap rather than erroring).
+
+### Workstream C — `code_search` (regex content search)
+
+- In-Go regex (RE2, `regexp`) content search over `codeSource`: returns capped `path:line` +
+  surrounding-context matches; optional `path_glob` to scope; **required `reason`** (same
+  pattern as `data_query`, surfaced in the step trail). Caps on files scanned / matches
+  returned / total bytes / per-match context lines, with an explicit truncation note. No
+  external `rg` dependency.
+
+### Workstream D — `code_read` (windowed file read)
+
+- Read a file by FS-relative path, optional `[start_line, end_line]`, returns numbered lines;
+  **required `reason`**. A large file with no range ⇒ first window + a "request a range" note.
+  Per-read byte/line cap. Path is normalized (reject `..` / absolute); with the in-DB/read-only
+  FS, traversal escape is structurally impossible (no symlinks, no parent dirs).
+
+### Workstream E — system prompt, loop wiring & verification
+
+- **Wiring (trivial):** register `codeSearchTool(src)` / `codeReadTool(src)` in the
+  `runAgentSSE` tool slice. They return text-only `toolResult`s; `runToolCalls` and the SSE
+  `step`/`observation` events already handle arbitrary tools, so the visible trail renders for
+  free. **No frontend changes** (unlike `daisen_view`).
+- **System prompt:** document the two tools and *when* to use them ("when a Kind / milestone /
+  `What` type / component is unfamiliar, read the source to ground the interpretation before
+  explaining it — do not guess"), plus a short **source map** (akita:
+  `mem/{cache,dram,mshr,rob,vm}`, `noc/`, `messaging/`, `queueing/`, `tracing/`, `simulation/`)
+  so searches are targeted. Tie back to the bottleneck catalog (§4.4): confirm a hypothesized
+  mechanism by reading the component's source.
+- **Verification** (mirrors `agentloop_test.go`): guard/cap units (path normalization, byte/
+  line/match caps, regex over a fixture FS); real-source integration (`code_search` finds
+  `type ReadReq`; `code_read` returns its definition) over a seeded source blob; and a
+  mock-provider end-to-end `TestAgentCodeToolsSSE` that scripts `code_search` → `code_read` →
+  final answer and asserts the SSE `step` → `observation` → `message` sequence — deterministic,
+  **no API key**.
+
+### (Optional) skills
+
+Once `code_read` exists over an `fs.FS`, a minimal **skills** feature (the §7-D successor to
+the hardcoded prompt) is nearly free: embed `daisen2/skills/*.md` playbooks the agent can read,
+or add a thin `list_skills` / `read_skill` pair (literally `code_*` pointed at a `skills/`
+dir). Land it after the code tools if there is appetite; not required for Phase 3.
+
+### Decisions (accepted 2026-06-17)
+
+1. **Source travels in the trace**, recorded at generation time — daisen2 is replay-only and
+   `//go:embed` can reach neither the sim binary nor akita's sibling dirs. ✅
+2. **akita source recorded by default; component-author source recommended + opt-in**, and
+   documented in the tutorial/component docs. Graceful degradation when the author's source is
+   absent — never fabricate. ✅
+3. **In-DB**, stored in the trace (gzip-tar per root), not a sidecar — one self-contained
+   artifact per simulation. ✅
+4. **akita source read from disk at record time** (module cache / `replace` / working tree),
+   *not* an embedded blob. Chosen over embedding because Daisen's user iterates on a concrete
+   simulator: disk-read always matches the rebuilt binary and has no artifact to regenerate.
+   Trade-off: a `-trimpath` build or a binary moved off the build machine has no source on
+   disk → record nothing for akita (graceful). ✅ *(supersedes the earlier embed/`go generate`
+   approach)*
+5. v1 search is **plain regex**, not a `go/packages` symbol index. ✅
+6. **Stored as base64 TEXT**, not a BLOB — the data recorder accepts scalar struct fields only,
+   so the gzip-tar is base64-wrapped (~+33%; akita ≈242 KB gz → ≈322 KB base64). Native BLOB
+   support in `datarecording` is a possible later cleanup to drop the overhead. ✅
+7. **Recorded only for traced sims** (gated on `WithVisTracingOnStart`); the trace is the
+   consumer, so untraced sim DBs stay minimal. `WithoutSourceRecording()` opts out;
+   `WithSourceFS(root, fs)` adds author roots. ✅
+
+---
+
+## 9. Open questions / to audit
 
 1. ~~**Multi-select / large selections**~~ — **Resolved (Workstream A):** no
    multi-selection exists in any page; single-value params suffice. Revisit only if
@@ -613,7 +768,7 @@ failure-mode catalog, multi-agent, the off-screen capture.
 
 ---
 
-## 9. Non-goals
+## 10. Non-goals
 
 - No headless/server-side rendering (Chromium) — the live frontend is the renderer.
 - No bespoke charting (matplotlib/plotly) for agent perception — Daisen renders.
@@ -641,3 +796,8 @@ failure-mode catalog, multi-agent, the off-screen capture.
 | Evidence is hypothesis-driven, vital-signs-first, budgeted (§4.5) | Minimizes tokens/latency and keeps raw data off the LLM wire. |
 | Canonical dashboard route `/dashboard` (redirect `/`) | One canonical URL per view; required for shareable links and deterministic agent rendering. |
 | Single-widget URL mode `/dashboard?widget=<component>` | A single focused chart is the agent's natural perception unit for `daisen_view`; also user-shareable. |
+| Phase 3 source travels *in the trace*, recorded at generation time | daisen2 is offline-replay, so a sim-binary `//go:embed` is unreachable, and `//go:embed` can't cross sibling dirs (`daisen2/` ↔ `mem/`). Recording into the trace is self-contained and version-matched by construction. |
+| akita source recorded by default; component-author source recommended + opt-in (documented) | akita-level components are always interpretable; authors opt in for custom components, with graceful degradation (and no fabrication) when absent. |
+| Source stored in-DB as one gzipped blob, not a sidecar | One self-contained artifact per simulation; the source can't get separated from the trace. |
+| akita source read from disk at record time (not embedded) | Daisen's user iterates on a concrete simulator (edit→rebuild→run); disk-read always matches the rebuilt binary and needs no regenerated/embedded artifact. Degrades gracefully (records nothing) under `-trimpath` or a moved binary. Supersedes the embed/`go generate` approach. |
+| v1 `code` search is plain regex, not a symbol index | Regex over recorded source is simple and dependency-free; `go/packages` indexing needs the code to compile and adds build deps — deferred. |

--- a/daisen2/docs/daisenbot-agent-plan.md
+++ b/daisen2/docs/daisenbot-agent-plan.md
@@ -1,6 +1,6 @@
 # DaisenBot Agentic Upgrade — Design & Implementation Plan
 
-**Status:** Phases 1–2 merged (#387, #392) · Phase 5 (viz perception) merged with #392 · **Phase 3 in progress — Workstream A (source recording) implemented; query tools (B–E) pending — §8** · **Last updated:** 2026-06-17
+**Status:** Phases 1–2 merged (#387, #392) · Phase 5 (viz perception) merged with #392 · **Phase 3 in progress — Workstreams A (source recording) + B (daisen2 source reader) implemented; tools C–E pending — §8** · **Last updated:** 2026-06-17
 
 This document captures the design decisions and phased plan for turning DaisenBot
 from a single-shot Q&A proxy into a tool-using agent that can *investigate* an
@@ -651,6 +651,22 @@ the same interface without touching the tools.
   in-memory **read-only** `fs.FS` (`codeSource`). Absent ⇒ empty `codeSource` with a clear
   "no source recorded for this trace" capability note surfaced to the agent (and the tools are
   still offered but report the gap rather than erroring).
+
+**Status (2026-06-18): implemented.**
+- `sourcefs.OpenTraceSource(db *sql.DB) (*Source, error)` reads the `source` table, base64-decodes
+  + un-tars each root via `ReadArchive`, and returns a read-only `fs.FS` (paths `<root>/<file>`)
+  plus `Roots` / `Files`. A missing/empty `source` table is **not** an error — it returns an empty
+  `Source` — so pre-Phase-3 traces load fine. (`database/sql`-only, so it's reusable outside
+  daisen2.)
+- daisen2 `Server` loads it once on startup (`loadCodeSource`) into `s.codeSource` and exposes
+  `CodeSource()` for the tools. Startup logs coverage, e.g.
+  `DaisenBot: recorded source available — 268 files across [github.com/sarchlab/akita/v5]`, or
+  `no source recorded in this trace`.
+- Verified: `OpenTraceSource` unit tests (populated table + reads a file back; missing table →
+  empty); running daisen2 against the recorded virtualmem trace logs the 268-file coverage.
+  `go build ./...`, `sourcefs` + `daisen2/internal/httpapi` suites, gofmt, vet all green.
+- **Next (Workstreams C/D):** `code_search` / `code_read` tools over `Server.CodeSource().FS()`,
+  registered in the `runAgentSSE` tool slice.
 
 ### Workstream C — `code_search` (regex content search)
 

--- a/daisen2/docs/daisenbot-agent-plan.md
+++ b/daisen2/docs/daisenbot-agent-plan.md
@@ -1,6 +1,6 @@
 # DaisenBot Agentic Upgrade — Design & Implementation Plan
 
-**Status:** Phases 1–2 merged (#387, #392) · Phase 5 (viz perception) merged with #392 · **Phase 3 in progress — Workstreams A (source recording) + B (daisen2 source reader) implemented; tools C–E pending — §8** · **Last updated:** 2026-06-17
+**Status:** Phases 1–2 merged (#387, #392) · Phase 5 (viz perception) merged with #392 · **Phase 3 in progress — Workstreams A (source recording), B (daisen2 reader), C/D (`code_search`/`code_read` tools) implemented; E (system-prompt update) pending — §8** · **Last updated:** 2026-06-17
 
 This document captures the design decisions and phased plan for turning DaisenBot
 from a single-shot Q&A proxy into a tool-using agent that can *investigate* an
@@ -682,6 +682,24 @@ the same interface without touching the tools.
   **required `reason`**. A large file with no range ⇒ first window + a "request a range" note.
   Per-read byte/line cap. Path is normalized (reject `..` / absolute); with the in-DB/read-only
   FS, traversal escape is structurally impossible (no symlinks, no parent dirs).
+
+**Status (2026-06-18): C + D implemented.**
+- `daisen2/internal/httpapi/codetools.go`: `code_search` (RE2 regex over
+  `Server.CodeSource().FS()`, optional `path_contains` substring filter, capped matches/bytes/
+  line-length with a truncation note) and `code_read` (FS-relative path, optional
+  `start_line`/`end_line`, numbered lines, default window + "more lines" note, per-read
+  line/byte caps, `fs.ValidPath` guard). Both require `reason`; an empty `codeSource` returns a
+  "no source recorded" observation rather than erroring. Registered in the `runAgentSSE` tool
+  slice — no frontend changes (the SSE step trail already renders arbitrary tools).
+- Added `sourcefs.NewSource(fsys, roots)` so the tools — and a future on-disk `--code-root`
+  override — build over any `fs.FS`.
+- Note: `path_contains` (substring) replaces the planned `path_glob`; `path.Match` can't span
+  `/`, so it's useless on deep module paths. Search returns match lines only; the agent uses
+  `code_read` for surrounding context (the natural search→read flow).
+- Verified: unit tests (search match / filter / no-match / invalid-regex / caps / empty; read
+  window / range / not-found / traversal-reject / long-file) and an end-to-end mock-provider SSE
+  test driving `code_search → code_read → answer`. `daisen2/internal/httpapi`, `sourcefs`,
+  `simulation` suites + `go build ./...` + vet green.
 
 ### Workstream E — system prompt, loop wiring & verification
 

--- a/daisen2/internal/httpapi/agentloop.go
+++ b/daisen2/internal/httpapi/agentloop.go
@@ -592,6 +592,8 @@ func (s *Server) runAgentSSE(
 	capture := s.newCaptureRequester(emit)
 	tools := []agentTool{
 		dataQueryTool(s.traceReader),
+		codeSearchTool(s.codeSource),
+		codeReadTool(s.codeSource),
 		daisenViewTool(capture),
 		screenshotTool(capture),
 	}

--- a/daisen2/internal/httpapi/agentloop.go
+++ b/daisen2/internal/httpapi/agentloop.go
@@ -514,41 +514,13 @@ func rawCellToString(v interface{}) string {
 	}
 }
 
-// ---- Agent system prompt & message assembly ----
-
-const agentSystemPrompt = `You are DaisenBot, an assistant that investigates Akita
-computer-architecture simulation traces.
-
-You can call the data_query tool to run read-only SQL over the trace. Use it to gather evidence
-before answering questions about behavior, bottlenecks, or specific tasks. Every data_query call
-must include a one-sentence "reason" describing what you are checking — it is shown to the user
-as your reasoning, so make it clear.
-
-You do NOT have the trace rows in your context. For any question about the trace's contents,
-timings, counts, or behavior, you MUST gather the facts with data_query first — do not answer
-such questions from memory or assumption, and never invent task IDs, durations, or counts. Run
-at least one query before making a quantitative claim.
-
-You can also SEE Daisen's visualizations:
-- screenshot_current_view: capture what the user is currently looking at on screen, and look at it.
-- daisen_view: render a specific Daisen view off-screen by its URL and look at it. URL scheme:
-"/dashboard?widget=<component>&starttime=<t>&endtime=<t>&primary=<metric>&secondary=<metric>";
-"/component?name=<component>&taskid=<id>&starttime=<t>&endtime=<t>";
-"/task?id=<taskid>&where=<component>&kind=<kind>". Times are raw trace values.
-Use these when a question is about visual patterns (timelines, bursts, periodicity, occupancy
-shapes) that are easier to see than to query. Both take a one-sentence "reason".
-
-Front door:
-- If a question is a simple definition or can be answered from the provided context, answer directly without tools.
-- If a question is ambiguous (e.g. which component, which time range), ask ONE concise clarifying question.
-- Otherwise, investigate: form a hypothesis, run targeted data_query calls to confirm or refute it,
-then answer with the evidence (cite the numbers you found). Prefer aggregates over dumping rows.
-
-Common Akita bottleneck patterns to consider (seed list — not exhaustive): cache miss/thrashing,
-queue backpressure / buffer-full stalls, limited outstanding requests (MSHRs), DRAM bank conflicts,
-bandwidth saturation, head-of-line blocking, and address-translation (TLB) stalls.
-
-Be concise and concrete. When you are uncertain, say so and report what you ruled out.`
+// ---- Agent message assembly ----
+//
+// The agent system prompt is authored as markdown in prompts/agent_system.md and
+// embedded via //go:embed (see prompt.go) so it can use real markdown (code spans,
+// lists) and be edited without touching Go. It documents the data_query, code_search,
+// code_read, screenshot_current_view, and daisen_view tools, the front door, the
+// evidence policy, and the seed bottleneck catalog.
 
 // assembleAgentMessages builds the message list for an agent-mode request: just
 // the agent system prompt followed by the user's conversation, verbatim. Nothing

--- a/daisen2/internal/httpapi/codetools.go
+++ b/daisen2/internal/httpapi/codetools.go
@@ -1,0 +1,299 @@
+package httpapi
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"path"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/sarchlab/akita/v5/sourcefs"
+)
+
+// Code tools (DaisenBot Phase 3, Workstreams C/D): code_search and code_read let
+// the agent read the simulator source recorded in the trace (Workstream B's
+// codeSource) so it can interpret Kinds, milestones, types, and components
+// instead of guessing. Both are guarded with caps so a search or read can never
+// flood the model context, mirroring data_query.
+
+const (
+	codeSearchMaxMatches   = 60
+	codeSearchMaxBytes     = 16 << 10
+	codeSearchMaxLineBytes = 300
+
+	codeReadDefaultLines = 200
+	codeReadMaxLines     = 400
+	codeReadMaxBytes     = 24 << 10
+)
+
+const noSourceRecorded = "No simulator source is recorded in this trace, so code " +
+	"cannot be searched or read. Answer from general knowledge and say you could " +
+	"not consult the source for this trace."
+
+func codeSearchTool(src *sourcefs.Source) agentTool {
+	return agentTool{
+		name: "code_search",
+		description: "Search the simulator source recorded in this trace (Go RE2 regular " +
+			"expression, matched per line) to find where a Kind, milestone, type (e.g. " +
+			"*mem.ReadReq), or component is defined or used. Returns matching file:line " +
+			"locations; read around a match with code_read. Use this to ground what a trace " +
+			"label means before explaining it.",
+		parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"reason": map[string]interface{}{
+					"type":        "string",
+					"description": "One sentence: what you are looking for and why. Shown to the user.",
+				},
+				"query": map[string]interface{}{
+					"type":        "string",
+					"description": "A Go (RE2) regular expression to match against source lines.",
+				},
+				"path_contains": map[string]interface{}{
+					"type": "string",
+					"description": "Optional: only search files whose path contains this substring " +
+						"(e.g. \"mem/cache\" or \"dram\").",
+				},
+			},
+			"required": []string{"reason", "query"},
+		},
+		run: func(_ context.Context, args map[string]interface{}) (toolResult, error) {
+			query, _ := args["query"].(string)
+			filter, _ := args["path_contains"].(string)
+			out, err := runCodeSearch(src, query, filter)
+			return toolResult{text: out}, err
+		},
+	}
+}
+
+func runCodeSearch(src *sourcefs.Source, query, filter string) (string, error) {
+	if src.IsEmpty() {
+		return noSourceRecorded, nil
+	}
+	if strings.TrimSpace(query) == "" {
+		return "", fmt.Errorf("a query is required")
+	}
+	re, err := regexp.Compile(query)
+	if err != nil {
+		return "", fmt.Errorf("invalid regular expression: %w", err)
+	}
+
+	fsys := src.FS()
+	paths := sortedFilePaths(fsys)
+
+	var body strings.Builder
+	matches := 0
+	truncated := false
+
+	for _, p := range paths {
+		if filter != "" && !strings.Contains(p, filter) {
+			continue
+		}
+		data, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			continue
+		}
+
+		scanner := bufio.NewScanner(bytes.NewReader(data))
+		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		lineNo := 0
+		for scanner.Scan() {
+			lineNo++
+			line := scanner.Text()
+			if !re.MatchString(line) {
+				continue
+			}
+			if matches >= codeSearchMaxMatches {
+				truncated = true
+				break
+			}
+			entry := fmt.Sprintf("%s:%d: %s\n", p, lineNo, clipLine(strings.TrimSpace(line)))
+			if body.Len()+len(entry) > codeSearchMaxBytes {
+				truncated = true
+				break
+			}
+			body.WriteString(entry)
+			matches++
+		}
+		if truncated {
+			break
+		}
+	}
+
+	if matches == 0 {
+		scope := ""
+		if filter != "" {
+			scope = fmt.Sprintf(" in paths containing %q", filter)
+		}
+		return fmt.Sprintf("No matches for %q%s.", query, scope), nil
+	}
+
+	header := fmt.Sprintf("%d match(es):\n", matches)
+	footer := ""
+	if truncated {
+		footer = "[truncated — refine the query or pass path_contains]\n"
+	}
+	return header + body.String() + footer, nil
+}
+
+func codeReadTool(src *sourcefs.Source) agentTool {
+	return agentTool{
+		name: "code_read",
+		description: "Read a file (or a line range) from the simulator source recorded in this " +
+			"trace. Paths look like \"github.com/sarchlab/akita/v5/mem/mshr/mshr.go\" (as shown " +
+			"by code_search). Use after code_search to study the logic around a match.",
+		parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"reason": map[string]interface{}{
+					"type":        "string",
+					"description": "One sentence: what you want to read and why. Shown to the user.",
+				},
+				"path": map[string]interface{}{
+					"type":        "string",
+					"description": "FS-relative path as shown by code_search.",
+				},
+				"start_line": map[string]interface{}{
+					"type":        "integer",
+					"description": "Optional 1-based first line to read.",
+				},
+				"end_line": map[string]interface{}{
+					"type":        "integer",
+					"description": "Optional 1-based last line to read (inclusive).",
+				},
+			},
+			"required": []string{"reason", "path"},
+		},
+		run: func(_ context.Context, args map[string]interface{}) (toolResult, error) {
+			p, _ := args["path"].(string)
+			out, err := runCodeRead(src, p, intArg(args["start_line"]), intArg(args["end_line"]))
+			return toolResult{text: out}, err
+		},
+	}
+}
+
+func runCodeRead(src *sourcefs.Source, p string, start, end int) (string, error) {
+	if src.IsEmpty() {
+		return noSourceRecorded, nil
+	}
+	clean, err := normalizeReadPath(p)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := fs.ReadFile(src.FS(), clean)
+	if err != nil {
+		return fmt.Sprintf("File not found: %q. Use code_search to find the right path "+
+			"(recorded roots: %v).", p, src.Roots), nil
+	}
+
+	lines := splitLines(data)
+	total := len(lines)
+	ranged := start > 0 || end > 0
+
+	from, to := 1, total
+	if start > 0 {
+		from = start
+	}
+	if end > 0 {
+		to = end
+	} else if !ranged && total > codeReadDefaultLines {
+		to = codeReadDefaultLines
+	}
+
+	if total == 0 {
+		return fmt.Sprintf("%s is empty (0 lines).", clean), nil
+	}
+	from = max(from, 1)
+	to = min(to, total)
+	if from > total {
+		return fmt.Sprintf("%s has %d lines; start_line %d is past the end.", clean, total, start), nil
+	}
+	if to < from {
+		to = from
+	}
+	if to-from+1 > codeReadMaxLines {
+		to = min(from+codeReadMaxLines-1, total)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (lines %d-%d of %d):\n", clean, from, to, total)
+	width := len(strconv.Itoa(to))
+	truncated := false
+	for i := from; i <= to; i++ {
+		row := fmt.Sprintf("%*d\t%s\n", width, i, lines[i-1])
+		if b.Len()+len(row) > codeReadMaxBytes {
+			truncated = true
+			break
+		}
+		b.WriteString(row)
+	}
+
+	switch {
+	case truncated:
+		b.WriteString("[output truncated — narrow the line range]\n")
+	case to < total:
+		fmt.Fprintf(&b, "[%d more lines; pass start_line/end_line to read further]\n", total-to)
+	}
+	return b.String(), nil
+}
+
+func sortedFilePaths(fsys fs.FS) []string {
+	var paths []string
+	_ = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		paths = append(paths, p)
+		return nil
+	})
+	sort.Strings(paths)
+	return paths
+}
+
+func normalizeReadPath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	p = strings.TrimPrefix(p, "./")
+	if p == "" {
+		return "", fmt.Errorf("a path is required")
+	}
+	clean := path.Clean(p)
+	if !fs.ValidPath(clean) {
+		return "", fmt.Errorf("invalid path %q", p)
+	}
+	return clean, nil
+}
+
+func splitLines(data []byte) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	lines := strings.Split(string(data), "\n")
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1] // drop the empty element after a trailing newline
+	}
+	return lines
+}
+
+func clipLine(s string) string {
+	if len(s) > codeSearchMaxLineBytes {
+		return s[:codeSearchMaxLineBytes] + "…"
+	}
+	return s
+}
+
+func intArg(v interface{}) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	default:
+		return 0
+	}
+}

--- a/daisen2/internal/httpapi/codetools.go
+++ b/daisen2/internal/httpapi/codetools.go
@@ -84,13 +84,10 @@ func runCodeSearch(src *sourcefs.Source, query, filter string) (string, error) {
 	}
 
 	fsys := src.FS()
-	paths := sortedFilePaths(fsys)
-
 	var body strings.Builder
 	matches := 0
 	truncated := false
-
-	for _, p := range paths {
+	for _, p := range sortedFilePaths(fsys) {
 		if filter != "" && !strings.Contains(p, filter) {
 			continue
 		}
@@ -98,47 +95,55 @@ func runCodeSearch(src *sourcefs.Source, query, filter string) (string, error) {
 		if err != nil {
 			continue
 		}
-
-		scanner := bufio.NewScanner(bytes.NewReader(data))
-		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
-		lineNo := 0
-		for scanner.Scan() {
-			lineNo++
-			line := scanner.Text()
-			if !re.MatchString(line) {
-				continue
-			}
-			if matches >= codeSearchMaxMatches {
-				truncated = true
-				break
-			}
-			entry := fmt.Sprintf("%s:%d: %s\n", p, lineNo, clipLine(strings.TrimSpace(line)))
-			if body.Len()+len(entry) > codeSearchMaxBytes {
-				truncated = true
-				break
-			}
-			body.WriteString(entry)
-			matches++
-		}
-		if truncated {
+		if appendFileMatches(re, p, data, &body, &matches) {
+			truncated = true
 			break
 		}
 	}
+	return formatSearchResult(query, filter, body.String(), matches, truncated), nil
+}
 
+// appendFileMatches appends "path:line: snippet" for each regex match in data, up
+// to the match and byte caps. It returns true if a cap was hit (so the caller
+// stops searching further files).
+func appendFileMatches(
+	re *regexp.Regexp, p string, data []byte, body *strings.Builder, matches *int,
+) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := scanner.Text()
+		if !re.MatchString(line) {
+			continue
+		}
+		if *matches >= codeSearchMaxMatches {
+			return true
+		}
+		entry := fmt.Sprintf("%s:%d: %s\n", p, lineNo, clipLine(strings.TrimSpace(line)))
+		if body.Len()+len(entry) > codeSearchMaxBytes {
+			return true
+		}
+		body.WriteString(entry)
+		*matches++
+	}
+	return false
+}
+
+func formatSearchResult(query, filter, body string, matches int, truncated bool) string {
 	if matches == 0 {
 		scope := ""
 		if filter != "" {
 			scope = fmt.Sprintf(" in paths containing %q", filter)
 		}
-		return fmt.Sprintf("No matches for %q%s.", query, scope), nil
+		return fmt.Sprintf("No matches for %q%s.", query, scope)
 	}
-
-	header := fmt.Sprintf("%d match(es):\n", matches)
-	footer := ""
+	out := fmt.Sprintf("%d match(es):\n%s", matches, body)
 	if truncated {
-		footer = "[truncated — refine the query or pass path_contains]\n"
+		out += "[truncated — refine the query or pass path_contains]\n"
 	}
-	return header + body.String() + footer, nil
+	return out
 }
 
 func codeReadTool(src *sourcefs.Source) agentTool {
@@ -193,10 +198,22 @@ func runCodeRead(src *sourcefs.Source, p string, start, end int) (string, error)
 	}
 
 	lines := splitLines(data)
-	total := len(lines)
-	ranged := start > 0 || end > 0
+	if len(lines) == 0 {
+		return fmt.Sprintf("%s is empty (0 lines).", clean), nil
+	}
+	from, to, msg := resolveReadWindow(clean, start, end, len(lines))
+	if msg != "" {
+		return msg, nil
+	}
+	return renderReadWindow(clean, lines, from, to), nil
+}
 
-	from, to := 1, total
+// resolveReadWindow computes the 1-based [from, to] line window to show, honoring
+// the requested range, the default window, and the max-lines cap. A non-empty msg
+// means return it instead (e.g. start_line past the end of the file).
+func resolveReadWindow(clean string, start, end, total int) (from, to int, msg string) {
+	from, to = 1, total
+	ranged := start > 0 || end > 0
 	if start > 0 {
 		from = start
 	}
@@ -206,13 +223,10 @@ func runCodeRead(src *sourcefs.Source, p string, start, end int) (string, error)
 		to = codeReadDefaultLines
 	}
 
-	if total == 0 {
-		return fmt.Sprintf("%s is empty (0 lines).", clean), nil
-	}
 	from = max(from, 1)
 	to = min(to, total)
 	if from > total {
-		return fmt.Sprintf("%s has %d lines; start_line %d is past the end.", clean, total, start), nil
+		return 0, 0, fmt.Sprintf("%s has %d lines; start_line %d is past the end.", clean, total, start)
 	}
 	if to < from {
 		to = from
@@ -220,7 +234,13 @@ func runCodeRead(src *sourcefs.Source, p string, start, end int) (string, error)
 	if to-from+1 > codeReadMaxLines {
 		to = min(from+codeReadMaxLines-1, total)
 	}
+	return from, to, ""
+}
 
+// renderReadWindow formats lines[from-1:to] with line numbers, bounded by the
+// per-read byte cap, with a footer noting truncation or remaining lines.
+func renderReadWindow(clean string, lines []string, from, to int) string {
+	total := len(lines)
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s (lines %d-%d of %d):\n", clean, from, to, total)
 	width := len(strconv.Itoa(to))
@@ -240,7 +260,7 @@ func runCodeRead(src *sourcefs.Source, p string, start, end int) (string, error)
 	case to < total:
 		fmt.Fprintf(&b, "[%d more lines; pass start_line/end_line to read further]\n", total-to)
 	}
-	return b.String(), nil
+	return b.String()
 }
 
 func sortedFilePaths(fsys fs.FS) []string {

--- a/daisen2/internal/httpapi/codetools_test.go
+++ b/daisen2/internal/httpapi/codetools_test.go
@@ -1,0 +1,202 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/sarchlab/akita/v5/sourcefs"
+)
+
+func testSource(t *testing.T, files map[string]string) *sourcefs.Source {
+	t.Helper()
+	mapFS := fstest.MapFS{}
+	for p, content := range files {
+		mapFS[p] = &fstest.MapFile{Data: []byte(content)}
+	}
+	src, err := sourcefs.NewSource(mapFS, []string{"example.com/m"})
+	if err != nil {
+		t.Fatalf("NewSource: %v", err)
+	}
+	return src
+}
+
+func TestCodeSearch(t *testing.T) {
+	src := testSource(t, map[string]string{
+		"example.com/m/mem/read.go":  "package mem\ntype ReadReq struct{}\n\nfunc handle() {}\n",
+		"example.com/m/mem/write.go": "package mem\ntype WriteReq struct{}\n",
+		"example.com/m/noc/conn.go":  "package noc\n// ReadReq is referenced here\n",
+	})
+
+	out, err := runCodeSearch(src, `ReadReq`, "")
+	if err != nil {
+		t.Fatalf("runCodeSearch: %v", err)
+	}
+	// Two files mention ReadReq; results are file:line.
+	if !strings.Contains(out, "example.com/m/mem/read.go:2:") {
+		t.Errorf("missing definition match:\n%s", out)
+	}
+	if !strings.Contains(out, "example.com/m/noc/conn.go:2:") {
+		t.Errorf("missing reference match:\n%s", out)
+	}
+
+	// path_contains narrows the search.
+	out, _ = runCodeSearch(src, `ReadReq`, "mem/")
+	if strings.Contains(out, "noc/conn.go") {
+		t.Errorf("path_contains=mem/ should exclude noc:\n%s", out)
+	}
+
+	// No match.
+	if out, _ := runCodeSearch(src, `DoesNotExist`, ""); !strings.Contains(out, "No matches") {
+		t.Errorf("expected no-match message, got:\n%s", out)
+	}
+
+	// Invalid regex is an error the model can recover from.
+	if _, err := runCodeSearch(src, `(unclosed`, ""); err == nil {
+		t.Errorf("expected error for invalid regex")
+	}
+}
+
+func TestCodeSearchCapsMatches(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("package big\n")
+	for i := 0; i < codeSearchMaxMatches+50; i++ {
+		sb.WriteString("// needle here\n")
+	}
+	src := testSource(t, map[string]string{"example.com/m/big.go": sb.String()})
+
+	out, err := runCodeSearch(src, "needle", "")
+	if err != nil {
+		t.Fatalf("runCodeSearch: %v", err)
+	}
+	if !strings.Contains(out, "truncated") {
+		t.Errorf("expected truncation note for a flood of matches:\n%s", out[:min(len(out), 400)])
+	}
+	if got := strings.Count(out, "needle here"); got > codeSearchMaxMatches {
+		t.Errorf("returned %d matches, want <= %d", got, codeSearchMaxMatches)
+	}
+}
+
+func TestCodeSearchEmptySource(t *testing.T) {
+	out, err := runCodeSearch(&sourcefs.Source{}, "anything", "")
+	if err != nil {
+		t.Fatalf("runCodeSearch: %v", err)
+	}
+	if !strings.Contains(out, "No simulator source is recorded") {
+		t.Errorf("expected no-source message, got:\n%s", out)
+	}
+}
+
+func TestCodeRead(t *testing.T) {
+	src := testSource(t, map[string]string{
+		"example.com/m/mem/read.go": "package mem\n\ntype ReadReq struct{}\n\nfunc handle() {}\n",
+	})
+
+	// Full small file is numbered.
+	out, err := runCodeRead(src, "example.com/m/mem/read.go", 0, 0)
+	if err != nil {
+		t.Fatalf("runCodeRead: %v", err)
+	}
+	if !strings.Contains(out, "1\tpackage mem") || !strings.Contains(out, "3\ttype ReadReq struct{}") {
+		t.Errorf("expected numbered lines:\n%s", out)
+	}
+	if !strings.Contains(out, "of 5):") {
+		t.Errorf("expected total-line count of 5:\n%s", out)
+	}
+
+	// Range selects a window.
+	out, _ = runCodeRead(src, "example.com/m/mem/read.go", 3, 3)
+	if !strings.Contains(out, "3\ttype ReadReq struct{}") || strings.Contains(out, "package mem") {
+		t.Errorf("range 3-3 should show only line 3:\n%s", out)
+	}
+
+	// Missing file is reported (not an error), with a hint.
+	out, _ = runCodeRead(src, "example.com/m/nope.go", 0, 0)
+	if !strings.Contains(out, "not found") {
+		t.Errorf("expected not-found message:\n%s", out)
+	}
+
+	// Invalid path is rejected.
+	if _, err := runCodeRead(src, "../escape", 0, 0); err == nil {
+		t.Errorf("expected error for traversal path")
+	}
+}
+
+func TestCodeReadDefaultWindowTruncates(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < codeReadDefaultLines+100; i++ {
+		sb.WriteString("line\n")
+	}
+	src := testSource(t, map[string]string{"example.com/m/long.go": sb.String()})
+
+	out, err := runCodeRead(src, "example.com/m/long.go", 0, 0)
+	if err != nil {
+		t.Fatalf("runCodeRead: %v", err)
+	}
+	if !strings.Contains(out, "more lines; pass start_line/end_line") {
+		t.Errorf("expected a 'more lines' note for a long file:\n%s", out[:min(len(out), 300)])
+	}
+}
+
+// TestHTTPChatProxyCodeToolsSSE drives the whole /api/gpt agent loop against a
+// mock provider that scripts code_search -> code_read -> answer over a seeded
+// codeSource, asserting the SSE step/observation/message sequence. No API key.
+func TestHTTPChatProxyCodeToolsSSE(t *testing.T) {
+	t.Setenv("DAISEN_ALLOW_PRIVATE_LLM_URL", "1")
+
+	src := testSource(t, map[string]string{
+		"example.com/m/mem/read.go": "package mem\ntype ReadReq struct{}\n",
+	})
+
+	calls := 0
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			io.WriteString(w, `{"choices":[{"message":{"role":"assistant","tool_calls":[`+
+				`{"id":"c1","type":"function","function":{"name":"code_search",`+
+				`"arguments":"{\"reason\":\"find ReadReq\",\"query\":\"ReadReq\"}"}}]}}]}`)
+		case 2:
+			io.WriteString(w, `{"choices":[{"message":{"role":"assistant","tool_calls":[`+
+				`{"id":"c2","type":"function","function":{"name":"code_read",`+
+				`"arguments":"{\"reason\":\"read it\",\"path\":\"example.com/m/mem/read.go\"}"}}]}}]}`)
+		default:
+			io.WriteString(w, `{"choices":[{"message":{"role":"assistant","content":`+
+				`"ReadReq is a memory read request type."}}]}`)
+		}
+	}))
+	defer llm.Close()
+
+	s := &Server{codeSource: src}
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"provider": "openai-compatible",
+		"baseURL":  llm.URL,
+		"model":    "mock",
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": []map[string]interface{}{{"type": "text", "text": "what is ReadReq?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/api/gpt", bytes.NewReader(reqBody))
+	rec := httptest.NewRecorder()
+
+	s.httpChatProxy(rec, req)
+
+	out := rec.Body.String()
+	for _, want := range []string{
+		`"type":"step"`, "code_search", "code_read",
+		"example.com/m/mem/read.go", "memory read request", `"type":"done"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("SSE stream missing %q\nstream:\n%s", want, out)
+		}
+	}
+}

--- a/daisen2/internal/httpapi/prompt.go
+++ b/daisen2/internal/httpapi/prompt.go
@@ -1,0 +1,12 @@
+package httpapi
+
+import _ "embed"
+
+// agentSystemPrompt is DaisenBot's system prompt. It is authored as markdown in
+// prompts/agent_system.md and embedded at build time, so editing the prompt — the
+// tool guidance, the front door, the source map, the bottleneck catalog — is a
+// markdown edit with no Go change. assembleAgentMessages prepends it as the system
+// message of every agent request.
+//
+//go:embed prompts/agent_system.md
+var agentSystemPrompt string

--- a/daisen2/internal/httpapi/prompt_test.go
+++ b/daisen2/internal/httpapi/prompt_test.go
@@ -1,0 +1,24 @@
+package httpapi
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAgentSystemPromptEmbedded(t *testing.T) {
+	if len(agentSystemPrompt) < 500 {
+		t.Fatalf("embedded agent system prompt looks too short (%d bytes) — //go:embed wiring broken?",
+			len(agentSystemPrompt))
+	}
+
+	// The prompt must document every tool the agent is offered so the model knows
+	// they exist and when to reach for them.
+	for _, want := range []string{
+		"DaisenBot", "data_query", "code_search", "code_read",
+		"daisen_view", "screenshot_current_view",
+	} {
+		if !strings.Contains(agentSystemPrompt, want) {
+			t.Errorf("system prompt does not mention %q", want)
+		}
+	}
+}

--- a/daisen2/internal/httpapi/prompts/agent_system.md
+++ b/daisen2/internal/httpapi/prompts/agent_system.md
@@ -1,0 +1,127 @@
+# DaisenBot
+
+You are **DaisenBot**, an assistant that investigates Akita computer-architecture
+simulation traces. You help users understand simulated hardware behavior —
+bottlenecks, latencies, utilization, the lifecycle of specific tasks — by gathering
+evidence from the trace and from the simulator's own source code, then explaining
+what you found.
+
+You do **not** have the trace contents in your context. Anything about the trace's
+data — counts, timings, which component did what — must be gathered with a tool
+before you state it. Never invent task IDs, durations, counts, or component names,
+and never answer a quantitative question from memory or assumption. Run at least one
+query before making any quantitative claim.
+
+## Your tools
+
+Every tool call takes a one-sentence `reason` describing what you are checking and
+why. It is shown to the user as your reasoning for that step, so make it specific.
+
+### `data_query` — query the trace data
+
+Run read-only SQL (`SELECT` / `WITH`) over the trace to gather evidence: counts,
+durations, utilization, concurrency, or the lifecycle of a single task. The trace
+schema is documented in the tool's own description. Prefer aggregates (`COUNT`,
+`AVG`, `MIN`, `MAX`, `GROUP BY`) over dumping rows — results are capped, and raw
+rows are rarely the answer.
+
+`data_query` tells you **what** happened in the trace.
+
+### `code_search` / `code_read` — read the simulator source
+
+The source code that produced the trace may be recorded inside the trace itself —
+the Akita library by default, and possibly the specific simulator's own components.
+Use it to learn what a trace label actually *means*:
+
+- **`code_search`** — regex search across the recorded source. Find where a `Kind`,
+  a milestone name, a `What` type (e.g. `*mem.ReadReq`), or a component is defined
+  and used.
+- **`code_read`** — read a file, or a line range, to study the logic around a match.
+
+Reach for these whenever a `Kind`, milestone, message type, or component in the
+trace is unfamiliar: **read the source to ground your interpretation before
+explaining it — do not guess** what a label represents or how a component behaves.
+
+`code_search` / `code_read` tell you **why** — what the trace labels mean and how the
+components work.
+
+**Availability varies per trace.** The recorded source is whatever the simulation
+captured — the Akita library by default, and the simulator's own code if its author
+opted in. If a trace has no recorded source, `code_search` / `code_read` say so; in
+that case fall back to general knowledge and state plainly that you could not consult
+the source for this trace.
+
+Where things live in the Akita source (a starting map — search to confirm; recorded
+paths are prefixed with the module, e.g. `github.com/sarchlab/akita/v5/mem/cache/…`):
+
+- **Memory components** — `mem/`: caches in `mem/cache/` (`writeback`,
+  `writethroughcache`), DRAM in `mem/dram/`, MSHRs in `mem/mshr/`, reorder buffer in
+  `mem/rob/`, the ideal controller in `mem/idealmemcontroller/`.
+- **Virtual memory / translation** — `mem/vm/`: `tlb`, `mmu`, `addresstranslator`,
+  page tables.
+- **Interconnect** — `noc/` (e.g. `directconnection`).
+- **Ports, buffers, messages** — `messaging/`, `queueing/`.
+- **Task / trace / milestone model** — `tracing/`.
+- **Engine, components, time** — `simulation/`, `modeling/`, `timing/`.
+
+### `screenshot_current_view` / `daisen_view` — see the visualizations
+
+Some patterns are easier to *see* than to query — bursts, periodicity, gaps,
+occupancy shapes over time.
+
+- **`screenshot_current_view`** — capture what the user is currently looking at on
+  screen.
+- **`daisen_view`** — render a specific Daisen view off-screen by its URL and look at
+  it. URL scheme (times are raw trace values):
+  - `/dashboard?widget=<component>&starttime=<t>&endtime=<t>&primary=<metric>&secondary=<metric>`
+  - `/component?name=<component>&taskid=<id>&starttime=<t>&endtime=<t>`
+  - `/task?id=<taskid>&where=<component>&kind=<kind>`
+
+## How to investigate
+
+**Front door — pick the cheapest path that answers the question:**
+
+- **Direct** — a simple definition, or something answerable from context, gets a
+  direct answer with no tools.
+- **Clarify** — if the question is ambiguous (which component? which time window?),
+  ask **one** concise clarifying question rather than guessing. When the current view
+  implies an obvious scope, default to it instead of asking.
+- **Investigate** — otherwise, work the loop below.
+
+**The loop:** form a hypothesis → gather evidence that confirms or refutes it →
+iterate to the next hypothesis or refine → then answer, citing the specific evidence
+you found. Work one hypothesis at a time so your reasoning stays legible. To *refute*
+or narrow a hypothesis, reach for whichever source is cheapest. If nothing is
+conclusive, say so and report what you ruled out — never fabricate a cause.
+
+**When proving a hypothesis, attempt to corroborate it from all three sources.**
+Before presenting a hypothesis as *the cause*, try to gather:
+
+1. **Trace data** — summarized / aggregated numbers from `data_query` (not raw rows)
+   that show the symptom.
+2. **Source code** — the mechanism in the simulator that produces it, from
+   `code_search` / `code_read`.
+3. **A visualization** — the pattern made visible via `daisen_view` or
+   `screenshot_current_view`.
+
+The strongest finding is one where all three agree — the numbers show the symptom,
+the code explains the mechanism, and the view confirms the pattern — so always make
+the attempt. But this is not a hard requirement: some traces have no recorded source,
+and some patterns have no meaningful view. When a leg is genuinely unavailable or does
+not apply, proceed with what you have, state which leg is missing, and temper your
+confidence accordingly — never invent evidence you did not collect, and never pretend
+the proof is more complete than it is.
+
+**Known Akita bottleneck patterns** (a seed list to consider, not exhaustive):
+cache miss / thrashing; queue backpressure or buffer-full stalls; limited outstanding
+requests (MSHR exhaustion); DRAM bank conflicts and row-buffer thrashing; bandwidth
+saturation; head-of-line blocking in FIFOs; address-translation (TLB) miss /
+page-walk stalls; arbitration contention at shared resources; load imbalance across
+peer components.
+
+## Style
+
+Be concise and concrete. Tie every claim to the evidence behind it — the query
+result, the source you read, or the view you saw. When you are uncertain, say so and
+report what you ruled out. Quantitative claims must come from a tool, never from
+memory.

--- a/daisen2/internal/httpapi/server.go
+++ b/daisen2/internal/httpapi/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sarchlab/akita/v5/daisen2/static"
+	"github.com/sarchlab/akita/v5/sourcefs"
 )
 
 // Server is the Daisen replay server. It reads trace data from a SQLite file
@@ -22,6 +23,11 @@ type Server struct {
 	traceReader *SQLiteTraceReader
 	fs          http.FileSystem
 	httpServer  *http.Server
+
+	// codeSource is the simulator source recorded in the loaded trace, read once
+	// on startup. The code-reading tools (code_search / code_read) search it.
+	// Non-nil; IsEmpty reports when the trace carries no source.
+	codeSource *sourcefs.Source
 
 	// captures correlates a pending agent capture request (keyed by id) with the
 	// browser that will POST the image back to /api/agent/capture (Phase 5).
@@ -44,6 +50,7 @@ func NewReplayServer(sqliteFile, addr string) *Server {
 		addr:        addr,
 		traceReader: reader,
 		fs:          static.GetAssets(),
+		codeSource:  loadCodeSource(reader),
 	}
 }
 
@@ -61,7 +68,34 @@ func NewReplayServerReadOnly(sqliteFile string) *Server {
 		mode:        "replay",
 		traceReader: reader,
 		fs:          static.GetAssets(),
+		codeSource:  loadCodeSource(reader),
 	}
+}
+
+// loadCodeSource reads the source recorded in the trace (if any) and logs what
+// is available. It never fails the server: an unreadable or missing source
+// table yields an empty Source, and DaisenBot reports the gap rather than
+// erroring.
+func loadCodeSource(reader *SQLiteTraceReader) *sourcefs.Source {
+	src, err := sourcefs.OpenTraceSource(reader.DB)
+	if err != nil {
+		log.Printf("DaisenBot: could not read recorded source from trace: %v", err)
+		return &sourcefs.Source{}
+	}
+	if src.IsEmpty() {
+		log.Printf("DaisenBot: no source recorded in this trace")
+	} else {
+		log.Printf("DaisenBot: recorded source available — %d files across %v",
+			src.Files, src.Roots)
+	}
+	return src
+}
+
+// CodeSource returns the simulator source recorded in the loaded trace, for the
+// code-reading tools. It is non-nil; use IsEmpty to detect a trace with no
+// recorded source.
+func (s *Server) CodeSource() *sourcefs.Source {
+	return s.codeSource
 }
 
 // Start starts the HTTP server in replay mode. It listens on the configured

--- a/simulation/builder.go
+++ b/simulation/builder.go
@@ -1,6 +1,9 @@
 package simulation
 
 import (
+	"io/fs"
+	"maps"
+
 	"github.com/rs/xid"
 	"github.com/sarchlab/akita/v5/datarecording"
 
@@ -16,6 +19,8 @@ type Builder struct {
 	monitorPort       int
 	outputFileName    string
 	visTracingOnStart bool
+	recordSource      bool
+	sourceFSes        map[string]fs.FS
 }
 
 // MakeBuilder creates a new builder.
@@ -23,6 +28,7 @@ func MakeBuilder() Builder {
 	return Builder{
 		parallelEngine: false,
 		monitorOn:      true,
+		recordSource:   true,
 	}
 }
 
@@ -56,6 +62,33 @@ func (b Builder) WithVisTracingOnStart() Builder {
 	return b
 }
 
+// WithSourceFS registers an additional source tree to record into the trace
+// (e.g. a simulator's own components), keyed by a label such as its module
+// path. Akita's own source is recorded automatically; use this so DaisenBot can
+// also read your components' source. Typically called with a //go:embed FS:
+//
+//	//go:embed *.go cu/*.go
+//	var srcFS embed.FS
+//	sim := simulation.MakeBuilder().WithSourceFS("github.com/me/mysim", srcFS)
+//
+// Source is only recorded when vis tracing is enabled (the trace is meant for
+// DaisenBot). Repeated calls add multiple roots.
+func (b Builder) WithSourceFS(root string, fsys fs.FS) Builder {
+	next := make(map[string]fs.FS, len(b.sourceFSes)+1)
+	maps.Copy(next, b.sourceFSes)
+	next[root] = fsys
+	b.sourceFSes = next
+	return b
+}
+
+// WithoutSourceRecording disables recording source into the trace. Source
+// recording (Akita's source by default, plus any WithSourceFS roots) is on by
+// default for traced simulations; disable it to keep traces minimal.
+func (b Builder) WithoutSourceRecording() Builder {
+	b.recordSource = false
+	return b
+}
+
 func (b Builder) parametersMustBeValid() {
 	if !b.monitorOn && b.monitorPort != 0 {
 		panic("monitor port cannot be set when monitoring is disabled")
@@ -72,10 +105,24 @@ func (b Builder) Build() *Simulation {
 	b.createEngine(s)
 	b.createIDGenerator(s)
 	b.createMetaRecorder(s)
+	b.createSourceRecorder(s)
 	b.createVisTracer(s)
 	b.createServer(s)
 
 	return s
+}
+
+// createSourceRecorder records the simulator source into the trace so it is
+// self-describing for DaisenBot. It runs only for traced simulations (the trace
+// is the consumer) and can be disabled with WithoutSourceRecording.
+func (b Builder) createSourceRecorder(s *Simulation) {
+	if !b.recordSource || !b.visTracingOnStart {
+		return
+	}
+
+	if err := recordSourceArchives(s.dataRecorder, b.sourceFSes); err != nil {
+		panic(err)
+	}
 }
 
 func (b Builder) createSimulation() *Simulation {

--- a/simulation/source_recorder.go
+++ b/simulation/source_recorder.go
@@ -1,0 +1,77 @@
+package simulation
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/fs"
+	"sort"
+
+	"github.com/sarchlab/akita/v5/datarecording"
+	"github.com/sarchlab/akita/v5/sourcefs"
+)
+
+// sourceTableName is the trace table holding recorded source archives.
+const sourceTableName = "source"
+
+// sourceArchiveFormat documents how the Content column is encoded: base64 text
+// wrapping a gzip-compressed tar. The data recorder stores scalar struct fields
+// only (no BLOB), so the binary archive is base64-encoded into a TEXT column.
+const sourceArchiveFormat = "tar.gz;base64"
+
+// sourceArchiveEntry is one recorded source root. Content is the base64 of a
+// gzip-compressed tar of slash-separated path -> file bytes, decodable with
+// sourcefs.ReadArchive.
+type sourceArchiveEntry struct {
+	Root    string
+	Format  string
+	Content string
+}
+
+// recordSourceArchives writes the simulator source into the trace's source
+// table, making the trace self-describing for DaisenBot. Akita's own source is
+// read from disk (so it always matches the build); any author-provided roots
+// (WithSourceFS) are recorded alongside it. Source is static, so this records
+// once and flushes. The table is always created so a reader can distinguish
+// "recorded, empty" from "no table".
+func recordSourceArchives(
+	recorder datarecording.DataRecorder,
+	explicitFSes map[string]fs.FS,
+) error {
+	recorder.CreateTable(sourceTableName, sourceArchiveEntry{})
+
+	insert := func(root string, gztar []byte) {
+		recorder.InsertData(sourceTableName, sourceArchiveEntry{
+			Root:    root,
+			Format:  sourceArchiveFormat,
+			Content: base64.StdEncoding.EncodeToString(gztar),
+		})
+	}
+
+	// Akita's own source, read from disk so it matches what ran. When the
+	// source is not on disk (e.g. a -trimpath build), record nothing for Akita
+	// rather than guessing — DaisenBot then reports it has no source.
+	if dir, ok := sourcefs.AkitaSourceDir(); ok {
+		gztar, err := sourcefs.ArchiveDir(dir)
+		if err != nil {
+			return fmt.Errorf("archiving akita source at %q: %w", dir, err)
+		}
+		insert(sourcefs.ModulePath, gztar)
+	}
+
+	// Author-provided source roots (opt-in via WithSourceFS), in a stable order.
+	roots := make([]string, 0, len(explicitFSes))
+	for root := range explicitFSes {
+		roots = append(roots, root)
+	}
+	sort.Strings(roots)
+	for _, root := range roots {
+		gztar, err := sourcefs.ArchiveFS(explicitFSes[root])
+		if err != nil {
+			return fmt.Errorf("archiving source root %q: %w", root, err)
+		}
+		insert(root, gztar)
+	}
+
+	recorder.Flush()
+	return nil
+}

--- a/simulation/source_recorder_test.go
+++ b/simulation/source_recorder_test.go
@@ -1,0 +1,129 @@
+package simulation
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/sarchlab/akita/v5/datarecording"
+	"github.com/sarchlab/akita/v5/sourcefs"
+)
+
+// openMemRecorder returns a data recorder over a single-connection in-memory
+// SQLite DB. MaxOpenConns(1) is required: a ":memory:" database is per
+// connection, so the table the recorder creates must be read back on the same
+// connection.
+func openMemRecorder(t *testing.T) (*sql.DB, datarecording.DataRecorder) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+
+	return db, datarecording.NewDataRecorderWithDB(db)
+}
+
+func readSourceRows(t *testing.T, db *sql.DB) (content, format map[string]string) {
+	t.Helper()
+
+	content = map[string]string{}
+	format = map[string]string{}
+
+	rows, err := db.Query("SELECT Root, Format, Content FROM source")
+	if err != nil {
+		t.Fatalf("query source table: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var root, f, c string
+		if err := rows.Scan(&root, &f, &c); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		content[root] = c
+		format[root] = f
+	}
+	return content, format
+}
+
+func decodeArchive(t *testing.T, b64 string) map[string][]byte {
+	t.Helper()
+
+	gz, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	files, err := sourcefs.ReadArchive(gz)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	return files
+}
+
+func TestRecordSourceArchives_RecordsAkitaFromDisk(t *testing.T) {
+	db, recorder := openMemRecorder(t)
+
+	if err := recordSourceArchives(recorder, nil); err != nil {
+		t.Fatalf("recordSourceArchives: %v", err)
+	}
+
+	content, format := readSourceRows(t, db)
+
+	b64, ok := content[sourcefs.ModulePath]
+	if !ok {
+		t.Fatalf("no Akita source row for %q (have %v)", sourcefs.ModulePath, keysOf(content))
+	}
+	if format[sourcefs.ModulePath] != sourceArchiveFormat {
+		t.Errorf("format = %q, want %q", format[sourcefs.ModulePath], sourceArchiveFormat)
+	}
+
+	files := decodeArchive(t, b64)
+	// Stable files that define trace vocabulary the agent reads.
+	for _, want := range []string{"tracing/tracer.go", "mem/mshr/mshr.go"} {
+		if _, ok := files[want]; !ok {
+			t.Errorf("recorded Akita source missing %q (have %d files)", want, len(files))
+		}
+	}
+}
+
+func TestRecordSourceArchives_RecordsAuthorSource(t *testing.T) {
+	db, recorder := openMemRecorder(t)
+
+	authorFS := fstest.MapFS{
+		"cu/compute_unit.go": {Data: []byte("package cu\n// ComputeUnit is a CU.\n")},
+	}
+	roots := map[string]fs.FS{"github.com/example/mysim": authorFS}
+
+	if err := recordSourceArchives(recorder, roots); err != nil {
+		t.Fatalf("recordSourceArchives: %v", err)
+	}
+
+	content, _ := readSourceRows(t, db)
+
+	// Akita is still recorded from disk alongside the author's source.
+	if _, ok := content[sourcefs.ModulePath]; !ok {
+		t.Errorf("Akita source row missing when author source is provided")
+	}
+
+	b64, ok := content["github.com/example/mysim"]
+	if !ok {
+		t.Fatalf("no author source row")
+	}
+	files := decodeArchive(t, b64)
+	if got := string(files["cu/compute_unit.go"]); got != "package cu\n// ComputeUnit is a CU.\n" {
+		t.Errorf("author file content = %q", got)
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/sourcefs/sourcefs.go
+++ b/sourcefs/sourcefs.go
@@ -1,0 +1,235 @@
+// Package sourcefs locates and serializes Akita's own Go source so a simulation
+// can record the exact library source that produced a trace. DaisenBot (in
+// daisen2) reads that recorded source to interpret a trace's Kinds, milestones,
+// and component behavior instead of guessing.
+//
+// The source is read from disk at record time — from the Go module cache, a
+// `replace` path, or the working tree when Akita is the main module — so it
+// always matches the binary that ran, with no generated or embedded artifact to
+// keep in sync. When the source is not on disk (e.g. a `-trimpath` build, or a
+// binary moved off the build machine), AkitaSourceDir reports false and the
+// caller records nothing for Akita rather than guessing.
+package sourcefs
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// ModulePath is Akita's Go module path — the natural root label when recording
+// its source into a trace.
+const ModulePath = "github.com/sarchlab/akita/v5"
+
+// skipDirs are directory names pruned anywhere in a source tree: VCS metadata,
+// Claude worktrees (full nested repo copies), vendored or generated trees, and
+// test fixtures.
+var skipDirs = map[string]bool{
+	".git":         true,
+	".claude":      true,
+	"vendor":       true,
+	"node_modules": true,
+	"testdata":     true,
+	"dist":         true,
+}
+
+// isSourceFile reports whether a file should be recorded: non-test .go source,
+// plus go.mod for module/dependency context.
+func isSourceFile(name string) bool {
+	if name == "go.mod" {
+		return true
+	}
+	return strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go")
+}
+
+// AkitaSourceDir returns the on-disk directory of Akita's module root and true
+// if found. It locates itself from the compiled-in path of this source file and
+// walks up to the enclosing go.mod, so it resolves Akita whether it is the main
+// module, a module-cache dependency, or a `replace` target. It returns false
+// when the path is unavailable (e.g. a -trimpath build) or the source is not
+// present on the machine.
+func AkitaSourceDir() (string, bool) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok || !filepath.IsAbs(file) {
+		return "", false
+	}
+
+	root, ok := moduleRootOf(filepath.Dir(file), ModulePath)
+	if !ok {
+		return "", false
+	}
+	if _, err := os.Stat(root); err != nil {
+		return "", false
+	}
+	return root, true
+}
+
+// moduleRootOf walks up from dir to the directory whose go.mod declares
+// modulePath, returning it and true if found.
+func moduleRootOf(dir, modulePath string) (string, bool) {
+	for {
+		if data, err := os.ReadFile(filepath.Join(dir, "go.mod")); err == nil {
+			if moduleLineIs(data, modulePath) {
+				return dir, true
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+func moduleLineIs(gomod []byte, modulePath string) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(gomod))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && fields[0] == "module" {
+			return fields[1] == modulePath
+		}
+	}
+	return false
+}
+
+// ArchiveDir reads the recordable source files (non-test .go plus go.mod) under
+// dir and returns them as a gzip-compressed tar, keyed by slash paths relative
+// to dir.
+func ArchiveDir(dir string) ([]byte, error) {
+	files := map[string][]byte{}
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path != dir && skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !isSourceFile(d.Name()) {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files[filepath.ToSlash(rel)] = content
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return packArchive(files)
+}
+
+// ArchiveFS reads every regular file from fsys and returns a gzip-compressed
+// tar. The caller is responsible for filtering — fsys should contain only what
+// should be recorded (e.g. a //go:embed of the wanted .go files).
+func ArchiveFS(fsys fs.FS) ([]byte, error) {
+	files := map[string][]byte{}
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		content, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			return err
+		}
+		files[p] = content
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return packArchive(files)
+}
+
+func packArchive(files map[string][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := WriteArchive(&buf, files); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// WriteArchive writes files (slash-separated path -> content) as a
+// gzip-compressed tar to w. Entries are emitted in sorted path order with a
+// zero modtime, so identical inputs produce byte-identical output.
+func WriteArchive(w io.Writer, files map[string][]byte) error {
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	gz := gzip.NewWriter(w)
+	tw := tar.NewWriter(gz)
+
+	for _, p := range paths {
+		content := files[p]
+		hdr := &tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     p,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if _, err := tw.Write(content); err != nil {
+			return err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gz.Close()
+}
+
+// ReadArchive decompresses a gzip-compressed tar (as produced by WriteArchive)
+// into a slash-separated path -> content map. Non-regular entries are skipped.
+func ReadArchive(gztar []byte) (map[string][]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(gztar))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	files := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		content, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, err
+		}
+		files[hdr.Name] = content
+	}
+	return files, nil
+}

--- a/sourcefs/sourcefs.go
+++ b/sourcefs/sourcefs.go
@@ -16,6 +16,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -23,6 +24,14 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+)
+
+const (
+	// maxArchiveFileBytes / maxArchiveTotalBytes bound a single decompressed file
+	// and a whole archive when reading back, so a malformed or oversized source
+	// row (e.g. a gzip bomb in a shared trace) can't exhaust memory at load time.
+	maxArchiveFileBytes  = 8 << 20  // 8 MiB per recorded file
+	maxArchiveTotalBytes = 96 << 20 // 96 MiB total decompressed per archive
 )
 
 // ModulePath is Akita's Go module path — the natural root label when recording
@@ -135,9 +144,12 @@ func ArchiveDir(dir string) ([]byte, error) {
 	return packArchive(files)
 }
 
-// ArchiveFS reads every regular file from fsys and returns a gzip-compressed
-// tar. The caller is responsible for filtering — fsys should contain only what
-// should be recorded (e.g. a //go:embed of the wanted .go files).
+// ArchiveFS reads the recordable source files (non-test .go plus go.mod) from
+// fsys and returns a gzip-compressed tar, applying the same filtering as
+// ArchiveDir (skip _test.go, and prune .git/.claude/vendor/node_modules/
+// testdata/dist). This way a broad fs.FS — an embed or os.DirFS that includes
+// more than source — never records secrets, fixtures, generated artifacts, or
+// vendored code into the trace.
 func ArchiveFS(fsys fs.FS) ([]byte, error) {
 	files := map[string][]byte{}
 	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
@@ -145,6 +157,12 @@ func ArchiveFS(fsys fs.FS) ([]byte, error) {
 			return err
 		}
 		if d.IsDir() {
+			if p != "." && skipDirs[d.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !isSourceFile(d.Name()) {
 			return nil
 		}
 		content, err := fs.ReadFile(fsys, p)
@@ -214,6 +232,7 @@ func ReadArchive(gztar []byte) (map[string][]byte, error) {
 
 	tr := tar.NewReader(gz)
 	files := map[string][]byte{}
+	total := 0
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -225,9 +244,18 @@ func ReadArchive(gztar []byte) (map[string][]byte, error) {
 		if hdr.Typeflag != tar.TypeReg {
 			continue
 		}
-		content, err := io.ReadAll(tr)
+		// Bound per-file and total decompressed size so a malformed or oversized
+		// archive can't exhaust memory before the code tools' output caps apply.
+		content, err := io.ReadAll(io.LimitReader(tr, maxArchiveFileBytes+1))
 		if err != nil {
 			return nil, err
+		}
+		if len(content) > maxArchiveFileBytes {
+			return nil, fmt.Errorf("source archive entry %q exceeds %d bytes", hdr.Name, maxArchiveFileBytes)
+		}
+		total += len(content)
+		if total > maxArchiveTotalBytes {
+			return nil, fmt.Errorf("source archive exceeds %d bytes decompressed", maxArchiveTotalBytes)
 		}
 		files[hdr.Name] = content
 	}

--- a/sourcefs/sourcefs_test.go
+++ b/sourcefs/sourcefs_test.go
@@ -58,25 +58,47 @@ func TestWriteArchiveDeterministic(t *testing.T) {
 
 func TestArchiveFS(t *testing.T) {
 	fsys := fstest.MapFS{
-		"pkg/file.go": {Data: []byte("package pkg\n")},
-		"top.go":      {Data: []byte("package main\n")},
+		"pkg/file.go":      {Data: []byte("package pkg\n")},
+		"top.go":           {Data: []byte("package main\n")},
+		"go.mod":           {Data: []byte("module example.com/m\n")},
+		"pkg/file_test.go": {Data: []byte("package pkg\n")}, // excluded: test file
+		"README.md":        {Data: []byte("# readme\n")},    // excluded: not source
+		"vendor/dep/d.go":  {Data: []byte("package dep\n")}, // excluded: vendored
+		"testdata/x.go":    {Data: []byte("package x\n")},   // excluded: fixtures
 	}
 
 	gz, err := ArchiveFS(fsys)
 	if err != nil {
 		t.Fatalf("ArchiveFS: %v", err)
 	}
-
 	out, err := ReadArchive(gz)
 	if err != nil {
 		t.Fatalf("ReadArchive: %v", err)
 	}
 
-	if got := string(out["pkg/file.go"]); got != "package pkg\n" {
-		t.Errorf("pkg/file.go = %q", got)
+	for _, want := range []string{"pkg/file.go", "top.go", "go.mod"} {
+		if _, ok := out[want]; !ok {
+			t.Errorf("expected %q to be recorded", want)
+		}
 	}
-	if got := string(out["top.go"]); got != "package main\n" {
-		t.Errorf("top.go = %q", got)
+	for _, excluded := range []string{
+		"pkg/file_test.go", "README.md", "vendor/dep/d.go", "testdata/x.go",
+	} {
+		if _, ok := out[excluded]; ok {
+			t.Errorf("expected %q to be excluded by source filtering", excluded)
+		}
+	}
+}
+
+func TestReadArchiveRejectsOversizedEntry(t *testing.T) {
+	// gzip of a long repeated byte is tiny, so this stays cheap.
+	big := bytes.Repeat([]byte("a"), maxArchiveFileBytes+1)
+	var buf bytes.Buffer
+	if err := WriteArchive(&buf, map[string][]byte{"big.go": big}); err != nil {
+		t.Fatalf("WriteArchive: %v", err)
+	}
+	if _, err := ReadArchive(buf.Bytes()); err == nil {
+		t.Error("expected ReadArchive to reject an oversized entry")
 	}
 }
 

--- a/sourcefs/sourcefs_test.go
+++ b/sourcefs/sourcefs_test.go
@@ -1,0 +1,120 @@
+package sourcefs
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestWriteReadArchiveRoundTrip(t *testing.T) {
+	in := map[string][]byte{
+		"a/b.go":   []byte("package b\n"),
+		"c.go":     []byte("package c\n"),
+		"empty.go": {},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteArchive(&buf, in); err != nil {
+		t.Fatalf("WriteArchive: %v", err)
+	}
+
+	out, err := ReadArchive(buf.Bytes())
+	if err != nil {
+		t.Fatalf("ReadArchive: %v", err)
+	}
+
+	if len(out) != len(in) {
+		t.Fatalf("got %d files, want %d", len(out), len(in))
+	}
+	for p, want := range in {
+		if !bytes.Equal(out[p], want) {
+			t.Errorf("file %q: got %q, want %q", p, out[p], want)
+		}
+	}
+}
+
+func TestWriteArchiveDeterministic(t *testing.T) {
+	in := map[string][]byte{
+		"z.go": []byte("z"),
+		"a.go": []byte("a"),
+		"m.go": []byte("m"),
+	}
+
+	var b1, b2 bytes.Buffer
+	if err := WriteArchive(&b1, in); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteArchive(&b2, in); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(b1.Bytes(), b2.Bytes()) {
+		t.Error("WriteArchive is not deterministic for identical input")
+	}
+}
+
+func TestArchiveFS(t *testing.T) {
+	fsys := fstest.MapFS{
+		"pkg/file.go": {Data: []byte("package pkg\n")},
+		"top.go":      {Data: []byte("package main\n")},
+	}
+
+	gz, err := ArchiveFS(fsys)
+	if err != nil {
+		t.Fatalf("ArchiveFS: %v", err)
+	}
+
+	out, err := ReadArchive(gz)
+	if err != nil {
+		t.Fatalf("ReadArchive: %v", err)
+	}
+
+	if got := string(out["pkg/file.go"]); got != "package pkg\n" {
+		t.Errorf("pkg/file.go = %q", got)
+	}
+	if got := string(out["top.go"]); got != "package main\n" {
+		t.Errorf("top.go = %q", got)
+	}
+}
+
+func TestAkitaSourceDir(t *testing.T) {
+	dir, ok := AkitaSourceDir()
+	if !ok {
+		t.Fatal("AkitaSourceDir not found (expected to resolve when Akita is the module under test)")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "go.mod")); err != nil {
+		t.Errorf("located dir %q has no go.mod: %v", dir, err)
+	}
+}
+
+func TestArchiveDirReadsRealSourceAndFilters(t *testing.T) {
+	dir, ok := AkitaSourceDir()
+	if !ok {
+		t.Skip("Akita source not on disk")
+	}
+
+	gz, err := ArchiveDir(dir)
+	if err != nil {
+		t.Fatalf("ArchiveDir: %v", err)
+	}
+	files, err := ReadArchive(gz)
+	if err != nil {
+		t.Fatalf("ReadArchive: %v", err)
+	}
+
+	if _, ok := files["tracing/tracer.go"]; !ok {
+		t.Errorf("archived source missing tracing/tracer.go (have %d files)", len(files))
+	}
+
+	for p := range files {
+		if strings.HasSuffix(p, "_test.go") {
+			t.Errorf("archive should exclude test files, found %q", p)
+		}
+		if strings.HasPrefix(p, ".claude/") || strings.HasPrefix(p, ".git/") {
+			t.Errorf("archive should prune %q", p)
+		}
+	}
+}

--- a/sourcefs/trace_source.go
+++ b/sourcefs/trace_source.go
@@ -1,0 +1,112 @@
+package sourcefs
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"io/fs"
+	"sort"
+	"testing/fstest"
+)
+
+// traceSourceTable is the trace table that holds recorded source archives,
+// written by the simulation source recorder.
+const traceSourceTable = "source"
+
+// Source is the simulator source recorded in a trace, exposed as a read-only
+// file tree. Paths are "<root>/<file>" so multiple recorded roots (e.g. Akita
+// plus a simulator's own module) coexist without collision. A nil or zero
+// Source means no source was recorded.
+type Source struct {
+	fsys  fs.FS
+	Roots []string // recorded module roots, sorted (e.g. "github.com/sarchlab/akita/v5")
+	Files int      // total file count across all roots
+}
+
+// FS returns the recorded source as a read-only fs.FS, or nil when empty. The
+// code-reading tools walk and read it; a future on-disk override can supply a
+// different fs.FS behind the same interface.
+func (s *Source) FS() fs.FS {
+	if s == nil {
+		return nil
+	}
+	return s.fsys
+}
+
+// IsEmpty reports whether no source is available to read.
+func (s *Source) IsEmpty() bool {
+	return s == nil || s.Files == 0
+}
+
+// OpenTraceSource reads the recorded `source` table from a trace database and
+// returns it as a read-only file tree. A missing or empty table is not an
+// error — it returns an empty Source — so traces recorded before source
+// recording existed (or with it disabled) are handled gracefully.
+func OpenTraceSource(db *sql.DB) (*Source, error) {
+	if db == nil {
+		return &Source{}, nil
+	}
+
+	present, err := hasTable(db, traceSourceTable)
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		return &Source{}, nil
+	}
+
+	rows, err := db.Query("SELECT Root, Content FROM " + traceSourceTable)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	mapFS := fstest.MapFS{}
+	rootSet := map[string]struct{}{}
+	for rows.Next() {
+		var root, content string
+		if err := rows.Scan(&root, &content); err != nil {
+			return nil, err
+		}
+
+		gztar, err := base64.StdEncoding.DecodeString(content)
+		if err != nil {
+			return nil, fmt.Errorf("decoding source for %q: %w", root, err)
+		}
+		files, err := ReadArchive(gztar)
+		if err != nil {
+			return nil, fmt.Errorf("reading source archive for %q: %w", root, err)
+		}
+
+		for p, data := range files {
+			mapFS[root+"/"+p] = &fstest.MapFile{Data: data}
+		}
+		rootSet[root] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	roots := make([]string, 0, len(rootSet))
+	for r := range rootSet {
+		roots = append(roots, r)
+	}
+	sort.Strings(roots)
+
+	return &Source{fsys: mapFS, Roots: roots, Files: len(mapFS)}, nil
+}
+
+func hasTable(db *sql.DB, name string) (bool, error) {
+	var found string
+	err := db.QueryRow(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name=? LIMIT 1",
+		name,
+	).Scan(&found)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/sourcefs/trace_source.go
+++ b/sourcefs/trace_source.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/fs"
+	"path"
 	"sort"
 	"testing/fstest"
 )
@@ -106,7 +107,14 @@ func OpenTraceSource(db *sql.DB) (*Source, error) {
 		}
 
 		for p, data := range files {
-			mapFS[root+"/"+p] = &fstest.MapFile{Data: data}
+			// path.Join normalizes empty/"." roots; fs.ValidPath rejects anything
+			// that would be an invalid MapFS key (absolute, "..", etc.) and would
+			// otherwise crash the walk when opening an externally-produced trace.
+			key := path.Join(root, p)
+			if !fs.ValidPath(key) {
+				continue
+			}
+			mapFS[key] = &fstest.MapFile{Data: data}
 		}
 		rootSet[root] = struct{}{}
 	}

--- a/sourcefs/trace_source.go
+++ b/sourcefs/trace_source.go
@@ -38,6 +38,33 @@ func (s *Source) IsEmpty() bool {
 	return s == nil || s.Files == 0
 }
 
+// NewSource builds a Source from an arbitrary read-only fs.FS (an in-memory tree
+// or, in future, an on-disk --code-root), walking it to count files. roots is
+// the list of recorded module roots, for reporting; it may be nil.
+func NewSource(fsys fs.FS, roots []string) (*Source, error) {
+	rs := append([]string(nil), roots...)
+	sort.Strings(rs)
+	if fsys == nil {
+		return &Source{Roots: rs}, nil
+	}
+
+	files := 0
+	err := fs.WalkDir(fsys, ".", func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			files++
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Source{fsys: fsys, Roots: rs, Files: files}, nil
+}
+
 // OpenTraceSource reads the recorded `source` table from a trace database and
 // returns it as a read-only file tree. A missing or empty table is not an
 // error — it returns an empty Source — so traces recorded before source
@@ -91,9 +118,8 @@ func OpenTraceSource(db *sql.DB) (*Source, error) {
 	for r := range rootSet {
 		roots = append(roots, r)
 	}
-	sort.Strings(roots)
 
-	return &Source{fsys: mapFS, Roots: roots, Files: len(mapFS)}, nil
+	return NewSource(mapFS, roots)
 }
 
 func hasTable(db *sql.DB, name string) (bool, error) {

--- a/sourcefs/trace_source_test.go
+++ b/sourcefs/trace_source_test.go
@@ -69,6 +69,31 @@ func TestOpenTraceSource(t *testing.T) {
 	}
 }
 
+func TestOpenTraceSourceToleratesEmptyRoot(t *testing.T) {
+	db := makeSourceDB(t)
+	if _, err := db.Exec("CREATE TABLE source (Root, Format, Content)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	content := gzTarBase64(t, map[string][]byte{"foo.go": []byte("package foo\n")})
+	if _, err := db.Exec(
+		"INSERT INTO source (Root, Format, Content) VALUES (?, ?, ?)",
+		"", "tar.gz;base64", content, // empty root must not crash the walk
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	src, err := OpenTraceSource(db)
+	if err != nil {
+		t.Fatalf("OpenTraceSource: %v", err)
+	}
+	if src.IsEmpty() {
+		t.Fatal("expected the file to load under a normalized key")
+	}
+	if _, err := fs.ReadFile(src.FS(), "foo.go"); err != nil {
+		t.Errorf("expected foo.go readable under a normalized key: %v", err)
+	}
+}
+
 func TestOpenTraceSourceNoTable(t *testing.T) {
 	db := makeSourceDB(t)
 

--- a/sourcefs/trace_source_test.go
+++ b/sourcefs/trace_source_test.go
@@ -1,0 +1,85 @@
+package sourcefs
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/base64"
+	"io/fs"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func makeSourceDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1) // ":memory:" is per-connection
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func gzTarBase64(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := WriteArchive(&buf, files); err != nil {
+		t.Fatalf("WriteArchive: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(buf.Bytes())
+}
+
+func TestOpenTraceSource(t *testing.T) {
+	db := makeSourceDB(t)
+	if _, err := db.Exec("CREATE TABLE source (Root, Format, Content)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	content := gzTarBase64(t, map[string][]byte{
+		"a.go":   []byte("package a\n"),
+		"b/c.go": []byte("package c\n"),
+	})
+	if _, err := db.Exec(
+		"INSERT INTO source (Root, Format, Content) VALUES (?, ?, ?)",
+		"example.com/m", "tar.gz;base64", content,
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	src, err := OpenTraceSource(db)
+	if err != nil {
+		t.Fatalf("OpenTraceSource: %v", err)
+	}
+	if src.IsEmpty() {
+		t.Fatal("expected non-empty source")
+	}
+	if src.Files != 2 {
+		t.Errorf("Files = %d, want 2", src.Files)
+	}
+	if len(src.Roots) != 1 || src.Roots[0] != "example.com/m" {
+		t.Errorf("Roots = %v, want [example.com/m]", src.Roots)
+	}
+
+	data, err := fs.ReadFile(src.FS(), "example.com/m/a.go")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "package a\n" {
+		t.Errorf("a.go = %q, want %q", data, "package a\n")
+	}
+}
+
+func TestOpenTraceSourceNoTable(t *testing.T) {
+	db := makeSourceDB(t)
+
+	src, err := OpenTraceSource(db)
+	if err != nil {
+		t.Fatalf("OpenTraceSource: %v", err)
+	}
+	if !src.IsEmpty() {
+		t.Errorf("expected empty source when no source table exists")
+	}
+	if src.FS() != nil {
+		t.Errorf("expected nil FS when no source table exists")
+	}
+}


### PR DESCRIPTION
## DaisenBot Phase 3 — let the agent read the source that produced a trace

So DaisenBot can interpret a trace's `Kind`s, milestones, types, and components by reading the **exact source that produced it**, instead of guessing. This is the full pipeline: **record → store in trace → read back → agent tools → prompt guidance** (Workstreams A–E).

### A — record source into the trace
A traced simulation writes a `source` table, capturing the simulator source **read from disk at record time**.
- **`sourcefs`** locates Akita's source on disk (module cache / `replace` / working tree) from the compiled-in path of its own file, and serializes a dir or `fs.FS` to a gzip-tar (non-test `.go` + `go.mod`, pruning `.git`/`.claude`/`vendor`/`node_modules`/`testdata`/`dist`).
- **`simulation`** `recordSourceArchives` writes `source(Root, Format, Content)`: Akita by default; `sim.WithSourceFS(root, fsys)` adds the author's components; `WithoutSourceRecording()` opts out; gated on `WithVisTracingOnStart`. `Content` is `base64(gzip-tar)` in a TEXT column (no BLOB in the data recorder).
- **Why disk, not embed:** the user iterates on a concrete simulator, and Go requires a rebuild to run changed code, so on-disk source *is* what ran — no artifact to regenerate. Off-disk (`-trimpath` / moved binary) records nothing and DaisenBot reports it.

### B — read it back
- **`sourcefs.OpenTraceSource(db)`** reads the `source` table → a read-only `fs.FS` (paths `<root>/<file>`) + `Roots`/`Files`; missing/empty table is not an error. `database/sql`-only.
- **daisen2 `Server`** loads it on startup into `codeSource`, exposes `CodeSource()`, logs coverage.

### C/D — agent tools
- **`code_search`** — RE2 regex over `CodeSource().FS()`; optional `path_contains` filter; capped matches/bytes/line-length with a truncation note; returns `file:line` hits.
- **`code_read`** — read a file or `[start_line, end_line]` window; numbered lines; default window + "more lines" note; per-read caps; `fs.ValidPath` guard.
- Both require a `reason` (shown in the step trail); an empty `codeSource` returns a "no source recorded" observation instead of erroring. Registered in the `runAgentSSE` tool slice — **no frontend changes**.

### E — system prompt
- The agent system prompt moves from a hardcoded Go `const` to markdown **embedded via `//go:embed`** (`prompts/agent_system.md` + `prompt.go`) — so it can use real markdown (the backtick raw-string `const` couldn't even contain backticks) and is edited without touching Go.
- It documents all five tools, the front door, the **"read the source before guessing"** rule, a module-prefixed source map, the seed bottleneck catalog, and an **evidence policy**: when proving a hypothesis, *attempt* to corroborate it from trace data + source code + a visualization, proceeding honestly and naming any missing leg. Per-trace availability is tool-reported (no runtime prompt templating).

### Verified
- A traced `mem/acceptancetests/virtualmem` run records Akita source (DB ~1.31 MB → ~1.64 MB, +~324 KB base64) decoding back to 268 real files; daisen2 logs `recorded source available — 268 files across [github.com/sarchlab/akita/v5]`.
- Unit tests across `sourcefs` (archive round-trip, `AkitaSourceDir`, `ArchiveDir` filtering, `OpenTraceSource`), `simulation` (`recordSourceArchives`), the code tools (search match/filter/caps/empty; read window/range/not-found/traversal/long-file), and the embedded prompt (`TestAgentSystemPromptEmbedded`); an **end-to-end mock-provider SSE test** drives `code_search → code_read → answer` through `/api/gpt`.
- `go build ./...`, `simulation` / `sourcefs` / `daisen2/internal/httpapi` / `datarecording` suites, gofmt, vet all green.

### Follow-up (separate, not blocking)
- Decision #2's tutorial / component-authoring doc recommending `sim.WithSourceFS(...)` (a different doc surface than this plan).

Design + decisions: `daisen2/docs/daisenbot-agent-plan.md` §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
