### PR TITLE
daisen2/httpapi: add code_ls source-browsing tool for DaisenBot

### DIFF
--- a/daisen2/internal/httpapi/agentloop.go
+++ b/daisen2/internal/httpapi/agentloop.go
@@ -566,6 +566,7 @@ func (s *Server) runAgentSSE(
 		dataQueryTool(s.traceReader),
 		codeSearchTool(s.codeSource),
 		codeReadTool(s.codeSource),
+		codeLsTool(s.codeSource),
 		daisenViewTool(capture),
 		screenshotTool(capture),
 	}

--- a/daisen2/internal/httpapi/codetools.go
+++ b/daisen2/internal/httpapi/codetools.go
@@ -29,6 +29,9 @@ const (
 	codeReadDefaultLines = 200
 	codeReadMaxLines     = 400
 	codeReadMaxBytes     = 24 << 10
+
+	codeLsMaxEntries = 300
+	codeLsMaxBytes   = 16 << 10
 )
 
 const noSourceRecorded = "No simulator source is recorded in this trace, so code " +
@@ -261,6 +264,187 @@ func renderReadWindow(clean string, lines []string, from, to int) string {
 		fmt.Fprintf(&b, "[%d more lines; pass start_line/end_line to read further]\n", total-to)
 	}
 	return b.String()
+}
+
+func codeLsTool(src *sourcefs.Source) agentTool {
+	return agentTool{
+		name: "code_ls",
+		description: "Browse the directory tree of the simulator source recorded in this trace: " +
+			"list the immediate sub-directories and files under a directory. Call with an empty " +
+			"path to see the recorded module roots, then pass a path (as shown by code_search or " +
+			"a previous code_ls) to list one directory. Directories end with \"/\"; files show " +
+			"their line and byte counts. Use this to discover what exists and learn the layout " +
+			"before reading, instead of guessing paths.",
+		parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"reason": map[string]interface{}{
+					"type":        "string",
+					"description": "One sentence: what you are looking for and why. Shown to the user.",
+				},
+				"path": map[string]interface{}{
+					"type": "string",
+					"description": "Optional directory to list (FS-relative, as shown by code_search " +
+						"or code_ls). Empty or omitted lists the recorded module roots.",
+				},
+			},
+			"required": []string{"reason"},
+		},
+		run: func(_ context.Context, args map[string]interface{}) (toolResult, error) {
+			p, _ := args["path"].(string)
+			out, err := runCodeLs(src, p)
+			return toolResult{text: out}, err
+		},
+	}
+}
+
+func runCodeLs(src *sourcefs.Source, p string) (string, error) {
+	if src.IsEmpty() {
+		return noSourceRecorded, nil
+	}
+
+	p = strings.TrimSpace(p)
+	p = strings.TrimPrefix(p, "./")
+	p = strings.TrimSuffix(p, "/")
+
+	fsys := src.FS()
+	if p == "" || p == "." {
+		// The recorded FS is a deep single-child chain (github.com/sarchlab/…), so
+		// listing "." literally would just show "github.com/". Surface the recorded
+		// module roots directly — that is what "the top-level directories" means here.
+		if roots := nonEmptyRoots(src.Roots); len(roots) > 0 {
+			return formatRootListing(roots), nil
+		}
+		return listDir(fsys, "."), nil // roots unknown/blank: fall back to the real root
+	}
+
+	clean := path.Clean(p)
+	if !fs.ValidPath(clean) {
+		return "", fmt.Errorf("invalid path %q", p)
+	}
+
+	info, err := fs.Stat(fsys, clean)
+	if err != nil {
+		return fmt.Sprintf("Directory not found: %q. Use code_search to find a path, or call "+
+			"code_ls with no path to see the recorded roots (%v).", p, src.Roots), nil
+	}
+	if !info.IsDir() {
+		return fmt.Sprintf("%s is a file, not a directory. Use code_read to read it.", clean), nil
+	}
+	return listDir(fsys, clean), nil
+}
+
+// listDir renders the immediate entries under dir: directories first (trailing
+// "/"), then files annotated with line and byte counts, bounded by the entry and
+// byte caps so a large directory can never flood the model context.
+func listDir(fsys fs.FS, dir string) string {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return fmt.Sprintf("Could not list %s: %v.", dir, err)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		di, dj := entries[i].IsDir(), entries[j].IsDir()
+		if di != dj {
+			return di // directories before files
+		}
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	totalDirs, totalFiles := 0, 0
+	for _, e := range entries {
+		if e.IsDir() {
+			totalDirs++
+		} else {
+			totalFiles++
+		}
+	}
+
+	var body strings.Builder
+	truncated := false
+	shown := 0
+	for _, e := range entries {
+		if shown >= codeLsMaxEntries {
+			truncated = true
+			break
+		}
+		var line string
+		if e.IsDir() {
+			line = e.Name() + "/\n"
+		} else {
+			line = fmt.Sprintf("%s\t%s\n", e.Name(), fileAnnotation(fsys, path.Join(dir, e.Name())))
+		}
+		if body.Len()+len(line) > codeLsMaxBytes {
+			truncated = true
+			break
+		}
+		body.WriteString(line)
+		shown++
+	}
+
+	label := dir
+	if label == "." {
+		label = "(root)"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s — %d dir(s), %d file(s):\n", label, totalDirs, totalFiles)
+	b.WriteString(body.String())
+	if truncated {
+		b.WriteString("[truncated — list a sub-directory to narrow]\n")
+	}
+	return b.String()
+}
+
+// fileAnnotation returns "<n> lines, <size>" for a file, reading it once. A read
+// error degrades to "?" rather than failing the whole listing.
+func fileAnnotation(fsys fs.FS, p string) string {
+	data, err := fs.ReadFile(fsys, p)
+	if err != nil {
+		return "?"
+	}
+	return fmt.Sprintf("%d lines, %s", countLines(data), humanBytes(len(data)))
+}
+
+func formatRootListing(roots []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Recorded module root(s) — %d; pass one as the path to browse it:\n", len(roots))
+	for _, r := range roots {
+		fmt.Fprintf(&b, "%s/\n", r)
+	}
+	return b.String()
+}
+
+func nonEmptyRoots(roots []string) []string {
+	out := make([]string, 0, len(roots))
+	for _, r := range roots {
+		if strings.TrimSpace(r) != "" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// countLines counts lines the same way splitLines does: a trailing newline does
+// not add a phantom final line.
+func countLines(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	n := bytes.Count(data, []byte{'\n'})
+	if data[len(data)-1] != '\n' {
+		n++ // last line has no trailing newline
+	}
+	return n
+}
+
+func humanBytes(n int) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }
 
 func sortedFilePaths(fsys fs.FS) []string {

--- a/daisen2/internal/httpapi/codetools_test.go
+++ b/daisen2/internal/httpapi/codetools_test.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -140,6 +141,86 @@ func TestCodeReadDefaultWindowTruncates(t *testing.T) {
 	}
 	if !strings.Contains(out, "more lines; pass start_line/end_line") {
 		t.Errorf("expected a 'more lines' note for a long file:\n%s", out[:min(len(out), 300)])
+	}
+}
+
+func TestCodeLs(t *testing.T) {
+	src := testSource(t, map[string]string{
+		"example.com/m/mem/cache/cache.go": "package cache\ntype Cache struct{}\n",
+		"example.com/m/mem/read.go":        "package mem\ntype ReadReq struct{}\n\nfunc handle() {}\n",
+		"example.com/m/mem/write.go":       "package mem\ntype WriteReq struct{}\n",
+		"example.com/m/noc/conn.go":        "package noc\n",
+	})
+
+	// Empty path lists the recorded module roots, not the github.com/... chain.
+	out, err := runCodeLs(src, "")
+	if err != nil {
+		t.Fatalf("runCodeLs root: %v", err)
+	}
+	if !strings.Contains(out, "example.com/m/") {
+		t.Errorf("root listing should show the recorded root:\n%s", out)
+	}
+
+	// Listing a directory shows sub-directories (trailing /) and files with counts.
+	out, err = runCodeLs(src, "example.com/m/mem")
+	if err != nil {
+		t.Fatalf("runCodeLs dir: %v", err)
+	}
+	if !strings.Contains(out, "cache/") {
+		t.Errorf("expected sub-directory cache/ marked as a directory:\n%s", out)
+	}
+	if !strings.Contains(out, "read.go\t4 lines, ") || !strings.Contains(out, "write.go\t2 lines, ") {
+		t.Errorf("expected files annotated with line counts:\n%s", out)
+	}
+	// Directories sort before files.
+	if strings.Index(out, "cache/") > strings.Index(out, "read.go") {
+		t.Errorf("directories should be listed before files:\n%s", out)
+	}
+
+	// A file path is reported (not an error), steering to code_read.
+	out, _ = runCodeLs(src, "example.com/m/mem/read.go")
+	if !strings.Contains(out, "is a file") {
+		t.Errorf("expected file-not-a-directory message:\n%s", out)
+	}
+
+	// A missing directory is reported, not an error.
+	out, _ = runCodeLs(src, "example.com/m/nope")
+	if !strings.Contains(out, "not found") {
+		t.Errorf("expected not-found message:\n%s", out)
+	}
+
+	// Invalid traversal path is rejected.
+	if _, err := runCodeLs(src, "../escape"); err == nil {
+		t.Errorf("expected error for traversal path")
+	}
+}
+
+func TestCodeLsCapsEntries(t *testing.T) {
+	files := map[string]string{}
+	for i := 0; i < codeLsMaxEntries+50; i++ {
+		files[fmt.Sprintf("example.com/m/big/f%04d.go", i)] = "package big\n"
+	}
+	src := testSource(t, files)
+
+	out, err := runCodeLs(src, "example.com/m/big")
+	if err != nil {
+		t.Fatalf("runCodeLs: %v", err)
+	}
+	if !strings.Contains(out, "truncated") {
+		t.Errorf("expected truncation note for a flood of entries:\n%s", out[:min(len(out), 400)])
+	}
+	if got := strings.Count(out, ".go\t"); got > codeLsMaxEntries {
+		t.Errorf("listed %d files, want <= %d", got, codeLsMaxEntries)
+	}
+}
+
+func TestCodeLsEmptySource(t *testing.T) {
+	out, err := runCodeLs(&sourcefs.Source{}, "")
+	if err != nil {
+		t.Fatalf("runCodeLs: %v", err)
+	}
+	if !strings.Contains(out, "No simulator source is recorded") {
+		t.Errorf("expected no-source message, got:\n%s", out)
 	}
 }
 

--- a/daisen2/internal/httpapi/prompt_test.go
+++ b/daisen2/internal/httpapi/prompt_test.go
@@ -14,7 +14,7 @@ func TestAgentSystemPromptEmbedded(t *testing.T) {
 	// The prompt must document every tool the agent is offered so the model knows
 	// they exist and when to reach for them.
 	for _, want := range []string{
-		"DaisenBot", "data_query", "code_search", "code_read",
+		"DaisenBot", "data_query", "code_search", "code_read", "code_ls",
 		"daisen_view", "screenshot_current_view",
 	} {
 		if !strings.Contains(agentSystemPrompt, want) {

--- a/daisen2/internal/httpapi/prompts/agent_system.md
+++ b/daisen2/internal/httpapi/prompts/agent_system.md
@@ -128,16 +128,22 @@ rows are rarely the answer.
 
 `data_query` tells you **what** happened in the trace.
 
-### `code_search` / `code_read` — read the simulator source
+### `code_ls` / `code_search` / `code_read` — read the simulator source
 
 The source code that produced the trace may be recorded inside the trace itself —
 the Akita library by default, and possibly the specific simulator's own components.
 Use it to learn what a trace label actually *means*:
 
+- **`code_ls`** — browse the directory tree. Call with an empty path to see the
+  recorded module roots, then list a directory to discover what packages and files
+  exist before reading. Directories end with `/`; files show line and byte counts.
 - **`code_search`** — regex search across the recorded source. Find where a `Kind`,
   a milestone name, the Go type behind a `What` value (e.g. `ReadReq`), or a
   component is defined and used.
 - **`code_read`** — read a file, or a line range, to study the logic around a match.
+
+Browse with `code_ls` when you are unsure where something lives, then `code_search`
+to pinpoint it and `code_read` to study it.
 
 Reach for these whenever a `Kind`, milestone, message type, or component in the
 trace is unfamiliar: **read the source to ground your interpretation before
@@ -152,8 +158,9 @@ opted in. If a trace has no recorded source, `code_search` / `code_read` say so;
 that case fall back to general knowledge and state plainly that you could not consult
 the source for this trace.
 
-Where things live in the Akita source (a starting map — search to confirm; recorded
-paths are prefixed with the module, e.g. `github.com/sarchlab/akita/v5/mem/cache/…`):
+Where things live in the Akita source (a starting map — `code_ls` to browse and
+`code_search` to confirm; recorded paths are prefixed with the module, e.g.
+`github.com/sarchlab/akita/v5/mem/cache/…`):
 
 - **Memory components** — `mem/`: caches in `mem/cache/` (`writeback`,
   `writethroughcache`), DRAM in `mem/dram/`, MSHRs in `mem/mshr/`, reorder buffer in


### PR DESCRIPTION
## Summary

Closes #401. Adds a `code_ls` directory-browsing tool for DaisenBot. The agent could already `code_search` (regex) and `code_read` (file/range) the simulator source recorded in a trace, but had no way to browse the directory tree — so it had to guess paths or grep blindly. `code_ls` lets it discover what packages/files exist and learn the layout before reading.

## What it does

- **Empty path** lists the recorded module roots. The recorded FS is a deep single-child chain (`github.com` → `sarchlab` → …), so listing `.` literally would only show `github.com/`; surfacing the roots is what "the top-level directories" means here.
- **A directory path** lists its immediate entries: directories first (trailing `/`), then files annotated with **line and byte counts** (e.g. `mshr.go  120 lines, 3.4 KB`).
- Same availability and capping semantics as the sibling code tools: the no-source message when a trace has no recorded source, and entry/byte caps so a large directory can't flood the model context.
- A file path or a missing directory returns a steering message (use `code_read` / `code_search`), not an error.

## Also

- Registers the tool in the agent loop.
- Documents `code_ls` in the agent system prompt (browse → search → read), and backs the "Where things live in the Akita source" map with it.

## Tests

`go build ./...`, `go vet`, and `gofmt` are clean. New `TestCodeLs`, `TestCodeLsCapsEntries`, and `TestCodeLsEmptySource` cover root-lists-roots, dirs-before-files with line counts, file/not-found steering, traversal rejection, entry-cap truncation, and the empty-source path. Full `httpapi` and `sourcefs` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)