### PR TITLE
tracing: end in-flight tasks on Reset across all mem components

### DIFF
--- a/TRACING_INSTRUMENTATION_PLAN.md
+++ b/TRACING_INSTRUMENTATION_PLAN.md
@@ -185,7 +185,7 @@ shared helper) and is intentionally deferred there, not fixed here.
 
 ---
 
-## Step 3 — Systemic fix: stop `handleReset` leaking in-flight tasks
+## Step 3 — Systemic fix: stop `handleReset` leaking in-flight tasks — DONE
 
 **Objective.** Eliminate the most widespread defect: every stateful component
 clears its in-flight container on Reset without ending open `req_in`/`req_out`
@@ -193,22 +193,49 @@ clears its in-flight container on Reset without ending open `req_in`/`req_out`
 started-never-ended tasks and slow registry growth whenever a Reset races
 traffic. (Drain paths are already clean — they let work finish.)
 
-**Scope (11 components).** `handleReset` in:
-`mem/rob/middleware.go:393`, `mem/vm/tlb/ctrlmiddleware.go:228`,
-`mem/vm/addresstranslator/ctrlmiddleware.go`, `mem/cache/writeback/ctrlmiddleware.go:237`,
-`mem/cache/writethroughcache/ctrlmiddleware.go:140`, `mem/datamover/ctrlmiddleware.go:124`,
-`mem/vm/mmu/ctrlmiddleware.go:124`, `mem/vm/gmmu/ctrlmiddleware.go`,
-`mem/dram/ctrlmiddleware.go:125`, `mem/idealmemcontroller/ctrlmiddleware.go:123`,
-`mem/simplebankedmemory/ctrlmiddleware.go:128`.
+**Delivered.** Two shared helpers in the tracing package converge all sites on
+one pattern:
 
-**Approach.** Before clearing state, iterate the in-flight work and
-`EndTask` + `ForgetMsgIDAtReceiver` each open task (mirroring the normal
-completion path). Prefer a small shared helper so all 11 sites converge on one
-correct pattern rather than 11 hand-rolled versions.
+- `tracing.EndReqInOnReset(domain, reqMsgID)` — resolves the receiver-side
+  (`req_in`) task ID for the request's message ID via a new lookup-only registry
+  accessor (`receiverTaskIDByMsgID`, no create), then `EndTask` + forgets the
+  entry. Mirrors `TraceReqComplete` but takes the message ID, which is all a
+  reset path retains. No-op when untraced or no task is registered.
+- `tracing.EndTaskOnReset(domain, taskID)` — `EndTask` by literal task ID, for
+  every task keyed on its own ID rather than the receiver registry: a downstream
+  `req_out` (like `TraceReqFinalize`), a DRAM sub-trans, a writethrough
+  `cache_transaction`, or a pipeline subtask. The `DBTracer` ignores ends for
+  IDs it never saw start, so a caller may blanket-end every task a transaction
+  could hold without tracking which were actually opened.
 
-**Verification.** A control-contract-style test that issues `Reset` with
-in-flight traffic and asserts the `DBTracer` has no unended tasks and an empty
-receiver registry afterward.
+Each component grew an `endInflightTasks()` method, called in `handleReset`
+**before** the in-flight container is cleared. Because `RecvTaskID ==
+MsgIDAtReceiver(reqMsgID)` (same registry key), even the components that store
+the task ID directly (mmu/gmmu/ideal) use the message-ID form, so all 11 are
+uniform.
+
+**Applied to all 12 sites** (`endInflightTasks` in each): `mem/rob/middleware.go`
+(replaced the old forget-only `forgetInflightReceiverIDs`, which never `EndTask`ed
+the `req_in` nor finalized the shadow `req_out`), `mem/vm/tlb`,
+`mem/vm/addresstranslator`, `mem/cache/writeback`, `mem/cache/writethroughcache`,
+`mem/datamover`, `mem/vm/mmu`, `mem/vm/gmmu`, `mem/dram`, `mem/idealmemcontroller`,
+`mem/simplebankedmemory`, and `mem/vm/mmuCache` (its existing `endInflightReqs`
+refactored onto the shared helpers, dropping the throwaway-message
+reconstruction). Beyond the plan's `req_in`/`req_out`/sub-trans, the rollout also
+ends the **subtask tiers** the cross-component audit surfaced: TLB/writeback/
+simplebanked pipeline subtasks and the writethrough `cache_transaction`.
+
+**Verified.** A `TestResetEndsInflightTracingTasks` in every component drives a
+request into flight (response withheld), issues `Reset`, and asserts a
+`tracingtest.LeakRecorder` (new shared helper) shows zero started-never-ended
+tasks. Several were negative-control checked (neutering `endInflightTasks` makes
+the test fail with the exact leaked kinds). Coverage spans every shape: leaf
+`req_in` (mmu/ideal), `req_in`+`req_out` (rob/datamover/AT/mmuCache/gmmu —
+gmmu reaches the remote-fetch path), sub-trans (dram), pipeline subtask
+(simplebanked/tlb), and the three-tier writethrough (`req_in` +
+`cache_transaction` + `req_out`). Plus `tracing/reset_test.go` unit-tests the two
+helpers directly. `go test ./tracing/... ./mem/...`, `go vet`, golangci-lint all
+clean.
 
 **Severity/effort.** SEV-2 (rare trigger) but highest leverage; medium.
 
@@ -328,17 +355,20 @@ only at true source/destination; or (b) connection-level hooks. Decide scope
 2. **Step 2** (AT stale-pointer + phantom milestone) — **DONE**; quick,
    confirmed correctness win; improves the quality of every translation trace
    including the ROB's.
-3. **Step 3** (reset-leak helper) — *next*; highest leverage; one shared fix for
-   11 components (includes the deferred AT `handleReset` leak).
-4. **Step 4** (per-component SEV-1) — normal-run correctness.
-5. **Step 5** (milestone/tag rollout) — coverage, incremental.
+3. **Step 3** (reset-leak helper) — **DONE**; highest leverage; one shared fix
+   across all 12 sites (includes the deferred AT `handleReset` leak).
+4. **Step 4** (per-component SEV-1) — *next*; normal-run correctness. Items 1 & 3
+   shipped in Step 5; the gmmu remote-path and endpoint `msg_e2e` defects remain.
+5. **Step 5** (milestone/tag rollout) — **DONE**; coverage, incremental.
 6. **Step 6** (network-transfer subtask) — the remaining architectural phase.
 
 ## Confidence notes
 
 - Step 0 (#2) and the Step 2 (AT bug) diagnosis are **empirically confirmed** on
   a traced `virtualmem` run; Step 2 is now fixed and covered by unit tests.
-- The reset-leak *pattern* is confirmed where exercised; the mmuCache/gmmu/
-  datamover bugs (Step 4) are **high-confidence static findings** —
-  `virtualmem`'s hierarchy does not instantiate those components, so confirm
-  with a scenario that does before/after fixing.
+- The reset-leak fix (Step 3) is now **verified per component** by a
+  `TestResetEndsInflightTracingTasks` that resets mid-flight traffic and asserts
+  no unended tasks (several negative-control checked).
+- The mmuCache/gmmu/datamover bugs (Step 4) are **high-confidence static
+  findings** — `virtualmem`'s hierarchy does not instantiate those components, so
+  confirm with a scenario that does before/after fixing.

--- a/mem/cache/writeback/ctrlmiddleware.go
+++ b/mem/cache/writeback/ctrlmiddleware.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sarchlab/akita/v5/mem/vm"
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 )
 
 // ctrlMiddleware owns every control verb except CmdFlush, which is
@@ -245,6 +246,7 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 	cache.DirectoryReset(
 		&next.DirectoryState, spec.NumSets, spec.WayAssociativity, blockSize)
 	next.MSHRState = cache.MSHRState{}
+	m.endInflightTasks()
 	next.Transactions = nil
 	next.EvictingList = map[uint64]bool{}
 
@@ -264,6 +266,38 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 		req.Src, req.ID, true, ""))
 	m.ctrlPort().RetrieveIncoming()
 	return true
+}
+
+// endInflightTasks completes the req_in tracing task of every in-flight
+// transaction, finalizes its downstream fetch and eviction-writeback req_out
+// tasks, and closes its directory-pipeline subtask, so a hard Reset that drops
+// the transaction table leaves no started-never-ended task and no leaked
+// receiver-registry entry. A slot already marked Removed can still hold an
+// in-flight eviction (its req_in long since completed), so every slot is
+// visited and the req_in end is idempotent. Mirrors bank/mshr-stage (req_in),
+// write-buffer stage (req_out), and the directory pipeline (subtask) completion.
+func (m *ctrlMiddleware) endInflightTasks() {
+	comp := m.pipeline.comp
+
+	for i := range comp.State.Transactions {
+		trans := &comp.State.Transactions[i]
+
+		if trans.HasRead || trans.HasWrite || trans.HasFlush {
+			tracing.EndReqInOnReset(comp, trans.reqMeta().ID)
+		}
+
+		if trans.HasFetchReadReq {
+			tracing.EndTaskOnReset(comp, trans.FetchReadReqMeta.ID)
+		}
+
+		if trans.HasEvictionWriteReq {
+			tracing.EndTaskOnReset(comp, trans.EvictionWriteReqMeta.ID)
+		}
+
+		if trans.DirPipelinePID != 0 {
+			tracing.EndTaskOnReset(comp, trans.DirPipelinePID)
+		}
+	}
 }
 
 // clearCachePipelinesAndBuffers empties every stage buffer, pipeline, and

--- a/mem/cache/writeback/reset_leak_test.go
+++ b/mem/cache/writeback/reset_leak_test.go
@@ -1,0 +1,122 @@
+package writeback
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks drives a read MISS into the writeback cache
+// so it opens a transaction and sends a fetch ReadReq out the Bottom port —
+// leaving the req_in, the fetch req_out, and the directory-pipeline subtask
+// open — then issues a Reset without answering the fetch and asserts every
+// task the transaction opened is ended. A mid-flight Reset that drops the
+// transaction table must leave no started-never-ended task (and no leaked
+// receiver-registry entry).
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+	storage := mem.NewStorage(1 * mem.MB)
+
+	spec := DefaultSpec()
+	spec.TotalByteSize = 64 * 1024
+	spec.NumBanks = 1
+	spec.NumMSHREntry = 16
+	spec.NumReqPerCycle = 4
+	spec.WayAssociativity = 2
+	spec.Log2BlockSize = 6
+	spec.BankLatency = 1
+	spec.DirLatency = 1
+
+	comp := MakeBuilder().
+		WithRegistrar(modeling.NewStandaloneRegistrar(engine)).
+		WithSpec(spec).
+		WithResources(Resources{
+			Storage: storage,
+			AddressToPortMapper: &mem.SinglePortMapper{
+				Port: messaging.RemotePort("LowerCache"),
+			},
+		}).
+		Build("L1Cache")
+
+	for _, name := range []string{"Top", "Bottom", "Control"} {
+		comp.AssignPort(name,
+			messaging.NewPort(comp, 16, 16, comp.Name()+"."+name))
+	}
+	topPort := comp.GetPortByName("Top")
+	botPort := comp.GetPortByName("Bottom")
+	ctrlPort := comp.GetPortByName("Control")
+	for _, p := range []messaging.Port{topPort, botPort, ctrlPort} {
+		(&ccNoopConn{}).PlugIn(p)
+	}
+
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(comp, rec)
+
+	// Deliver a read that MISSES: the cache opens a transaction and forwards a
+	// fetch ReadReq out the Bottom port. We never answer it, so req_in, the
+	// fetch req_out, and the directory-pipeline subtask stay open.
+	read := memprotocol.ReadReq{}
+	read.ID = timing.GetIDGenerator().Generate()
+	read.Src = messaging.RemotePort("Agent")
+	read.Dst = topPort.AsRemote()
+	read.Address = 0x10000
+	read.AccessByteSize = 4
+	read.TrafficBytes = 12
+	read.TrafficClass = "memprotocol.ReadReq"
+	topPort.Deliver(read)
+
+	// Tick until the fetch is in flight: a transaction with HasFetchReadReq.
+	// Do NOT answer the Bottom read; the request stays genuinely in flight.
+	inFlight := false
+	for i := 0; i < 64 && !inFlight; i++ {
+		comp.Tick()
+		for j := range comp.State.Transactions {
+			if comp.State.Transactions[j].HasFetchReadReq {
+				inFlight = true
+				break
+			}
+		}
+	}
+
+	if !inFlight {
+		t.Fatalf("expected an in-flight fetch transaction, none appeared")
+	}
+	if rec.NumStarted() < 2 {
+		t.Fatalf("expected req_in and fetch req_out to be opened, "+
+			"got %d task starts", rec.NumStarted())
+	}
+
+	// Reset while the fetch is in flight.
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = ctrlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	ctrlPort.Deliver(reset)
+
+	acked := false
+	for i := 0; i < 64 && !acked; i++ {
+		comp.Tick()
+		if msg := ctrlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/cache/writethroughcache/ctrlmiddleware.go
+++ b/mem/cache/writethroughcache/ctrlmiddleware.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sarchlab/akita/v5/mem/vm"
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 )
 
 // ctrlMiddleware owns every control verb: the universal verbs (Pause,
@@ -153,6 +154,7 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 		&next.DirectoryState, spec.NumSets, spec.WayAssociativity,
 		int(1<<spec.Log2BlockSize))
 	next.MSHRState = cache.MSHRState{}
+	m.endInflightTasks()
 	next.Transactions = nil
 	next.IsPaused = false
 	next.IsDraining = false
@@ -170,6 +172,44 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 		req.Src, req.ID, true, ""))
 	m.ctrlPort().RetrieveIncoming()
 	return true
+}
+
+// endInflightTasks completes the req_in tracing task of every in-flight
+// transaction, ends its cache_transaction task, finalizes its downstream
+// read/write req_out tasks, and closes its directory-pipeline subtask, so a hard
+// Reset that drops the transaction table leaves no started-never-ended task and
+// no leaked receiver-registry entry. A slot already marked Removed can still
+// hold a downstream write whose response will be ignored, so every slot is
+// visited and the already-ended req_in/cache_transaction ends are idempotent.
+// Mirrors respondStage (req_in), bankstage/bottomparser (cache_transaction),
+// bottomparser (req_out), and the directory pipeline (subtask) completion.
+func (m *ctrlMiddleware) endInflightTasks() {
+	comp := m.pipeline.comp
+
+	for i := range comp.State.Transactions {
+		trans := &comp.State.Transactions[i]
+
+		switch {
+		case trans.HasRead:
+			tracing.EndReqInOnReset(comp, trans.ReadMeta.ID)
+		case trans.HasWrite:
+			tracing.EndReqInOnReset(comp, trans.WriteMeta.ID)
+		}
+
+		tracing.EndTaskOnReset(comp, trans.ID)
+
+		if trans.HasReadToBottom {
+			tracing.EndTaskOnReset(comp, trans.ReadToBottomMeta.ID)
+		}
+
+		if trans.HasWriteToBottom {
+			tracing.EndTaskOnReset(comp, trans.WriteToBottomMeta.ID)
+		}
+
+		if trans.DirPipelineTaskID != 0 {
+			tracing.EndTaskOnReset(comp, trans.DirPipelineTaskID)
+		}
+	}
 }
 
 // handleInvalidate drops directory blocks matching the request's

--- a/mem/cache/writethroughcache/reset_leak_test.go
+++ b/mem/cache/writethroughcache/reset_leak_test.go
@@ -1,0 +1,144 @@
+package writethroughcache
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks drives a read miss into the writethrough
+// cache so the transaction has all three tiers of tracing tasks open — the
+// req_in for the top request, the cache_transaction, and the downstream
+// req_out for the bottom fetch — then issues a Reset and asserts every task is
+// ended. A mid-flight Reset drops the transaction table, so each started task
+// must be ended by endInflightTasks or it leaks (and, for a req_in, leaks a
+// receiver-registry entry too).
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+	storage := mem.NewStorage(4 * mem.GB)
+	reg := modeling.NewStandaloneRegistrar(engine)
+
+	spec := DefaultSpec()
+	spec.NumReqPerCycle = 1
+	spec.NumBanks = 1
+	spec.NumMSHREntry = 8
+	spec.WayAssociativity = 2
+	spec.Log2BlockSize = 6
+	spec.BankLatency = 1
+	spec.DirLatency = 1
+	spec.TotalByteSize = 64 * 1024
+	spec.MaxNumConcurrentTrans = 16
+
+	comp := MakeBuilder().
+		WithRegistrar(reg).
+		WithSpec(spec).
+		WithResources(Resources{
+			Storage: storage,
+			AddressMapper: &mem.SinglePortMapper{
+				Port: messaging.RemotePort("LowerCache"),
+			},
+		}).
+		Build("L1Cache")
+
+	// Build declares the ports; assign every declared port instance and plug
+	// each into a no-op connection before the component is ticked.
+	assign := func(name string) messaging.Port {
+		p := modeling.MakePortBuilder().
+			WithRegistrar(reg).
+			WithComponent(comp).
+			WithSpec(modeling.PortSpec{BufSize: 16}).
+			Build(name)
+		comp.AssignPort(name, p)
+		(&ccNoopConn{}).PlugIn(p)
+		return p
+	}
+
+	topPort := assign("Top")
+	bottomPort := assign("Bottom")
+	ctrlPort := assign("Control")
+
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(comp, rec)
+
+	// Admit a read miss. intake opens the req_in and the cache_transaction
+	// task; the directory then issues a bottom fetch (req_out) that is never
+	// answered, leaving the transaction in flight with all three tiers open.
+	read := memprotocol.ReadReq{Address: 0, AccessByteSize: 4}
+	read.ID = timing.GetIDGenerator().Generate()
+	read.Src = messaging.RemotePort("Agent")
+	read.Dst = topPort.AsRemote()
+	read.TrafficBytes = 12
+	read.TrafficClass = "memprotocol.ReadReq"
+	topPort.Deliver(read)
+
+	// Tick until the bottom fetch has been sent, so the in-flight transaction
+	// has HasReadToBottom set and its req_out task is open. Do NOT answer the
+	// bottom request.
+	bottomSent := false
+	for i := 0; i < 256 && !bottomSent; i++ {
+		comp.Tick()
+		if out := bottomPort.RetrieveOutgoing(); out != nil {
+			if _, ok := out.(memprotocol.ReadReq); ok {
+				bottomSent = true
+			}
+		}
+	}
+
+	if !bottomSent {
+		t.Fatal("bottom fetch was never issued; transaction not in flight")
+	}
+
+	// The transaction is genuinely in flight: a slot exists that is not yet
+	// removed and has issued its downstream read.
+	inflight := false
+	for i := range comp.State.Transactions {
+		trans := &comp.State.Transactions[i]
+		if !trans.Removed && trans.HasReadToBottom {
+			inflight = true
+		}
+	}
+	if !inflight {
+		t.Fatal("expected an in-flight transaction with a bottom read")
+	}
+
+	// req_in + cache_transaction + req_out.
+	if rec.NumStarted() < 3 {
+		t.Fatalf("expected req_in, cache_transaction and req_out to be "+
+			"opened, got %d task starts: %s",
+			rec.NumStarted(), rec.OpenSummary())
+	}
+
+	// Reset while the transaction is in flight.
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = ctrlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	ctrlPort.Deliver(reset)
+
+	acked := false
+	for i := 0; i < 64 && !acked; i++ {
+		comp.Tick()
+		if msg := ctrlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/datamover/ctrlmiddleware.go
+++ b/mem/datamover/ctrlmiddleware.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/modeling"
 	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 )
 
 type ctrlMiddleware struct {
@@ -127,6 +128,7 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 	}
 
 	state := &m.comp.State
+	m.endInflightTasks()
 	state.CurrentTransaction = dataMoverTransactionState{
 		PendingRead:  map[uint64]pendingReadState{},
 		PendingWrite: map[uint64]pendingWriteState{},
@@ -147,6 +149,28 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 		req.Src, req.ID, true, ""))
 	m.ctrlPort().RetrieveIncoming()
 	return true
+}
+
+// endInflightTasks completes the req_in tracing task of the in-flight move (when
+// one is active) and finalizes the req_out task of every outstanding downstream
+// read and write, so a hard Reset that wipes the transaction leaves no
+// started-never-ended task and no leaked receiver-registry entry. The pending
+// maps are keyed by the downstream message's own ID, which is the req_out task
+// ID. Mirrors ctrlParseMW (req_in) and dataTransferMW (req_out) completion.
+func (m *ctrlMiddleware) endInflightTasks() {
+	trans := &m.comp.State.CurrentTransaction
+
+	if trans.Active {
+		tracing.EndReqInOnReset(m.comp, trans.ReqID)
+	}
+
+	for id := range trans.PendingRead {
+		tracing.EndTaskOnReset(m.comp, id)
+	}
+
+	for id := range trans.PendingWrite {
+		tracing.EndTaskOnReset(m.comp, id)
+	}
 }
 
 func (m *ctrlMiddleware) handleUnsupported(req memcontrolprotocol.Req) bool {

--- a/mem/datamover/reset_leak_test.go
+++ b/mem/datamover/reset_leak_test.go
@@ -1,0 +1,139 @@
+package datamover
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/datamoverprotocol"
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks drives a move into flight (req_in open, the
+// outstanding Outside-read req_out open), then issues a control Reset and asserts
+// the Reset cleanup (ctrlMiddleware.endInflightTasks) ends every started task,
+// leaving no started-never-ended tracing leak.
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+
+	spec := DefaultSpec()
+	spec.BufferSize = 2048
+	spec.InsideByteGranularity = 64
+	spec.OutsideByteGranularity = 64
+
+	reg := modeling.NewStandaloneRegistrar(engine)
+
+	dataMover := MakeBuilder().
+		WithRegistrar(reg).
+		WithSpec(spec).
+		WithResources(Resources{
+			InsideMapper: &mem.SinglePortMapper{
+				Port: messaging.RemotePort("InsideMem"),
+			},
+			OutsideMapper: &mem.SinglePortMapper{
+				Port: messaging.RemotePort("OutsideMem"),
+			},
+		}).
+		Build("DataMover")
+
+	assign := func(name string, bufSize int) messaging.Port {
+		p := modeling.MakePortBuilder().
+			WithRegistrar(reg).
+			WithComponent(dataMover).
+			WithSpec(modeling.PortSpec{BufSize: bufSize}).
+			Build(name)
+		dataMover.AssignPort(name, p)
+		(&ccNoopConn{}).PlugIn(p)
+		return p
+	}
+
+	topPort := assign("Top", 16)
+	assign("Inside", 64)
+	outsidePort := assign("Outside", 64)
+	ctrlPort := assign("Control", 1024)
+
+	// Attach the leak tracker BEFORE any traffic is driven so every task start
+	// and end is observed.
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(dataMover, rec)
+
+	makeMove := func() datamoverprotocol.DataMoveRequest {
+		req := datamoverprotocol.DataMoveRequest{}
+		req.ID = timing.GetIDGenerator().Generate()
+		req.Src = messaging.RemotePort("Agent")
+		req.Dst = topPort.AsRemote()
+		req.SrcAddress = 0
+		req.SrcSide = "outside"
+		req.DstAddress = 0
+		req.DstSide = "inside"
+		req.ByteSize = 64
+		req.TrafficClass = "datamoverprotocol.DataMoveRequest"
+		return req
+	}
+
+	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
+		req := memcontrolprotocol.Req{Command: cmd}
+		req.ID = timing.GetIDGenerator().Generate()
+		req.Src = messaging.RemotePort("Cmd")
+		req.Dst = ctrlPort.AsRemote()
+		req.TrafficClass = "memcontrolprotocol.Req"
+		return req
+	}
+
+	// startMove delivers a move and ticks until the first Outside read is issued.
+	// The read is left unanswered, so the move's req_in task and the read's
+	// req_out task stay open.
+	startMove := func() (memprotocol.ReadReq, bool) {
+		topPort.Deliver(makeMove())
+
+		var read memprotocol.ReadReq
+		gotRead := false
+		for i := 0; i < 64 && !gotRead; i++ {
+			dataMover.Tick()
+			if out := outsidePort.RetrieveOutgoing(); out != nil {
+				read, gotRead = out.(memprotocol.ReadReq)
+			}
+		}
+		return read, gotRead
+	}
+
+	_, gotRead := startMove()
+	if !gotRead {
+		t.Fatal("expected an Outside read to be issued")
+	}
+	if !dataMover.State.CurrentTransaction.Active {
+		t.Fatal("expected the move to be active in flight")
+	}
+
+	// Guard against a vacuous test: the req_in and the read req_out must be open.
+	if rec.NumStarted() < 2 {
+		t.Fatalf("expected at least 2 tasks opened, got %d", rec.NumStarted())
+	}
+
+	reset := makeCtrlReq(memcontrolprotocol.CmdReset)
+	ctrlPort.Deliver(reset)
+
+	acked := false
+	for i := 0; i < 64 && !acked; i++ {
+		dataMover.Tick()
+		if out := ctrlPort.RetrieveOutgoing(); out != nil {
+			if rsp, ok := out.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+			}
+		}
+	}
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/dram/ctrlmiddleware.go
+++ b/mem/dram/ctrlmiddleware.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/modeling"
 	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 )
 
 type ctrlMiddleware struct {
@@ -122,6 +123,7 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 	state := &m.comp.State
 	spec := m.comp.Spec()
 
+	m.endInflightTasks()
 	state.Transactions = nil
 	state.SubTransQueue = subTransQueueState{Entries: []subTransRef{}}
 	state.CommandQueues = commandQueueState{
@@ -169,6 +171,30 @@ func resetStatistics(state *State) {
 	state.CompletedWrites = 0
 	state.BytesRead = 0
 	state.BytesWritten = 0
+}
+
+// endInflightTasks completes the req_in tracing task of every admitted
+// transaction and closes each of its not-yet-completed sub-trans subtasks, so a
+// hard Reset that drops the transaction table leaves no started-never-ended
+// task and no leaked receiver-registry entry. DRAM is a leaf, so there is no
+// downstream req_out. Mirrors respondMW.finalizeTransaction (req_in) and
+// bankTickMW.endSubTransTasks (sub-trans).
+func (m *ctrlMiddleware) endInflightTasks() {
+	for i := range m.comp.State.Transactions {
+		t := &m.comp.State.Transactions[i]
+
+		reqMsgID := t.WriteMsg.ID
+		if t.HasRead {
+			reqMsgID = t.ReadMsg.ID
+		}
+		tracing.EndReqInOnReset(m.comp, reqMsgID)
+
+		for _, sub := range t.SubTransactions {
+			if !sub.Completed {
+				tracing.EndTaskOnReset(m.comp, sub.ID)
+			}
+		}
+	}
 }
 
 func (m *ctrlMiddleware) handleUnsupported(req memcontrolprotocol.Req) bool {

--- a/mem/dram/reset_leak_test.go
+++ b/mem/dram/reset_leak_test.go
@@ -1,0 +1,111 @@
+package dram
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks admits a read into the DRAM controller so
+// its req_in and sub-trans tasks are open, then issues a Reset before the DRAM
+// access latency elapses (the request is still in flight) and asserts both
+// kinds of task are ended — i.e. a mid-flight Reset leaves no
+// started-never-ended task. DRAM is a leaf, so there is no downstream req_out.
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+	reg := modeling.NewStandaloneRegistrar(engine)
+
+	comp := MakeBuilder().
+		WithRegistrar(reg).
+		WithResources(Resources{Storage: mem.NewStorage(1 * mem.MB)}).
+		Build("DRAM")
+
+	assign := func(name string) messaging.Port {
+		p := modeling.MakePortBuilder().
+			WithRegistrar(reg).
+			WithComponent(comp).
+			WithSpec(modeling.PortSpec{BufSize: 16}).
+			Build(name)
+		comp.AssignPort(name, p)
+		(&noopConn{}).PlugIn(p)
+		return p
+	}
+
+	topPort := assign("Top")
+	ctrlPort := assign("Control")
+
+	// Attach the leak tracer BEFORE any traffic, so it sees every task start.
+	// Deliberately not CollectIncomingBufferTrace: those buffer tasks are ended
+	// by the port retrieve hook, not the component.
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(comp, rec)
+
+	// Admit a read: parseTop opens the req_in task and one sub-trans task per
+	// sub-transaction, then enqueues commands whose data return is many cycles
+	// out. Ticking just enough to admit the transaction — but far fewer than the
+	// DRAM access latency — leaves it in flight.
+	read := memprotocol.ReadReq{Address: 0, AccessByteSize: 4}
+	read.ID = timing.GetIDGenerator().Generate()
+	read.Src = messaging.RemotePort("Agent")
+	read.Dst = topPort.AsRemote()
+	read.TrafficBytes = 12
+	read.TrafficClass = "memprotocol.ReadReq"
+	topPort.Deliver(read)
+
+	for i := 0; i < 8 && len(comp.State.Transactions) == 0; i++ {
+		comp.Tick()
+	}
+
+	if len(comp.State.Transactions) == 0 {
+		t.Fatal("read was not admitted; no in-flight transaction")
+	}
+
+	// Confirm the transaction is genuinely still in flight: no sub-transaction
+	// has completed yet, so its sub-trans task is open and a leak is possible.
+	for _, sub := range comp.State.Transactions[0].SubTransactions {
+		if sub.Completed {
+			t.Fatal("sub-transaction completed before reset; not in flight")
+		}
+	}
+
+	// Guard against a vacuous test: req_in + at least one sub-trans must be open.
+	if rec.NumStarted() < 2 {
+		t.Fatalf("expected req_in and at least one sub-trans to be opened, "+
+			"got %d task starts", rec.NumStarted())
+	}
+
+	// Reset while the transaction is in flight.
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = ctrlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	ctrlPort.Deliver(reset)
+
+	acked := false
+	for range 16 {
+		comp.Tick()
+		if msg := ctrlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+				break
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/idealmemcontroller/ctrlmiddleware.go
+++ b/mem/idealmemcontroller/ctrlmiddleware.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/modeling"
 	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 )
 
 type ctrlMiddleware struct {
@@ -120,6 +121,7 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 	}
 
 	state := &m.comp.State
+	m.endInflightTasks()
 	state.InflightTransactions = nil
 	state.CurrentCmdID = 0
 	state.CurrentCmdSrc = ""
@@ -138,6 +140,17 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 		req.Src, req.ID, true, ""))
 	m.ctrlPort().RetrieveIncoming()
 	return true
+}
+
+// endInflightTasks completes the req_in tracing task of every in-flight access
+// so a hard Reset that drops InflightTransactions leaves no
+// started-never-ended task and no leaked receiver-registry entry. The ideal
+// memory controller is a leaf, so there is no downstream req_out to finalize.
+// Mirrors the completion in memMiddleware.traceReqComplete.
+func (m *ctrlMiddleware) endInflightTasks() {
+	for _, tx := range m.comp.State.InflightTransactions {
+		tracing.EndReqInOnReset(m.comp, tx.ReqID)
+	}
 }
 
 func (m *ctrlMiddleware) handleUnsupported(req memcontrolprotocol.Req) bool {

--- a/mem/idealmemcontroller/reset_leak_test.go
+++ b/mem/idealmemcontroller/reset_leak_test.go
@@ -1,0 +1,101 @@
+package idealmemcontroller
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks drives a read into the ideal memory
+// controller so its req_in task is open and the access is mid-flight (admitted
+// into InflightTransactions but not yet completed, because fewer ticks elapse
+// than the access latency), then issues a Reset and asserts the req_in task is
+// ended — i.e. a mid-flight Reset leaves no started-never-ended task. The
+// controller is a leaf, so the only open task per access is its req_in.
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+	reg := modeling.NewStandaloneRegistrar(engine)
+
+	storage := mem.NewStorage(1 * mem.MB)
+
+	spec := DefaultSpec()
+	spec.Width = 4
+	// A long latency keeps the access in flight: one Tick admits it into
+	// InflightTransactions (opening req_in) but is far short of completing it.
+	spec.Latency = 100
+	spec.CacheLineSize = 64
+
+	comp := MakeBuilder().
+		WithRegistrar(reg).
+		WithResources(Resources{Storage: storage}).
+		WithSpec(spec).
+		Build("MemCtrl")
+
+	comp.AssignPort("Top",
+		messaging.NewPort(comp, 16, 16, comp.Name()+".Top"))
+	comp.AssignPort("Control",
+		messaging.NewPort(comp, 16, 16, comp.Name()+".Control"))
+
+	topPort := comp.GetPortByName("Top")
+	ctrlPort := comp.GetPortByName("Control")
+	for _, p := range []messaging.Port{topPort, ctrlPort} {
+		(&noopConn{}).PlugIn(p)
+	}
+
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(comp, rec)
+
+	// Admit a read: takeNewReqs opens the req_in task and parks the access in
+	// InflightTransactions; the access never completes within the ticks below.
+	read := memprotocol.ReadReq{Address: 0, AccessByteSize: 4}
+	read.ID = timing.GetIDGenerator().Generate()
+	read.Src = messaging.RemotePort("Agent")
+	read.Dst = topPort.AsRemote()
+	read.TrafficClass = "memprotocol.ReadReq"
+	topPort.Deliver(read)
+	comp.Tick()
+
+	if len(comp.State.InflightTransactions) < 1 {
+		t.Fatalf("expected the read to be in flight, got %d in-flight transactions",
+			len(comp.State.InflightTransactions))
+	}
+	if rec.NumStarted() < 1 {
+		t.Fatalf("expected req_in to be opened, got %d task starts",
+			rec.NumStarted())
+	}
+
+	// Reset while the access is in flight.
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = ctrlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	ctrlPort.Deliver(reset)
+
+	acked := false
+	for range 16 {
+		comp.Tick()
+		if msg := ctrlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+				break
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/rob/middleware.go
+++ b/mem/rob/middleware.go
@@ -471,9 +471,9 @@ func (m *middleware) handleEnable(req memcontrolprotocol.Req) bool {
 }
 
 // handleReset drops every in-flight transaction, drains stale port
-// traffic, and lands the ROB back in Enabled. The tracing receiver-task
-// registry entries that topDown allocated for each in-flight top-side
-// request are released so they do not outlive the transactions.
+// traffic, and lands the ROB back in Enabled. The req_in/req_out tracing tasks
+// that topDown opened for each in-flight transaction are ended (and their
+// receiver-registry entries released) so they do not outlive the transactions.
 func (m *middleware) handleReset(req memcontrolprotocol.Req) bool {
 	if !m.ctrlPort().CanSend() {
 		return false
@@ -483,7 +483,7 @@ func (m *middleware) handleReset(req memcontrolprotocol.Req) bool {
 		req.Src, req.ID, true, ""))
 
 	state := &m.comp.State
-	m.forgetInflightReceiverIDs()
+	m.endInflightTasks()
 	state.Transactions = state.Transactions[:0]
 	state.CurrentCmdID = 0
 	state.CurrentCmdSrc = ""
@@ -536,13 +536,17 @@ func drainIncoming(p messaging.Port) {
 	}
 }
 
-// forgetInflightReceiverIDs releases the tracing receiver-task registry
-// entries that topDown allocated for each in-flight top-side request. Control
-// paths that drop the transaction table call this so the entries do not
-// outlive the transactions they describe.
-func (m *middleware) forgetInflightReceiverIDs() {
+// endInflightTasks completes the top-side req_in tracing task and finalizes the
+// shadow req_out task for each in-flight transaction, so a control path that
+// drops the transaction table leaves no started-never-ended task and no leaked
+// receiver-registry entry. topDown opens both tasks together when it admits a
+// request, so both are open until the transaction retires; the end is
+// idempotent if the shadow's response already finalized its req_out. Mirrors
+// bottomUp (req_in) and parseBottom (req_out) completion.
+func (m *middleware) endInflightTasks() {
 	for _, trans := range m.comp.State.Transactions {
-		tracing.ForgetMsgIDAtReceiver(trans.ReqFromTopID, m.comp)
+		tracing.EndReqInOnReset(m.comp, trans.ReqFromTopID)
+		tracing.EndTaskOnReset(m.comp, trans.ReqToBottomID)
 	}
 }
 

--- a/mem/rob/reset_leak_test.go
+++ b/mem/rob/reset_leak_test.go
@@ -1,0 +1,93 @@
+package rob
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks drives a request into the ROB so its req_in
+// and shadow req_out tasks are open, then issues a Reset and asserts both tasks
+// are ended — i.e. a mid-flight Reset leaves no started-never-ended task.
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+	reg := modeling.NewStandaloneRegistrar(engine)
+
+	spec := DefaultSpec()
+	spec.BufferSize = 4
+	spec.NumReqPerCycle = 2
+	spec.BottomUnit = messaging.RemotePort("BottomUnit")
+
+	rob := MakeBuilder().WithRegistrar(reg).WithSpec(spec).Build("Rob")
+
+	assign := func(name string) messaging.Port {
+		p := modeling.MakePortBuilder().
+			WithRegistrar(reg).
+			WithComponent(rob).
+			WithSpec(modeling.PortSpec{BufSize: 4}).
+			Build(name)
+		rob.AssignPort(name, p)
+		(&noopConn{}).PlugIn(p)
+		return p
+	}
+
+	topPort := assign("Top")
+	assign("Bottom")
+	ctrlPort := assign("Control")
+
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(rob, rec)
+
+	// Admit a read: topDown opens the top req_in and the shadow req_out, then
+	// waits on the bottom response (which never comes — the request is in flight).
+	read := memprotocol.ReadReq{Address: 0, AccessByteSize: 4}
+	read.ID = timing.GetIDGenerator().Generate()
+	read.Src = messaging.RemotePort("Agent")
+	read.Dst = topPort.AsRemote()
+	read.TrafficClass = "memprotocol.ReadReq"
+	topPort.Deliver(read)
+	rob.Tick()
+
+	if len(rob.State.Transactions) != 1 {
+		t.Fatalf("expected 1 in-flight transaction, got %d",
+			len(rob.State.Transactions))
+	}
+	if rec.NumStarted() < 2 {
+		t.Fatalf("expected req_in and req_out to be opened, got %d task starts",
+			rec.NumStarted())
+	}
+
+	// Reset while the transaction is in flight.
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = ctrlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	ctrlPort.Deliver(reset)
+
+	acked := false
+	for range 16 {
+		rob.Tick()
+		if msg := ctrlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+				break
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/simplebankedmemory/ctrlmiddleware.go
+++ b/mem/simplebankedmemory/ctrlmiddleware.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/modeling"
 	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 )
 
 type ctrlMiddleware struct {
@@ -125,6 +126,7 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 	}
 
 	state := &m.comp.State
+	m.endInflightTasks()
 	state.Banks = buildInitialBanks(m.comp.Spec())
 	state.CurrentCmdID = 0
 	state.CurrentCmdSrc = ""
@@ -137,6 +139,37 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 		req.Src, req.ID, true, ""))
 	m.ctrlPort().RetrieveIncoming()
 	return true
+}
+
+// endInflightTasks completes the req_in tracing task and closes the open
+// pipeline subtask of every request still in a bank pipeline or post-pipeline
+// buffer, so a hard Reset that rebuilds the banks leaves no
+// started-never-ended task and no leaked receiver-registry entry. The memory is
+// a leaf, so there is no downstream req_out. Mirrors the completion in
+// tickFinalizeMW.finishPipeline + TraceReqComplete.
+func (m *ctrlMiddleware) endInflightTasks() {
+	for i := range m.comp.State.Banks {
+		bank := &m.comp.State.Banks[i]
+		for _, stage := range bank.Pipeline.Stages() {
+			m.endItemTasks(stage.Item)
+		}
+		for _, item := range bank.PostPipelineBuf.Elements() {
+			m.endItemTasks(item)
+		}
+	}
+}
+
+func (m *ctrlMiddleware) endItemTasks(item bankPipelineItemState) {
+	reqMsgID := item.WriteMsg.ID
+	if item.IsRead {
+		reqMsgID = item.ReadMsg.ID
+	}
+
+	tracing.EndReqInOnReset(m.comp, reqMsgID)
+
+	if item.PipelineTaskID != 0 {
+		tracing.EndTaskOnReset(m.comp, item.PipelineTaskID)
+	}
 }
 
 func (m *ctrlMiddleware) handleUnsupported(req memcontrolprotocol.Req) bool {

--- a/mem/simplebankedmemory/reset_leak_test.go
+++ b/mem/simplebankedmemory/reset_leak_test.go
@@ -1,0 +1,90 @@
+package simplebankedmemory
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks drives a read into a bank pipeline so its
+// req_in and pipeline subtask are open but not yet completed, then issues a
+// Reset and asserts both tasks are ended — i.e. a mid-flight Reset that rebuilds
+// the banks leaves no started-never-ended task.
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+	storage := mem.NewStorage(1 * mem.MB)
+
+	reg := modeling.NewStandaloneRegistrar(engine)
+	comp := MakeBuilder().
+		WithRegistrar(reg).
+		WithResources(Resources{Storage: storage}).
+		Build("BankedMem")
+
+	assignPort(reg, comp, "Top", 16)
+	assignPort(reg, comp, "Control", 16)
+
+	topPort := comp.GetPortByName("Top")
+	ctrlPort := comp.GetPortByName("Control")
+	for _, p := range []messaging.Port{topPort, ctrlPort} {
+		(&noopConn{}).PlugIn(p)
+	}
+
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(comp, rec)
+
+	// Admit one read. A single Tick lets dispatchMW route it into the bank
+	// pipeline, opening req_in (TraceReqReceive) and the pipeline subtask. The
+	// pipeline latency (BankPipelineDepth*StageLatency = 10) far exceeds one
+	// tick, so the item is still in flight: it has not reached PostPipelineBuf
+	// and so has not been finalized/completed. The memory is a leaf, so there is
+	// no downstream req_out.
+	read := makeReadReq(messaging.RemotePort("Agent"), topPort.AsRemote(), 0)
+	topPort.Deliver(read)
+	comp.Tick()
+
+	if bankIsQuiescent(&comp.State.Banks[0]) {
+		t.Fatal("expected the read to be in flight in bank 0, but bank is quiescent")
+	}
+	if rec.NumStarted() < 2 {
+		t.Fatalf("expected req_in and pipeline subtask to be opened, "+
+			"got %d task starts", rec.NumStarted())
+	}
+	if open := rec.OpenTasks(); len(open) < 2 {
+		t.Fatalf("expected at least 2 open tasks before reset, got %d: %s",
+			len(open), rec.OpenSummary())
+	}
+
+	// Reset while the read is in flight.
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = ctrlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	ctrlPort.Deliver(reset)
+
+	acked := false
+	for range 16 {
+		comp.Tick()
+		if msg := ctrlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+				break
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/vm/addresstranslator/ctrlmiddleware.go
+++ b/mem/vm/addresstranslator/ctrlmiddleware.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/modeling"
 	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 )
 
 type ctrlMiddleware struct {
@@ -125,6 +126,7 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 	}
 
 	state := &m.comp.State
+	m.endInflightTasks()
 	state.Transactions = nil
 	state.InflightReqToBottom = nil
 	state.CurrentCmdID = 0
@@ -142,6 +144,29 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 		req.Src, req.ID, true, ""))
 	m.ctrlPort().RetrieveIncoming()
 	return true
+}
+
+// endInflightTasks completes the req_in tracing task of every in-flight request
+// and finalizes the req_out it currently owns, so a hard Reset that drops both
+// transaction tables leaves no started-never-ended task and no leaked
+// receiver-registry entry. A request awaiting translation (Transactions) holds a
+// translation req_out (TranslationReqID); one already translated and forwarded
+// (InflightReqToBottom) holds the downstream req_out (ReqToBottomID). The end is
+// idempotent for a req_out a response already finalized. Mirrors respond()
+// (req_in + downstream req_out) and traceTranslationComplete (translation
+// req_out) completion.
+func (m *ctrlMiddleware) endInflightTasks() {
+	for _, trans := range m.comp.State.Transactions {
+		for _, inc := range trans.IncomingReqs {
+			tracing.EndReqInOnReset(m.comp, inc.ID)
+		}
+		tracing.EndTaskOnReset(m.comp, trans.TranslationReqID)
+	}
+
+	for _, r := range m.comp.State.InflightReqToBottom {
+		tracing.EndReqInOnReset(m.comp, r.ReqFromTopID)
+		tracing.EndTaskOnReset(m.comp, r.ReqToBottomID)
+	}
 }
 
 func (m *ctrlMiddleware) handleUnsupported(req memcontrolprotocol.Req) bool {

--- a/mem/vm/addresstranslator/reset_leak_test.go
+++ b/mem/vm/addresstranslator/reset_leak_test.go
@@ -1,0 +1,128 @@
+package addresstranslator
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks drives a read into the address translator so
+// its req_in and the translation req_out tasks are open (a transaction awaiting
+// translation), then issues a Reset and asserts both tasks are ended — i.e. a
+// mid-flight Reset leaves no started-never-ended task.
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+	reg := modeling.NewStandaloneRegistrar(engine)
+
+	spec := DefaultSpec()
+	spec.Log2PageSize = 12
+	spec.Freq = 1
+
+	resources := Resources{
+		MemProviderMapper: &mem.SinglePortMapper{
+			Port: messaging.RemotePort("MemPort"),
+		},
+		TranslationProviderMapper: &mem.SinglePortMapper{
+			Port: messaging.RemotePort("TranslationProvider"),
+		},
+	}
+
+	at := MakeBuilder().
+		WithRegistrar(reg).
+		WithSpec(spec).
+		WithResources(resources).
+		Build("AddressTranslator")
+
+	assignPorts(reg, at, 16)
+
+	topPort := at.GetPortByName("Top")
+	translationPort := at.GetPortByName("Translation")
+	ctrlPort := at.GetPortByName("Control")
+
+	for _, p := range []messaging.Port{
+		topPort,
+		at.GetPortByName("Bottom"),
+		translationPort,
+		ctrlPort,
+	} {
+		(&noopConn{}).PlugIn(p)
+	}
+
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(at, rec)
+
+	// Admit a read: translate opens the top req_in and the translation req_out,
+	// then awaits the translation response (which never comes — the request is in
+	// flight). Tick until the transaction is created and the TranslationReq has
+	// actually gone out the Translation port.
+	read := memprotocol.ReadReq{Address: 0x1040, AccessByteSize: 4}
+	read.ID = timing.GetIDGenerator().Generate()
+	read.Src = messaging.RemotePort("Agent")
+	read.Dst = topPort.AsRemote()
+	read.TrafficBytes = 12
+	read.TrafficClass = "memprotocol.ReadReq"
+	topPort.Deliver(read)
+
+	var transReqSent bool
+	for range 8 {
+		at.Tick()
+		if out := translationPort.RetrieveOutgoing(); out != nil {
+			if _, ok := out.(vmprotocol.TranslationReq); ok {
+				transReqSent = true
+				break
+			}
+		}
+	}
+
+	if !transReqSent {
+		t.Fatal("translation request was not sent out the Translation port")
+	}
+	if len(at.State.Transactions) != 1 {
+		t.Fatalf("expected 1 in-flight transaction, got %d",
+			len(at.State.Transactions))
+	}
+	if rec.NumStarted() < 2 {
+		t.Fatalf("expected req_in and translation req_out to be opened, "+
+			"got %d task starts", rec.NumStarted())
+	}
+
+	// Reset while the transaction is in flight (translation never answered).
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = ctrlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	ctrlPort.Deliver(reset)
+
+	acked := false
+	for range 64 {
+		at.Tick()
+		if msg := ctrlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+				break
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if len(at.State.Transactions) != 0 {
+		t.Errorf("Reset left %d transaction(s) in state",
+			len(at.State.Transactions))
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/vm/gmmu/ctrlmiddleware.go
+++ b/mem/vm/gmmu/ctrlmiddleware.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/modeling"
 	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 )
 
 type ctrlMiddleware struct {
@@ -122,6 +123,7 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 	}
 
 	state := &m.comp.State
+	m.endInflightTasks()
 	state.WalkingTranslations = nil
 	// RemoteMemReqs must stay a usable (non-nil) map: walkMW writes to it
 	// directly, so leaving it nil would panic on the next remote walk.
@@ -140,6 +142,25 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 		req.Src, req.ID, true, ""))
 	m.ctrlPort().RetrieveIncoming()
 	return true
+}
+
+// endInflightTasks completes the req_in tracing task of every page walk still in
+// flight — local (WalkingTranslations) and remote (RemoteMemReqs) — and
+// finalizes the remote-fetch req_out for the remote ones, so a hard Reset that
+// drops both leaves no started-never-ended task and no leaked receiver-registry
+// entry. The RemoteMemReqs key is the downstream request's own ID, which is the
+// req_out task ID. A walk briefly pending removal can appear in both; the end is
+// idempotent. Mirrors walkMW (local req_in) and respondMW (remote req_out +
+// req_in) completion.
+func (m *ctrlMiddleware) endInflightTasks() {
+	for _, walking := range m.comp.State.WalkingTranslations {
+		tracing.EndReqInOnReset(m.comp, walking.ReqID)
+	}
+
+	for reqOutID, walking := range m.comp.State.RemoteMemReqs {
+		tracing.EndTaskOnReset(m.comp, reqOutID)
+		tracing.EndReqInOnReset(m.comp, walking.ReqID)
+	}
 }
 
 func (m *ctrlMiddleware) handleUnsupported(req memcontrolprotocol.Req) bool {

--- a/mem/vm/gmmu/reset_leak_test.go
+++ b/mem/vm/gmmu/reset_leak_test.go
@@ -1,0 +1,123 @@
+package gmmu
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/vm"
+	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks drives a translation into the GMMU until it
+// issues a remote memory request out the Bottom port — so the original req_in
+// and the downstream req_out tracing tasks are both open — then issues a Reset
+// without ever answering the remote request and asserts both tasks are ended.
+// A mid-flight Reset must leave no started-never-ended task (and no leaked
+// receiver-registry entry).
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	const (
+		deviceID  = uint64(0)
+		lowModule = messaging.RemotePort("LowModule")
+		agentPort = messaging.RemotePort("Agent")
+		vAddr     = uint64(0x10000000)
+	)
+
+	engine := timing.NewSerialEngine()
+	pageTable := vm.NewPageTable(12)
+
+	spec := DefaultSpec()
+	spec.DeviceID = deviceID
+	spec.Latency = 1
+	spec.LowModule = lowModule
+
+	reg := modeling.NewStandaloneRegistrar(engine)
+	comp := MakeBuilder().
+		WithRegistrar(reg).
+		WithResources(Resources{PageTable: pageTable}).
+		WithSpec(spec).
+		Build("GMMU")
+
+	assignDefaultPorts(reg, comp)
+	for _, name := range []string{"Top", "Bottom", "Control"} {
+		(&noopConn{}).PlugIn(comp.GetPortByName(name))
+	}
+
+	topPort := comp.GetPortByName("Top")
+	ctrlPort := comp.GetPortByName("Control")
+
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(comp, rec)
+
+	// The page lives on a different device, so the walk cannot resolve locally:
+	// it must send a remote memory request out the Bottom port and wait for a
+	// response (which never comes — the request is left in flight).
+	pageTable.Insert(vm.Page{
+		PID:      vm.PID(1),
+		VAddr:    vAddr,
+		DeviceID: 1,
+		Valid:    true,
+	})
+
+	req := vmprotocol.TranslationReq{}
+	req.ID = timing.GetIDGenerator().Generate()
+	req.Src = agentPort
+	req.Dst = topPort.AsRemote()
+	req.PID = 1
+	req.VAddr = vAddr
+	req.DeviceID = deviceID
+	req.TrafficClass = "vmprotocol.TranslationReq"
+	topPort.Deliver(req)
+
+	// Tick until the remote memory request has been issued: the walk has left
+	// WalkingTranslations and now sits in RemoteMemReqs, with both the original
+	// req_in and the downstream req_out tracing tasks open.
+	for i := 0; i < 64 && len(comp.State.RemoteMemReqs) == 0; i++ {
+		comp.Tick()
+	}
+
+	if len(comp.State.RemoteMemReqs) == 0 {
+		t.Fatalf("expected a remote memory request in flight, got none")
+	}
+	// req_in (TraceReqReceive in parseFromTop) and req_out (TraceReqInitiate in
+	// processRemoteMemReq) should both be open.
+	if rec.NumStarted() < 2 {
+		t.Fatalf("expected req_in and req_out to be opened, got %d task starts",
+			rec.NumStarted())
+	}
+	if open := rec.OpenTasks(); len(open) == 0 {
+		t.Fatalf("expected open tasks before reset, got none")
+	}
+
+	// Reset while the remote walk is in flight; the remote response is never
+	// delivered.
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = ctrlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	ctrlPort.Deliver(reset)
+
+	acked := false
+	for i := 0; i < 64 && !acked; i++ {
+		comp.Tick()
+		if msg := ctrlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/vm/mmu/ctrlmiddleware.go
+++ b/mem/vm/mmu/ctrlmiddleware.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/modeling"
 	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 )
 
 type ctrlMiddleware struct {
@@ -121,6 +122,7 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 	}
 
 	state := &m.comp.State
+	m.endInflightTasks()
 	state.WalkingTranslations = nil
 	state.ToRemoveFromPTW = nil
 	state.CurrentCmdID = 0
@@ -134,6 +136,17 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 		req.Src, req.ID, true, ""))
 	m.ctrlPort().RetrieveIncoming()
 	return true
+}
+
+// endInflightTasks completes the req_in tracing task of every page walk still
+// in flight, so a hard Reset that drops WalkingTranslations leaves no
+// started-never-ended task and no leaked receiver-registry entry. The MMU walk
+// is local, so there is no downstream req_out to finalize. Mirrors the
+// completion in translationMW.traceReqComplete.
+func (m *ctrlMiddleware) endInflightTasks() {
+	for _, walking := range m.comp.State.WalkingTranslations {
+		tracing.EndReqInOnReset(m.comp, walking.ReqID)
+	}
 }
 
 func (m *ctrlMiddleware) handleUnsupported(req memcontrolprotocol.Req) bool {

--- a/mem/vm/mmu/reset_leak_test.go
+++ b/mem/vm/mmu/reset_leak_test.go
@@ -1,0 +1,108 @@
+package mmu
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/vm"
+	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks drives a translation request into the MMU
+// so its page walk is in flight and the req_in tracing task is open, then issues
+// a Reset and asserts the task is ended — i.e. a mid-flight Reset that drops
+// WalkingTranslations leaves no started-never-ended task. The MMU walk is a
+// leaf page walk (no downstream req_out), so a single req_in is open per walk.
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+	reg := modeling.NewStandaloneRegistrar(engine)
+	pageTable := vm.NewPageTable(12)
+
+	// A long walk latency keeps the walk genuinely in flight after a single
+	// parse tick, well short of completion.
+	spec := DefaultSpec()
+	spec.Latency = 100
+
+	comp := MakeBuilder().
+		WithRegistrar(reg).
+		WithResources(Resources{PageTable: pageTable}).
+		WithSpec(spec).
+		Build("MMU")
+
+	topPort := assignPort(reg, comp, "Top", 16)
+	ctrlPort := assignPort(reg, comp, "Control", 4)
+	(&noopConn{}).PlugIn(topPort)
+	(&noopConn{}).PlugIn(ctrlPort)
+
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(comp, rec)
+
+	// Insert a mapped page so the walk resolves locally once its countdown
+	// elapses (no panic, no migration path), then admit the translation request.
+	page := vm.Page{
+		PID:      1,
+		VAddr:    0x1000,
+		PAddr:    0x1000,
+		PageSize: 4096,
+		Valid:    true,
+		DeviceID: 0,
+	}
+	pageTable.Insert(page)
+
+	req := vmprotocol.TranslationReq{}
+	req.ID = timing.GetIDGenerator().Generate()
+	req.Src = messaging.RemotePort("Agent")
+	req.Dst = topPort.AsRemote()
+	req.PID = 1
+	req.VAddr = 0x1000
+	req.DeviceID = 0
+	req.TrafficClass = "vmprotocol.TranslationReq"
+	topPort.Deliver(req)
+
+	// One tick parses the request into a walk (opening the req_in) with a full
+	// CycleLeft countdown of spec.Latency, so the walk is in flight but nowhere
+	// near finished.
+	comp.Tick()
+
+	if len(comp.State.WalkingTranslations) != 1 {
+		t.Fatalf("expected 1 in-flight walk, got %d",
+			len(comp.State.WalkingTranslations))
+	}
+	if rec.NumStarted() < 1 {
+		t.Fatalf("expected req_in to be opened, got %d task starts",
+			rec.NumStarted())
+	}
+
+	// Reset while the walk is in flight.
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = ctrlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	ctrlPort.Deliver(reset)
+
+	acked := false
+	for range 64 {
+		comp.Tick()
+		if msg := ctrlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+				break
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/vm/mmuCache/ctrlmiddleware.go
+++ b/mem/vm/mmuCache/ctrlmiddleware.go
@@ -298,7 +298,7 @@ func (m *ctrlMiddleware) handleReset(msg memcontrolprotocol.Req) bool {
 	// above), so end both tasks here — finalize the req_out and complete the
 	// req_in — mirroring the normal handleRsp completion so a mid-walk reset
 	// leaves no unended tasks rather than just an orphaned registry entry.
-	m.endInflightReqs()
+	m.endInflightTasks()
 	state.InflightReqs = map[uint64]inflightReqState{}
 
 	// Reset is a hard reset: drop the cached page-walk entries so the
@@ -318,20 +318,16 @@ func (m *ctrlMiddleware) handleReset(msg memcontrolprotocol.Req) bool {
 	return true
 }
 
-// endInflightReqs finalizes the forwarded req_out and completes the original
+// endInflightTasks finalizes the forwarded req_out and completes the original
 // req_in for every walk still in flight, so a hard Reset that drops the
-// in-flight table leaves no unended trace tasks. The matching responses are
-// discarded by handleRsp once OutstandingBottomReqs is cleared, so without this
-// the tasks would never close. Mirrors the completion path in handleRsp;
-// TraceReqComplete also releases the req_in receiver-task registry entry.
-func (m *ctrlMiddleware) endInflightReqs() {
+// in-flight table leaves no started-never-ended task and no leaked
+// receiver-registry entry. The matching responses are discarded by handleRsp
+// once OutstandingBottomReqs is cleared, so without this the tasks would never
+// close. Mirrors the completion path in handleRsp.
+func (m *ctrlMiddleware) endInflightTasks() {
 	for _, inflight := range m.comp.State.InflightReqs {
-		reqToBottom := restoreTransReq(
-			inflight.BottomReqID, inflight.BottomReqSrc, inflight.BottomReqDst)
-		topReq := restoreTransReq(
-			inflight.TopReqID, inflight.TopReqSrc, inflight.TopReqDst)
-		tracing.TraceReqFinalize(m.comp, reqToBottom)
-		tracing.TraceReqComplete(m.comp, topReq)
+		tracing.EndTaskOnReset(m.comp, inflight.BottomReqID)
+		tracing.EndReqInOnReset(m.comp, inflight.TopReqID)
 	}
 }
 

--- a/mem/vm/mmuCache/reset_leak_test.go
+++ b/mem/vm/mmuCache/reset_leak_test.go
@@ -1,0 +1,118 @@
+package mmuCache
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks delivers a Top translation request that
+// misses the (empty) cache, so the mmuCache forwards it down the Bottom port
+// and records it in State.InflightReqs — leaving the req_in and the forwarded
+// req_out tracing tasks open. The Bottom response is never delivered, so the
+// walk is genuinely in flight at Reset. It then issues a Reset and asserts both
+// tasks are ended — i.e. a mid-flight Reset leaves no started-never-ended task.
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+	reg := modeling.NewStandaloneRegistrar(engine)
+
+	spec := DefaultSpec()
+	spec.NumBlocks = 1
+	spec.NumLevels = 5
+	spec.PageSize = 4096
+	spec.Log2PageSize = 12
+	spec.NumReqPerCycle = 4
+	spec.LatencyPerLevel = 100
+
+	comp := MakeBuilder().
+		WithRegistrar(reg).
+		WithSpec(spec).
+		WithResources(Resources{
+			LowModulePort: messaging.RemotePort("LowModule"),
+			UpModulePort:  messaging.RemotePort("UpModule"),
+		}).
+		Build("MMUCache")
+
+	assignDefaultPorts(reg, comp)
+
+	topPort := comp.GetPortByName("Top")
+	bottomPort := comp.GetPortByName("Bottom")
+	controlPort := comp.GetPortByName("Control")
+	for _, p := range []messaging.Port{topPort, bottomPort, controlPort} {
+		(&noopConn{}).PlugIn(p)
+	}
+
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(comp, rec)
+
+	// Deliver a lookup that misses the empty cache. lookup forwards it out the
+	// Bottom port and opens both the top req_in and the forwarded req_out, then
+	// waits on the bottom response — which never comes, so the walk is in flight.
+	req := vmprotocol.TranslationReq{}
+	req.ID = timing.GetIDGenerator().Generate()
+	req.Src = messaging.RemotePort("Requester")
+	req.Dst = topPort.AsRemote()
+	req.PID = 1
+	req.VAddr = 0x1000
+	req.DeviceID = 1
+	req.TrafficClass = "vmprotocol.TranslationReq"
+	topPort.Deliver(req)
+
+	// Tick until the forward happens and the walk is recorded in flight.
+	forwarded := false
+	for i := 0; i < 64 && !forwarded; i++ {
+		comp.Tick()
+		if len(comp.State.InflightReqs) > 0 {
+			forwarded = true
+		}
+	}
+
+	if !forwarded {
+		t.Fatal("translation request was never forwarded down the Bottom port")
+	}
+	if len(comp.State.OutstandingBottomReqs) != 1 {
+		t.Fatalf("expected 1 outstanding bottom request, got %d",
+			len(comp.State.OutstandingBottomReqs))
+	}
+	if len(comp.State.InflightReqs) != 1 {
+		t.Fatalf("expected 1 in-flight req, got %d",
+			len(comp.State.InflightReqs))
+	}
+	if rec.NumStarted() < 2 {
+		t.Fatalf("expected req_in and req_out to be opened, got %d task starts",
+			rec.NumStarted())
+	}
+
+	// Reset while the walk is in flight (bottom response deliberately withheld).
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = controlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	controlPort.Deliver(reset)
+
+	acked := false
+	for i := 0; i < 64 && !acked; i++ {
+		comp.Tick()
+		if msg := controlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/mem/vm/tlb/ctrlmiddleware.go
+++ b/mem/vm/tlb/ctrlmiddleware.go
@@ -246,7 +246,9 @@ func (m *ctrlMiddleware) handleReset(msg memcontrolprotocol.Req) bool {
 	state.CurrentCmdSrc = ""
 
 	// Reset is a hard reset to the freshly-built shape: discard in-flight
-	// misses, the cached translations, and any staged pipeline work.
+	// misses, the cached translations, and any staged pipeline work. End their
+	// open tracing tasks first so the dropped work leaves none unended.
+	m.endInflightTasks()
 	state.MSHREntries = nil
 	state.HasRespondingMSHR = false
 	state.RespondingMSHRData = mshrEntryState{}
@@ -265,6 +267,52 @@ func (m *ctrlMiddleware) handleReset(msg memcontrolprotocol.Req) bool {
 
 	m.controlPort().RetrieveIncoming()
 	return true
+}
+
+// endInflightTasks completes the req_in tracing task of every request still in
+// flight — coalesced into an MSHR entry, draining from the responding MSHR, or
+// staged in the lookup pipeline/buffer — finalizes each MSHR's downstream fetch
+// req_out, and closes each staged request's pipeline subtask, so a hard Reset
+// that discards them leaves no started-never-ended task and no leaked
+// receiver-registry entry. The end is idempotent where a request appears in more
+// than one structure. Mirrors the respond path (req_in), the bottom fetch
+// (req_out), and finishPipeline (subtask) completion.
+func (m *ctrlMiddleware) endInflightTasks() {
+	state := &m.comp.State
+
+	for i := range state.MSHREntries {
+		m.endMSHREntryTasks(&state.MSHREntries[i])
+	}
+
+	if state.HasRespondingMSHR {
+		m.endMSHREntryTasks(&state.RespondingMSHRData)
+	}
+
+	for _, stage := range state.Pipeline.Stages() {
+		m.endPipelineItemTasks(stage.Item)
+	}
+
+	for _, item := range state.BufferItems.Elements() {
+		m.endPipelineItemTasks(item)
+	}
+}
+
+func (m *ctrlMiddleware) endMSHREntryTasks(entry *mshrEntryState) {
+	for i := range entry.Requests {
+		tracing.EndReqInOnReset(m.comp, entry.Requests[i].ID)
+	}
+
+	if entry.HasReqToBottom {
+		tracing.EndTaskOnReset(m.comp, entry.ReqToBottom.ID)
+	}
+}
+
+func (m *ctrlMiddleware) endPipelineItemTasks(item pipelineTLBReqState) {
+	tracing.EndReqInOnReset(m.comp, item.Msg.ID)
+
+	if item.PipelineTaskID != 0 {
+		tracing.EndTaskOnReset(m.comp, item.PipelineTaskID)
+	}
 }
 
 func (m *ctrlMiddleware) handleUnsupported(msg memcontrolprotocol.Req) bool {

--- a/mem/vm/tlb/reset_leak_test.go
+++ b/mem/vm/tlb/reset_leak_test.go
@@ -1,0 +1,114 @@
+package tlb
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
+	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+)
+
+// TestResetEndsInflightTracingTasks drives a translation lookup into the TLB so
+// it misses and an MSHR entry with an outstanding bottom fetch is in flight —
+// the request's req_in (and a pipeline subtask, if still staged) plus the
+// shadow req_out for the bottom fetch are all open. It then issues a Reset and
+// asserts every open task is ended, i.e. a mid-flight Reset leaves no
+// started-never-ended task.
+func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
+	engine := timing.NewSerialEngine()
+	reg := modeling.NewStandaloneRegistrar(engine)
+
+	remotePort := messaging.RemotePort("MMU")
+
+	tlbComp := MakeBuilder().
+		WithRegistrar(reg).
+		WithSpec(DefaultSpec()).
+		WithResources(Resources{
+			TranslationProviderMapper: &mem.SinglePortMapper{
+				Port: remotePort,
+			},
+		}).
+		Build("TLB")
+
+	assignDefaultPorts(reg, tlbComp)
+	plugNoopConn(tlbComp)
+
+	topPort := tlbComp.GetPortByName("Top")
+	bottomPort := tlbComp.GetPortByName("Bottom")
+	controlPort := tlbComp.GetPortByName("Control")
+
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(tlbComp, rec)
+
+	// Deliver a lookup that misses (fresh TLB), so it is staged into the lookup
+	// pipeline (opening req_in + a pipeline subtask) and, once it reaches the
+	// lookup, creates an MSHR entry and forwards a bottom fetch (opening the
+	// shadow req_out). The bottom fetch is never answered, so the miss stays in
+	// flight.
+	req := vmprotocol.TranslationReq{}
+	req.ID = timing.GetIDGenerator().Generate()
+	req.Src = messaging.RemotePort("Agent")
+	req.Dst = topPort.AsRemote()
+	req.PID = 1
+	req.VAddr = 0x1000
+	req.DeviceID = 1
+	req.TrafficClass = "vmprotocol.TranslationReq"
+	topPort.Deliver(req)
+
+	// Tick just far enough for the miss to reach an MSHR entry with a bottom
+	// fetch sent; do not answer the fetch.
+	bottomSent := false
+	for i := 0; i < 64 && mshrIsEmpty(tlbComp.State.MSHREntries); i++ {
+		tlbComp.Tick()
+		if out := bottomPort.RetrieveOutgoing(); out != nil {
+			if _, ok := out.(vmprotocol.TranslationReq); ok {
+				bottomSent = true
+			}
+		}
+	}
+
+	// Confirm the request is genuinely in flight: an MSHR entry exists.
+	if mshrIsEmpty(tlbComp.State.MSHREntries) {
+		t.Fatal("expected an in-flight MSHR entry before Reset, got none")
+	}
+	if !bottomSent {
+		t.Fatal("expected a bottom fetch to have been forwarded before Reset")
+	}
+	if rec.NumStarted() < 2 {
+		t.Fatalf("expected at least req_in and req_out to be opened, "+
+			"got %d task starts", rec.NumStarted())
+	}
+
+	// Reset while the miss is in flight.
+	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
+	reset.ID = timing.GetIDGenerator().Generate()
+	reset.Src = messaging.RemotePort("Cmd")
+	reset.Dst = controlPort.AsRemote()
+	reset.TrafficClass = "memcontrolprotocol.Req"
+	controlPort.Deliver(reset)
+
+	acked := false
+	for i := 0; i < 64; i++ {
+		tlbComp.Tick()
+		if msg := controlPort.RetrieveOutgoing(); msg != nil {
+			if rsp, ok := msg.(memcontrolprotocol.Rsp); ok &&
+				rsp.Command == memcontrolprotocol.CmdReset {
+				acked = true
+				break
+			}
+		}
+	}
+
+	if !acked {
+		t.Fatal("Reset was not acked")
+	}
+	if open := rec.OpenTasks(); len(open) != 0 {
+		t.Errorf("Reset left %d tracing task(s) unended: %s",
+			len(open), rec.OpenSummary())
+	}
+}

--- a/tracing/api.go
+++ b/tracing/api.go
@@ -257,6 +257,46 @@ func TraceReqFinalize(
 	EndTask(domain, TaskEnd{ID: msg.Meta().ID})
 }
 
+// EndReqInOnReset ends the receiver-side (req_in) task for an in-flight request
+// whose message ID is reqMsgID and releases the registry entry held for it. A
+// reset that drops in-flight work — whose responses will be discarded — calls
+// this to tear the task down now, mirroring [TraceReqComplete], rather than
+// leaving it started-never-ended and its registry entry leaked. It resolves the
+// task ID by message ID (the receiver registry), since reset paths retain the
+// request's ID, not its message value. It is a no-op when the domain has no
+// hooks or no task is registered for the ID (the request never opened a req_in,
+// or already completed).
+func EndReqInOnReset(domain NamedHookable, reqMsgID uint64) {
+	if domain.NumHooks() == 0 {
+		return
+	}
+
+	id, ok := receiverTaskIDByMsgID(reqMsgID, domain)
+	if !ok {
+		return
+	}
+
+	EndTask(domain, TaskEnd{ID: id})
+	forgetReceiverTaskIDByMsgID(reqMsgID, domain)
+}
+
+// EndTaskOnReset ends an in-flight task by its task ID on a reset path that
+// drops the work the task tracks. Use it for every open task that is keyed on
+// its own ID rather than the receiver registry: a forwarded request's
+// sender-side req_out (task ID == the downstream message's own ID, like
+// [TraceReqFinalize]), a DRAM sub-transaction, a cache_transaction, or a
+// pipeline subtask. The req_in task is the only kind that also needs its
+// registry entry released — use [EndReqInOnReset] for that. It is a no-op when
+// the domain has no hooks or the task was never started, so a caller may end
+// every task a transaction could hold without tracking which were opened.
+func EndTaskOnReset(domain NamedHookable, taskID uint64) {
+	if domain.NumHooks() == 0 {
+		return
+	}
+
+	EndTask(domain, TaskEnd{ID: taskID})
+}
+
 // msgTypeName returns the Go type name of the message's underlying type,
 // transparently unwrapping pointers so both value- and pointer-typed
 // implementations of [messaging.Msg] yield a non-empty name.

--- a/tracing/registry.go
+++ b/tracing/registry.go
@@ -38,6 +38,24 @@ func lookupOrCreateReceiverTaskID(msg messaging.Msg, domain NamedHookable) uint6
 	return id
 }
 
+// receiverTaskIDByMsgID returns the receiver-side task ID registered for the
+// message ID at the domain, and whether one exists. Unlike
+// lookupOrCreateReceiverTaskID it never creates an entry, so a reset path can
+// resolve an in-flight task's ID to end it without resurrecting an entry that
+// was already forgotten.
+func receiverTaskIDByMsgID(
+	msgID uint64, domain NamedHookable,
+) (uint64, bool) {
+	key := receiverTaskKey{domain: domain.Name(), msgID: msgID}
+
+	receiverTaskIDsMu.Lock()
+	defer receiverTaskIDsMu.Unlock()
+
+	id, ok := receiverTaskIDs[key]
+
+	return id, ok
+}
+
 func forgetReceiverTaskID(msg messaging.Msg, domain NamedHookable) {
 	forgetReceiverTaskIDByMsgID(msg.Meta().ID, domain)
 }

--- a/tracing/reset_test.go
+++ b/tracing/reset_test.go
@@ -1,0 +1,127 @@
+package tracing
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/timing"
+)
+
+// resetTestMsg is a minimal message used to drive the reset helpers through the
+// real receiver-task registry and a recording tracer.
+type resetTestMsg struct {
+	messaging.MsgMeta
+}
+
+var _ = Describe("Reset task-cleanup helpers", func() {
+	var (
+		comp   *ibFakeComp
+		tracer *ibRecordingTracer
+	)
+
+	BeforeEach(func() {
+		comp = &ibFakeComp{name: "ResetComp"}
+		tracer = &ibRecordingTracer{}
+		CollectTrace(comp, tracer)
+	})
+
+	Describe("EndReqInOnReset", func() {
+		It("ends the in-flight req_in task and forgets its registry entry", func() {
+			req := resetTestMsg{messaging.MsgMeta{ID: 7}}
+			comp.time = 100
+			TraceReqReceive(comp, req)
+
+			// The task started and its registry entry exists.
+			taskID, ok := receiverTaskIDByMsgID(7, comp)
+			Expect(ok).To(BeTrue())
+			Expect(tracer.starts).To(HaveLen(1))
+			Expect(tracer.starts[0].ID).To(Equal(taskID))
+			Expect(tracer.starts[0].Kind).To(Equal("req_in"))
+
+			comp.time = 150
+			EndReqInOnReset(comp, 7)
+
+			// The task ended at reset time and the registry entry is gone.
+			Expect(tracer.ends).To(HaveLen(1))
+			Expect(tracer.ends[0].ID).To(Equal(taskID))
+			Expect(tracer.ends[0].Time).To(Equal(timing.VTimeInPicoSec(150)))
+			_, ok = receiverTaskIDByMsgID(7, comp)
+			Expect(ok).To(BeFalse())
+		})
+
+		It("is a no-op for a message that opened no req_in", func() {
+			comp.time = 150
+			EndReqInOnReset(comp, 999)
+
+			Expect(tracer.ends).To(BeEmpty())
+			// No phantom registry entry is created by the lookup.
+			_, ok := receiverTaskIDByMsgID(999, comp)
+			Expect(ok).To(BeFalse())
+		})
+
+		It("matches the success-path completion for the same request", func() {
+			// TraceReqComplete and EndReqInOnReset must end the same task ID and
+			// both clear the registry, so a reset is indistinguishable in the
+			// trace from a normal completion except for the end time.
+			req := resetTestMsg{messaging.MsgMeta{ID: 11}}
+			TraceReqReceive(comp, req)
+			taskID, _ := receiverTaskIDByMsgID(11, comp)
+
+			EndReqInOnReset(comp, 11)
+
+			Expect(tracer.ends).To(HaveLen(1))
+			Expect(tracer.ends[0].ID).To(Equal(taskID))
+			_, ok := receiverTaskIDByMsgID(11, comp)
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("EndTaskOnReset", func() {
+		It("ends the in-flight req_out task by the message's own ID", func() {
+			reqToBottom := resetTestMsg{messaging.MsgMeta{ID: 42}}
+			comp.time = 100
+			TraceReqInitiate(comp, reqToBottom, 0)
+
+			Expect(tracer.starts).To(HaveLen(1))
+			Expect(tracer.starts[0].ID).To(Equal(uint64(42)))
+			Expect(tracer.starts[0].Kind).To(Equal("req_out"))
+
+			comp.time = 160
+			EndTaskOnReset(comp, 42)
+
+			Expect(tracer.ends).To(HaveLen(1))
+			Expect(tracer.ends[0].ID).To(Equal(uint64(42)))
+			Expect(tracer.ends[0].Time).To(Equal(timing.VTimeInPicoSec(160)))
+		})
+
+		It("ends a subtask (e.g. sub-trans or pipeline) by its own task ID", func() {
+			comp.time = 100
+			StartTask(comp, TaskStart{
+				ID: 77, ParentID: 5, Kind: "sub-trans", What: "subtrans",
+			})
+
+			comp.time = 170
+			EndTaskOnReset(comp, 77)
+
+			Expect(tracer.ends).To(HaveLen(1))
+			Expect(tracer.ends[0].ID).To(Equal(uint64(77)))
+		})
+
+		It("is a no-op when the domain has no hooks", func() {
+			untraced := &ibFakeComp{name: "Untraced"}
+			EndTaskOnReset(untraced, 12345)
+			Expect(tracer.ends).To(BeEmpty())
+		})
+
+		It("emits the end unconditionally; the consumer ignores unknown IDs", func() {
+			// Unlike EndReqInOnReset, EndTaskOnReset cannot tell whether the
+			// task was started — req_out/subtask IDs have no registry entry — so
+			// it always emits. The DBTracer drops ends for IDs it never saw
+			// start, which is what makes blanket end-on-reset safe.
+			EndTaskOnReset(comp, 12345)
+			Expect(tracer.ends).To(HaveLen(1))
+			Expect(tracer.ends[0].ID).To(Equal(uint64(12345)))
+		})
+	})
+})

--- a/tracing/tracingtest/leakrecorder.go
+++ b/tracing/tracingtest/leakrecorder.go
@@ -1,0 +1,81 @@
+// Package tracingtest provides tracing test helpers shared across the
+// component packages, so each does not re-implement the same recording tracer.
+package tracingtest
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sarchlab/akita/v5/tracing"
+)
+
+// LeakRecorder is a [tracing.Tracer] that tracks which tasks a component has
+// started but not yet ended. It exists for reset-leak tests: attach it with
+// [tracing.CollectTrace], drive the component into an in-flight state, issue a
+// control Reset, then assert [LeakRecorder.OpenTasks] is empty — any task still
+// open is a started-never-ended leak (and, for a req_in, a leaked
+// receiver-registry entry, since the component ends and forgets it together).
+//
+// It records only task starts and ends, so milestones and tags — which never
+// open a task — do not register, and a blanket end-on-reset of a task that was
+// never started is a no-op (deleting an absent key). Do not attach
+// [tracing.CollectIncomingBufferTrace]: the buffer tasks it opens are ended by
+// the port retrieve hook, not the component, and would otherwise show up here.
+type LeakRecorder struct {
+	tracing.NopTracer
+
+	started int
+	open    map[uint64]tracing.TaskStart
+}
+
+// StartTask records a task as open.
+func (r *LeakRecorder) StartTask(s tracing.TaskStart) {
+	if r.open == nil {
+		r.open = map[uint64]tracing.TaskStart{}
+	}
+
+	r.started++
+	r.open[s.ID] = s
+}
+
+// EndTask removes a task from the open set. Ending a task that was never started
+// is a no-op, which is what makes blanket end-on-reset safe.
+func (r *LeakRecorder) EndTask(e tracing.TaskEnd) {
+	delete(r.open, e.ID)
+}
+
+// NumStarted reports how many tasks were started, so a test can assert its
+// traffic actually opened tasks (otherwise an empty open set is vacuous).
+func (r *LeakRecorder) NumStarted() int {
+	return r.started
+}
+
+// OpenTasks returns the tasks that were started but not ended, sorted by ID for
+// a stable failure message.
+func (r *LeakRecorder) OpenTasks() []tracing.TaskStart {
+	out := make([]tracing.TaskStart, 0, len(r.open))
+	for _, s := range r.open {
+		out = append(out, s)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+
+	return out
+}
+
+// OpenSummary renders the still-open tasks as "kind:what" entries for a test
+// failure message; it returns "none" when there is no leak.
+func (r *LeakRecorder) OpenSummary() string {
+	open := r.OpenTasks()
+	if len(open) == 0 {
+		return "none"
+	}
+
+	parts := make([]string, len(open))
+	for i, s := range open {
+		parts[i] = fmt.Sprintf("%s:%s", s.Kind, s.What)
+	}
+
+	return strings.Join(parts, ", ")
+}


### PR DESCRIPTION
## Summary

Every stateful mem component cleared its in-flight container on `Reset` **without** ending the open `req_in`/`req_out` (and DRAM sub-trans) tracing tasks or releasing their receiver-registry entries — producing started-never-ended tasks and slow registry growth whenever a `Reset` raced traffic. (The ROB forgot the registry entries but still never `EndTask`'d the `req_in` nor finalized the shadow `req_out`.) This is **Step 3** of `TRACING_INSTRUMENTATION_PLAN.md`.

Two shared helpers make all sites converge on one pattern:

- **`tracing.EndReqInOnReset(domain, reqMsgID)`** — resolves the `req_in` task ID via a new lookup-only registry accessor (`receiverTaskIDByMsgID`, no create), then `EndTask` + forgets the entry. Mirrors `TraceReqComplete` but takes the message ID, which is all a reset path retains.
- **`tracing.EndTaskOnReset(domain, taskID)`** — `EndTask` by literal task ID, for every task keyed on its own ID rather than the receiver registry: a downstream `req_out`, a DRAM sub-trans, a writethrough `cache_transaction`, or a pipeline subtask. `EndTask` no-ops for IDs the `DBTracer` never saw start, so blanket end-on-reset is safe.

Each component grows an `endInflightTasks()` called in `handleReset` **before** the in-flight state is cleared. Because `RecvTaskID == MsgIDAtReceiver(reqMsgID)` (same registry key), even the components that store the task ID directly (mmu/gmmu/ideal) use the message-ID form, so all 12 sites are uniform.

## Changes

- **Helpers:** `tracing/api.go` (`EndReqInOnReset`, `EndTaskOnReset`), `tracing/registry.go` (lookup-only `receiverTaskIDByMsgID`).
- **All 12 `handleReset` sites** gain `endInflightTasks()`: rob, tlb, addresstranslator, writeback, writethroughcache, datamover, mmu, gmmu, dram, idealmemcontroller, simplebankedmemory, mmuCache.
  - ROB's forget-only `forgetInflightReceiverIDs` is **replaced** with full end+forget (it previously leaked both the `req_in` end and the shadow `req_out`).
  - mmuCache's existing `endInflightReqs` is **refactored** onto the shared helpers (drops throwaway-message reconstruction).
  - Beyond the plan's `req_in`/`req_out`/sub-trans, the rollout also ends the **pipeline subtasks** (tlb/writeback/simplebanked) and the writethrough **`cache_transaction`** surfaced by the cross-component audit.

## Testing

- A **`TestResetEndsInflightTracingTasks`** in every component drives a request into flight (response withheld), issues `Reset`, and asserts a new shared `tracingtest.LeakRecorder` shows zero started-never-ended tasks. Several are negative-control checked (neutering `endInflightTasks` fails the test with the exact leaked kinds). Coverage spans every shape: leaf `req_in` (mmu/ideal), `req_in`+`req_out` (rob/datamover/AT/mmuCache/gmmu — gmmu reaches the remote-fetch path), sub-trans (dram), pipeline subtask (simplebanked/tlb), and the three-tier writethrough.
- `tracing/reset_test.go` unit-tests the two helpers directly.
- `go test ./tracing/... ./mem/...`, `go vet`, and golangci-lint are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)