### PR TITLE
mem/vm/addresstranslator: fix translation-finalize stale pointer + phantom milestone (tracing plan Step 2)

### DIFF
--- a/TRACING_INSTRUMENTATION_PLAN.md
+++ b/TRACING_INSTRUMENTATION_PLAN.md
@@ -96,26 +96,48 @@ intervals are ~zero with no reorder penalty and positive when there is one.
 
 ---
 
-## Step 2 — Fix the address-translator stale-pointer finalize bug
+## Step 2 — Fix the address-translator stale-pointer finalize bug — DONE
 
-**Objective.** Stop orphaning TLB child tasks (empirically 11 per short run).
+**Objective.** Stop orphaning TLB child tasks (empirically 11 per short run),
+and make the AT fully and correctly instrumented.
 
-**Scope.** `mem/vm/addresstranslator/respondpipelinemw.go`, `comp.go`.
+**Scope.** `mem/vm/addresstranslator/respondpipelinemw.go`.
 
-**Problem.** `removeTransaction` (`comp.go:180`, an `append`-shift) runs at
-`respondpipelinemw.go:97` **before** `traceTranslationComplete` reads
-`trans.TranslationReqID` through the now-stale pointer (`:100`/`:129`). When the
-completing transaction is not last in the queue, `TraceReqFinalize` ends the
-**wrong** translation `req_out`; the correct one never ends, never gets written,
-and its TLB `req_in`/`incoming_queue` children are orphaned. Tracing-only — the
-functional path already uses local copies.
+**Problem.** `removeTransaction` (`comp.go:180`, an `append`-shift) ran
+**before** `traceTranslationComplete` read `trans.TranslationReqID` through the
+now-stale pointer. When the completing transaction is not last in the queue,
+`TraceReqFinalize` ended the **wrong** translation `req_out`; the correct one
+never ended, never got written, and its TLB `req_in`/`incoming_queue` children
+were orphaned. (When it *was* last the old value lingered in the backing array,
+so only non-last completions corrupted.) Tracing-only — the functional path
+already uses local copies.
 
-**Approach.** Capture `TranslationReqID/Src/Dst` (or build `fakeTransReq`) into
-locals **before** `removeTransaction`, or reorder so the trace read precedes the
-removal.
+**Second defect (found making the AT fully instrumented).** The bottom-send
+`network_busy` milestone was keyed off `MsgIDAtReceiver(translatedReq)`, but the
+AT *sends* `translatedReq`, so that receiver-side ID is a **phantom task** (no
+`TraceReqReceive` ever opens it) and leaked a registry entry per translation.
 
-**Verification.** Re-run the orphan query — `req_in`@TLB with a missing parent
-should drop to 0 (modulo any genuinely-untraced paths).
+**Fix.**
+- Reordered so `traceTranslationComplete` runs **before** `removeTransaction`.
+- Moved the bottom-send milestone onto the **top `req_in`**, matching the ROB
+  convention (Step 1) and the symmetric top-send milestone in `respond()`. The
+  AT `req_in` now records, in order: `translation`, `network_busy` (Bottom),
+  `data`/`subtask`, `network_busy` (Top). With the `req_out`/`req_in` lifecycle
+  and the global `incoming_queue` subtask (Step 0), the AT data path is now
+  fully instrumented.
+- Tests: new `mem/vm/addresstranslator/milestone_test.go` drives read/write
+  round trips through a recording tracer, asserting the ordered milestone set on
+  one shared `req_in` task and that completing a non-last transaction finalizes
+  its **own** translation `req_out`. Both assertions fail against the pre-fix
+  code.
+
+**Verified** by the new unit tests (`go test ./mem/vm/addresstranslator/...`,
+`go vet`, golangci-lint clean). Remaining integration check: re-run the orphan
+query — `req_in`@TLB with a missing parent should drop to 0 (modulo any
+genuinely-untraced paths).
+
+**Note.** The AT `handleReset` task leak is the AT instance of Step 3 (systemic,
+shared helper) and is intentionally deferred there, not fixed here.
 
 **Severity/effort.** SEV-1 (normal-run corruption), confirmed; small.
 
@@ -232,18 +254,19 @@ only at true source/destination; or (b) connection-level hooks. Decide scope
 ## Suggested order
 
 1. **Step 1** (ROB milestones) — **DONE**; the original goal, self-contained.
-2. **Step 2** (AT stale-pointer) — *next*; quick, confirmed correctness win;
-   improves the quality of every translation trace including the ROB's.
-3. **Step 3** (reset-leak helper) — highest leverage; one shared fix for 11
-   components.
+2. **Step 2** (AT stale-pointer + phantom milestone) — **DONE**; quick,
+   confirmed correctness win; improves the quality of every translation trace
+   including the ROB's.
+3. **Step 3** (reset-leak helper) — *next*; highest leverage; one shared fix for
+   11 components (includes the deferred AT `handleReset` leak).
 4. **Step 4** (per-component SEV-1) — normal-run correctness.
 5. **Step 5** (milestone/tag rollout) — coverage, incremental.
 6. **Step 6** (network-transfer subtask) — the remaining architectural phase.
 
 ## Confidence notes
 
-- Step 0 (#2) and Step 2 (AT bug) are **empirically confirmed** on a traced
-  `virtualmem` run.
+- Step 0 (#2) and the Step 2 (AT bug) diagnosis are **empirically confirmed** on
+  a traced `virtualmem` run; Step 2 is now fixed and covered by unit tests.
 - The reset-leak *pattern* is confirmed where exercised; the mmuCache/gmmu/
   datamover bugs (Step 4) are **high-confidence static findings** —
   `virtualmem`'s hierarchy does not instantiate those components, so confirm

--- a/mem/vm/addresstranslator/milestone_test.go
+++ b/mem/vm/addresstranslator/milestone_test.go
@@ -1,0 +1,280 @@
+package addresstranslator
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/mem/vm"
+	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+)
+
+// traceRecorder captures the full trace event stream the address translator
+// emits — task starts/ends, milestones, and tags — in emission order and
+// without the DBTracer's dedup, so a test can assert the exact ordered set of
+// milestones and which req_out tasks are finalized.
+type traceRecorder struct {
+	tracing.NopTracer
+	starts     []tracing.TaskStart
+	ends       []tracing.TaskEnd
+	milestones []tracing.Milestone
+	tags       []tracing.TaskTag
+}
+
+func (r *traceRecorder) StartTask(t tracing.TaskStart) {
+	r.starts = append(r.starts, t)
+}
+
+func (r *traceRecorder) EndTask(t tracing.TaskEnd) {
+	r.ends = append(r.ends, t)
+}
+
+func (r *traceRecorder) AddMilestone(m tracing.Milestone) {
+	r.milestones = append(r.milestones, m)
+}
+
+func (r *traceRecorder) AddTaskTag(t tracing.TaskTag) {
+	r.tags = append(r.tags, t)
+}
+
+func (r *traceRecorder) kinds() []tracing.MilestoneKind {
+	ks := make([]tracing.MilestoneKind, len(r.milestones))
+	for i, m := range r.milestones {
+		ks[i] = m.Kind
+	}
+
+	return ks
+}
+
+func (r *traceRecorder) endedIDs() []uint64 {
+	ids := make([]uint64, len(r.ends))
+	for i, e := range r.ends {
+		ids[i] = e.ID
+	}
+
+	return ids
+}
+
+// reqInTaskID returns the ID of the recorded req_in task start, or 0 if none.
+func (r *traceRecorder) reqInTaskID() uint64 {
+	for _, s := range r.starts {
+		if s.Kind == "req_in" {
+			return s.ID
+		}
+	}
+
+	return 0
+}
+
+var _ = Describe("Address Translator milestones", func() {
+	var (
+		engine          timing.Engine
+		at              *Comp
+		topPort         messaging.Port
+		bottomPort      messaging.Port
+		translationPort messaging.Port
+		ptMW            *parseTranslateMW
+		rpMW            *respondPipelineMW
+		rec             *traceRecorder
+	)
+
+	BeforeEach(func() {
+		engine = timing.NewSerialEngine()
+
+		spec := DefaultSpec()
+		spec.Log2PageSize = 12
+		spec.Freq = 1
+
+		resources := Resources{
+			MemProviderMapper: &mem.SinglePortMapper{
+				Port: messaging.RemotePort("MemPort"),
+			},
+			TranslationProviderMapper: &mem.SinglePortMapper{
+				Port: messaging.RemotePort("TranslationProvider"),
+			},
+		}
+
+		reg := modeling.NewStandaloneRegistrar(engine)
+		at = MakeBuilder().
+			WithRegistrar(reg).
+			WithSpec(spec).
+			WithResources(resources).
+			Build("AddressTranslator")
+
+		assignPorts(reg, at, topBufSize)
+
+		topPort = at.GetPortByName("Top")
+		bottomPort = at.GetPortByName("Bottom")
+		translationPort = at.GetPortByName("Translation")
+		ctrlPort := at.GetPortByName("Control")
+
+		for _, p := range []messaging.Port{
+			topPort, bottomPort, translationPort, ctrlPort,
+		} {
+			conn := &noopConn{}
+			conn.PlugIn(p)
+		}
+
+		ptMW = at.Middlewares()[1].(*parseTranslateMW)
+		rpMW = at.Middlewares()[2].(*respondPipelineMW)
+
+		// Attach the recorder before driving so MsgIDAtReceiver hands out
+		// real receiver-side task IDs (it returns 0 when there are no hooks).
+		rec = &traceRecorder{}
+		tracing.CollectTrace(at, rec)
+	})
+
+	makeRead := func(addr uint64) memprotocol.ReadReq {
+		req := memprotocol.ReadReq{Address: addr, AccessByteSize: 4}
+		req.ID = timing.GetIDGenerator().Generate()
+		req.Src = messaging.RemotePort("Agent")
+		req.Dst = topPort.AsRemote()
+		req.TrafficBytes = 12
+		req.TrafficClass = "memprotocol.ReadReq"
+		return req
+	}
+
+	makeWrite := func(addr uint64, data []byte) memprotocol.WriteReq {
+		req := memprotocol.WriteReq{Address: addr, Data: data}
+		req.ID = timing.GetIDGenerator().Generate()
+		req.Src = messaging.RemotePort("Agent")
+		req.Dst = topPort.AsRemote()
+		req.TrafficBytes = len(data) + 12
+		req.TrafficClass = "memprotocol.WriteReq"
+		return req
+	}
+
+	// driveRoundTrip pushes one request through the whole translator: admit
+	// and send the translation (translate), receive the translation and
+	// forward downstream (parseTranslation), then receive the bottom response
+	// and reply upstream (respond). bottomRsp builds the bottom-side response
+	// given the translated request's ID.
+	driveRoundTrip := func(
+		req memprotocol.AccessReq,
+		bottomRsp func(rspTo uint64) messaging.Msg,
+	) {
+		topPort.Deliver(req)
+		Expect(ptMW.translate()).To(BeTrue())
+
+		transReqID := at.State.Transactions[0].TranslationReqID
+		translationPort.RetrieveOutgoing()
+
+		transRsp := vmprotocol.TranslationRsp{
+			Page: vm.Page{PID: 1, VAddr: 0x10000, PAddr: 0x20000},
+		}
+		transRsp.ID = timing.GetIDGenerator().Generate()
+		transRsp.RspTo = transReqID
+		transRsp.TrafficClass = "vmprotocol.TranslationRsp"
+		translationPort.Deliver(transRsp)
+		Expect(rpMW.parseTranslation()).To(BeTrue())
+
+		bottomReqID := at.State.InflightReqToBottom[0].ReqToBottomID
+		bottomPort.RetrieveOutgoing()
+
+		bottomPort.Deliver(bottomRsp(bottomReqID))
+		Expect(rpMW.respond()).To(BeTrue())
+
+		topPort.RetrieveOutgoing()
+	}
+
+	It("records the four top-req_in milestones for a read on one task", func() {
+		driveRoundTrip(makeRead(0x10040), func(rspTo uint64) messaging.Msg {
+			rsp := memprotocol.DataReadyRsp{Data: []byte{1, 2, 3, 4}}
+			rsp.ID = timing.GetIDGenerator().Generate()
+			rsp.RspTo = rspTo
+			rsp.TrafficClass = "memprotocol.DataReadyRsp"
+			return rsp
+		})
+
+		Expect(rec.kinds()).To(Equal([]tracing.MilestoneKind{
+			tracing.MilestoneKindTranslation,
+			tracing.MilestoneKindNetworkBusy,
+			tracing.MilestoneKindData,
+			tracing.MilestoneKindNetworkBusy,
+		}))
+
+		Expect(rec.milestones[0].What).To(Equal("translation"))
+		Expect(rec.milestones[1].What).To(Equal(bottomPort.Name()))
+		Expect(rec.milestones[2].What).To(Equal("data"))
+		Expect(rec.milestones[3].What).To(Equal(topPort.Name()))
+
+		// Every milestone addresses the same non-zero req_in task — in
+		// particular the bottom network-busy milestone is on the top req_in,
+		// not on a phantom keyed by the downstream request's receiver ID.
+		taskID := rec.reqInTaskID()
+		Expect(taskID).ToNot(BeZero())
+		for _, m := range rec.milestones {
+			Expect(m.TaskID).To(Equal(taskID))
+		}
+	})
+
+	It("distinguishes a write with a subtask milestone", func() {
+		driveRoundTrip(
+			makeWrite(0x10040, []byte{1, 2, 3, 4}),
+			func(rspTo uint64) messaging.Msg {
+				rsp := memprotocol.WriteDoneRsp{}
+				rsp.ID = timing.GetIDGenerator().Generate()
+				rsp.RspTo = rspTo
+				rsp.TrafficClass = "memprotocol.WriteDoneRsp"
+				return rsp
+			},
+		)
+
+		Expect(rec.kinds()).To(Equal([]tracing.MilestoneKind{
+			tracing.MilestoneKindTranslation,
+			tracing.MilestoneKindNetworkBusy,
+			tracing.MilestoneKindSubTask,
+			tracing.MilestoneKindNetworkBusy,
+		}))
+
+		taskID := rec.reqInTaskID()
+		Expect(taskID).ToNot(BeZero())
+		for _, m := range rec.milestones {
+			Expect(m.TaskID).To(Equal(taskID))
+		}
+	})
+
+	It("finalizes the completing transaction's translation req_out, "+
+		"not a later transaction shifted into its slot", func() {
+		// Two in-flight transactions; complete the first (non-last) one. The
+		// removeTransaction append-shift must not redirect the trace finalize
+		// to the surviving transaction shifted into the freed slot.
+		transReq1ID := timing.GetIDGenerator().Generate()
+		transReq2ID := timing.GetIDGenerator().Generate()
+
+		req := makeRead(0x10040)
+
+		at.State = State{
+			Transactions: []transactionState{
+				{
+					TranslationReqID:  transReq1ID,
+					TranslationReqSrc: translationPort.AsRemote(),
+					TranslationReqDst: messaging.RemotePort("TranslationProvider"),
+					IncomingReqs: []incomingReqState{
+						msgToIncomingReqState(req),
+					},
+					TranslationDone: true,
+				},
+				{TranslationReqID: transReq2ID},
+			},
+		}
+
+		transRsp := vmprotocol.TranslationRsp{
+			Page: vm.Page{PID: 1, VAddr: 0x10000, PAddr: 0x20000},
+		}
+		transRsp.ID = timing.GetIDGenerator().Generate()
+		transRsp.RspTo = transReq1ID
+		transRsp.TrafficClass = "vmprotocol.TranslationRsp"
+		translationPort.Deliver(transRsp)
+
+		Expect(rpMW.parseTranslation()).To(BeTrue())
+
+		Expect(rec.endedIDs()).To(ContainElement(transReq1ID))
+		Expect(rec.endedIDs()).NotTo(ContainElement(transReq2ID))
+	})
+})

--- a/mem/vm/addresstranslator/respondpipelinemw.go
+++ b/mem/vm/addresstranslator/respondpipelinemw.go
@@ -93,37 +93,52 @@ func (m *respondPipelineMW) parseTranslation() bool {
 		nextState.InflightReqToBottom, reqToBot)
 	nextTrans.IncomingReqs = nextTrans.IncomingReqs[1:]
 
+	// Trace before removeTransaction. traceTranslationComplete reads the
+	// translation identity through nextTrans; removeTransaction's
+	// append-shift would leave nextTrans pointing at a different (or no)
+	// transaction, finalizing the wrong translation req_out and orphaning
+	// the correct one's children.
+	m.traceTranslationComplete(nextTrans, reqState, translatedReq)
+
 	if len(nextTrans.IncomingReqs) == 0 {
 		removeTransaction(nextState, transIdx)
 	}
-
-	m.traceTranslationComplete(nextTrans, reqState, translatedReq)
 
 	m.translationPort().RetrieveIncoming()
 
 	return true
 }
 
-// traceTranslationComplete records tracing milestones for a completed
-// translation and initiates the downstream request trace.
+// traceTranslationComplete records, on the top req_in task, the milestones
+// for a completed translation (the translation resolving, then the
+// network-busy wait to push the translated request downstream), finalizes
+// the translation req_out, and initiates the downstream (translated)
+// req_out parented to the top req_in. trans must still be live in
+// State.Transactions — the caller invokes this before removeTransaction so
+// the translation identity reads from the correct transaction.
 func (m *respondPipelineMW) traceTranslationComplete(
 	trans *transactionState,
 	reqState incomingReqState,
 	translatedReq messaging.Msg,
 ) {
-	tracing.AddMilestone(m.comp, tracing.Milestone{
-		TaskID: tracing.MsgIDAtReceiver(translatedReq, m.comp),
-		Kind:   tracing.MilestoneKindNetworkBusy,
-		What:   m.bottomPort().Name(),
-	})
-
 	fakeFromTop := restoreMemMsg(reqState.ID, reqState.Src, reqState.Dst,
 		reqState.RspTo, reqState.Type)
+	topTaskID := tracing.MsgIDAtReceiver(fakeFromTop, m.comp)
 
 	tracing.AddMilestone(m.comp, tracing.Milestone{
-		TaskID: tracing.MsgIDAtReceiver(fakeFromTop, m.comp),
+		TaskID: topTaskID,
 		Kind:   tracing.MilestoneKindTranslation,
 		What:   "translation",
+	})
+
+	// The translated request leaves through the Bottom port; this
+	// network-busy wait belongs to the top req_in, not to the downstream
+	// req_out (which this component sends, so its receiver-side ID would
+	// be a phantom task).
+	tracing.AddMilestone(m.comp, tracing.Milestone{
+		TaskID: topTaskID,
+		Kind:   tracing.MilestoneKindNetworkBusy,
+		What:   m.bottomPort().Name(),
 	})
 
 	fakeTransReq := vmprotocol.TranslationReq{
@@ -134,8 +149,7 @@ func (m *respondPipelineMW) traceTranslationComplete(
 		},
 	}
 	tracing.TraceReqFinalize(m.comp, fakeTransReq)
-	tracing.TraceReqInitiate(m.comp, translatedReq,
-		tracing.MsgIDAtReceiver(fakeFromTop, m.comp))
+	tracing.TraceReqInitiate(m.comp, translatedReq, topTaskID)
 }
 
 //nolint:funlen,gocyclo


### PR DESCRIPTION
## What

Tracing instrumentation plan **Step 2** — fix the address-translator stale-pointer finalize bug — plus a second AT instrumentation defect surfaced while making the component **fully instrumented**.

### 1. Stale-pointer translation finalize (Step 2, SEV-1)

`parseTranslation` called `removeTransaction` (an `append`-shift) **before** `traceTranslationComplete` read the translation identity (`TranslationReqID/Src/Dst`) through the transaction pointer. When the completing transaction was **not last** in the queue, the shift left the pointer on a *different* transaction, so `TraceReqFinalize` ended the **wrong** translation `req_out`; the correct one never ended and its TLB `req_in`/`incoming_queue` children were orphaned (empirically ~11 per short run). When it *was* last, the old value lingered in the backing array, which is why it only corrupted non-last completions.

Fix: trace **before** `removeTransaction`, so the read sees the correct transaction.

### 2. Bottom-send milestone on a phantom task

The bottom-send `network_busy` milestone was keyed off `MsgIDAtReceiver(translatedReq)`. But this component *sends* `translatedReq`, so its receiver-side ID is a **phantom task** — no `TraceReqReceive` ever opens it — and it leaked a registry entry per translation. Moved it onto the **top `req_in`**, matching the ROB convention (Step 1) and the symmetric top-send milestone already in `respond()`.

The AT `req_in` now records, in order: `translation` → `network_busy(Bottom)` → `data`/`subtask` → `network_busy(Top)`, all on one task. With the `req_out`/`req_in` lifecycle and the global `incoming_queue` subtask (Step 0), the AT data path is now fully and correctly instrumented.

## Test

New `mem/vm/addresstranslator/milestone_test.go` (mirrors the ROB `milestone_test.go`):
- read & write round trips assert the exact ordered milestone set on **one shared `req_in` task** (catches the phantom-task regression);
- completing a **non-last** transaction asserts its **own** translation `req_out` is finalized (catches the stale pointer).

Both assertions were confirmed to fail against the pre-fix code and pass after. `go test ./mem/vm/addresstranslator/...`, `go vet`, and `golangci-lint` are clean.

## Out of scope

The AT `handleReset` task leak (clears in-flight state without ending open tasks / forgetting registry entries) is the AT instance of **plan Step 3** — a systemic, 11-component fix the plan wants done via one shared helper, so it is intentionally deferred there rather than hand-rolled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)