### PR TITLE
tracing: trace outgoing-buffer residency as a per-port subtask

### DIFF
--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -131,10 +131,12 @@ func (s *Simulation) RegisterPort(p naming.Named) {
 
 	s.registerPort(port)
 
-	// Attach incoming-buffer tracing, mirroring how RegisterComponent attaches
-	// CollectTrace. The resulting tasks flow to the component tracer, so they
-	// only materialize for components that are themselves traced.
+	// Attach incoming- and outgoing-buffer tracing, mirroring how
+	// RegisterComponent attaches CollectTrace. The resulting tasks flow to the
+	// component tracer, so they only materialize for components that are
+	// themselves traced.
 	tracing.CollectIncomingBufferTrace(p)
+	tracing.CollectOutgoingBufferTrace(p)
 
 	if s.monitor != nil {
 		s.monitor.RegisterPort(port)

--- a/tracing/api.go
+++ b/tracing/api.go
@@ -189,6 +189,33 @@ func ForgetMsgIDAtIncomingBuffer(msgID uint64, domain NamedHookable) {
 	forgetIncomingBufferTaskIDByMsgID(msgID, domain)
 }
 
+// MsgIDAtOutgoingBuffer returns the task ID of the buffer task that tracks a
+// message's residency in the sending port's outgoing buffer. The ID lives in a
+// tracing-local registry keyed by (domain, msg.Meta().ID), so the port hook
+// that opens the task and the one that closes it derive the same ID without
+// mutating the message. When the domain has no hooks the ID is unused, so this
+// returns 0 without touching the registry.
+func MsgIDAtOutgoingBuffer(msg messaging.Msg, domain NamedHookable) uint64 {
+	if domain.NumHooks() == 0 {
+		return 0
+	}
+
+	return lookupOrCreateOutgoingBufferTaskID(msg, domain)
+}
+
+// ForgetMsgIDAtOutgoingBuffer releases the registry entry created by
+// [MsgIDAtOutgoingBuffer] for the message identified by msgID. The port hook
+// calls this when the buffer task ends (the message is drained by the
+// connection). When the domain has no hooks no entry was ever inserted, so this
+// is a no-op.
+func ForgetMsgIDAtOutgoingBuffer(msgID uint64, domain NamedHookable) {
+	if domain.NumHooks() == 0 {
+		return
+	}
+
+	forgetOutgoingBufferTaskIDByMsgID(msgID, domain)
+}
+
 // TraceReqInitiate marks a task starting at the sender of a message. The
 // task ID is the message's own ID, which is fixed at message construction.
 // The task kind is "req_out".

--- a/tracing/outgoingbuffertracer.go
+++ b/tracing/outgoingbuffertracer.go
@@ -1,0 +1,168 @@
+package tracing
+
+import (
+	"sync"
+
+	"github.com/sarchlab/akita/v5/hooking"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/naming"
+)
+
+// OutgoingBufferTaskKind is the Kind of the task that records how long a message
+// sits in a port's outgoing buffer — from the moment the owning component sends
+// it until the connection retrieves (drains) it onto the link. The task carries
+// a "reached head" milestone (emitted by the hook the instant the message
+// becomes the head of the buffer) that ends the waiting-behind-others interval;
+// the remaining time at the head, until the connection drains it, is the wait
+// for the link to become free. The component's own work that produced the
+// message is the separate req_out task, whose ID this task is parented to.
+const OutgoingBufferTaskKind = "outgoing_buffer"
+
+// outgoingBufferHook records, for each message sent from a port, a buffer task
+// spanning the message's residency in the outgoing buffer. The task is a child
+// of the message's req_out task (the request's own ID, or, for a response, the
+// ID it responds to). It is located at the sending port and emitted on the
+// port's owning component, so it flows to that component's tracers.
+//
+// The task opens on HookPosPortMsgSend (enqueue) and closes on
+// HookPosPortMsgRetrieveOutgoing (drain by the connection). The hook emits a
+// "reached head" milestone the instant the message becomes the head of the
+// buffer:
+//   - immediately, if it is sent into an empty buffer; or
+//   - when the message ahead of it is drained, exposing it as the new head.
+//
+// Reaching the head is detected here, from the buffer's own push/pop events, so
+// it is exact.
+//
+// HookPosPortMsgSend fires while the port holds its lock, so the hook must not
+// call back into the port there. It tracks the buffer depth itself (depth) to
+// tell whether a freshly sent message is already at the head. The outgoing
+// buffer is FIFO and the only push/pop paths are Send/RetrieveOutgoing, both of
+// which fire these hooks, so the mirrored depth stays exact.
+type outgoingBufferHook struct {
+	mu    sync.Mutex
+	depth int // messages currently in the port's outgoing buffer
+}
+
+// Func implements hooking.Hook.
+func (h *outgoingBufferHook) Func(ctx hooking.HookCtx) {
+	port, ok := ctx.Domain.(messaging.Port)
+	if !ok {
+		return
+	}
+
+	domain, ok := port.Component().(NamedHookable)
+	if !ok {
+		return
+	}
+
+	msg, ok := ctx.Item.(messaging.Msg)
+	if !ok {
+		return
+	}
+
+	switch ctx.Pos {
+	case messaging.HookPosPortMsgSend:
+		h.onSend(domain, port, msg)
+	case messaging.HookPosPortMsgRetrieveOutgoing:
+		h.onRetrieve(domain, port, msg)
+	}
+}
+
+// onSend opens the buffer task. A message sent into an empty buffer is already
+// at the head, so its reached-head milestone fires at once (its
+// waiting-behind-others interval is zero). Records nothing — and generates no
+// ID — when the component is not being traced.
+func (h *outgoingBufferHook) onSend(
+	domain NamedHookable,
+	port messaging.Port,
+	msg messaging.Msg,
+) {
+	if domain.NumHooks() == 0 {
+		return
+	}
+
+	meta := msg.Meta()
+
+	parentID := meta.ID
+	if meta.IsRsp() {
+		parentID = meta.RspTo
+	}
+
+	id := MsgIDAtOutgoingBuffer(msg, domain)
+
+	h.mu.Lock()
+	atHead := h.depth == 0
+	h.depth++
+	h.mu.Unlock()
+
+	StartTask(domain, TaskStart{
+		ID:       id,
+		ParentID: parentID,
+		Kind:     OutgoingBufferTaskKind,
+		What:     msgTypeName(msg),
+		Location: port.Name(),
+	})
+
+	if atHead {
+		h.markReachedHead(domain, port, id)
+	}
+}
+
+// onRetrieve closes the drained message's buffer task and, if the buffer is not
+// now empty, marks the message exposed as the new head as having reached it.
+// The retrieve hook runs after the port releases its lock, so peeking the new
+// head here is safe.
+func (h *outgoingBufferHook) onRetrieve(
+	domain NamedHookable,
+	port messaging.Port,
+	retrieved messaging.Msg,
+) {
+	if domain.NumHooks() == 0 {
+		return
+	}
+
+	h.mu.Lock()
+	if h.depth > 0 {
+		h.depth--
+	}
+	h.mu.Unlock()
+
+	EndTask(domain, TaskEnd{ID: MsgIDAtOutgoingBuffer(retrieved, domain)})
+	ForgetMsgIDAtOutgoingBuffer(retrieved.Meta().ID, domain)
+
+	newHead := port.PeekOutgoing()
+	if newHead == nil {
+		return
+	}
+
+	h.markReachedHead(domain, port, MsgIDAtOutgoingBuffer(newHead, domain))
+}
+
+// markReachedHead records that a message has reached the head of the buffer and
+// stopped waiting behind earlier messages. Any further delay before the
+// connection drains it is the wait for the link to become free.
+func (h *outgoingBufferHook) markReachedHead(
+	domain NamedHookable, port messaging.Port, taskID uint64,
+) {
+	AddMilestone(domain, Milestone{
+		TaskID: taskID,
+		Kind:   MilestoneKindQueue,
+		What:   port.Name(),
+	})
+}
+
+// CollectOutgoingBufferTrace attaches outgoing-buffer tracing to a port. It
+// accepts any named entity and is a no-op for anything that is not a
+// [messaging.Port], so callers that handle entities uniformly can pass them
+// through without a type switch. The emitted tasks flow to the tracers
+// collecting from the port's owning component, so this is only effective once
+// that component is itself being traced (see [CollectTrace]).
+func CollectOutgoingBufferTrace(port naming.Named) {
+	p, ok := port.(messaging.Port)
+	if !ok {
+		return
+	}
+
+	p.AcceptHook(&outgoingBufferHook{})
+}

--- a/tracing/outgoingbuffertracer_test.go
+++ b/tracing/outgoingbuffertracer_test.go
@@ -1,0 +1,155 @@
+package tracing
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/sarchlab/akita/v5/hooking"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/timing"
+)
+
+// obFakeComp is a minimal component that satisfies both messaging.Component
+// (so it can own a real port) and NamedHookable (so the tracing API can emit
+// tasks on it). InvokeHook is provided by the embedded HookableBase, which is
+// how CollectTrace forwards events to a tracer.
+type obFakeComp struct {
+	hooking.HookableBase
+	name string
+	time timing.VTimeInPicoSec
+}
+
+func (c *obFakeComp) Name() string                       { return c.name }
+func (c *obFakeComp) CurrentTime() timing.VTimeInPicoSec { return c.time }
+
+func (c *obFakeComp) DeclarePort(string, ...*messaging.Role) {}
+func (c *obFakeComp) AssignPort(string, messaging.Port)      {}
+func (c *obFakeComp) GetPortByName(string) messaging.Port    { return nil }
+func (c *obFakeComp) Ports() []messaging.Port                { return nil }
+func (c *obFakeComp) NotifyRecv(messaging.Port)              {}
+func (c *obFakeComp) NotifyPortFree(messaging.Port)          {}
+
+// obRecordingTracer captures the task events the hook produces.
+type obRecordingTracer struct {
+	NopTracer
+	starts     []TaskStart
+	ends       []TaskEnd
+	milestones []Milestone
+}
+
+func (t *obRecordingTracer) StartTask(ts TaskStart)   { t.starts = append(t.starts, ts) }
+func (t *obRecordingTracer) EndTask(te TaskEnd)       { t.ends = append(t.ends, te) }
+func (t *obRecordingTracer) AddMilestone(m Milestone) { t.milestones = append(t.milestones, m) }
+
+type obTestMsg struct {
+	messaging.MsgMeta
+}
+
+// obFakeConn is a no-op connection so that Send into an empty outgoing buffer
+// (which notifies the connection) does not dereference a nil pointer.
+type obFakeConn struct {
+	hooking.HookableBase
+}
+
+func (c *obFakeConn) Name() string                  { return "Conn" }
+func (c *obFakeConn) PlugIn(messaging.Port)          {}
+func (c *obFakeConn) Unplug(messaging.Port)          {}
+func (c *obFakeConn) NotifyAvailable(messaging.Port) {}
+func (c *obFakeConn) NotifySend()                    {}
+
+var _ = Describe("Outgoing buffer tracer", func() {
+	var (
+		comp   *obFakeComp
+		tracer *obRecordingTracer
+		port   messaging.Port
+	)
+
+	BeforeEach(func() {
+		comp = &obFakeComp{name: "Comp"}
+		tracer = &obRecordingTracer{}
+		CollectTrace(comp, tracer)
+
+		port = messaging.NewPort(comp, 4, 4, "Comp.Bottom")
+		port.SetConnection(&obFakeConn{})
+		CollectOutgoingBufferTrace(port)
+	})
+
+	It("spans send to drain and marks reached-head the instant the message "+
+		"becomes the head of the buffer", func() {
+		// A enters an empty buffer => immediately at the head.
+		a := obTestMsg{messaging.MsgMeta{ID: 7, Src: "Comp.Bottom", Dst: "Other.Top"}}
+		comp.time = 100
+		port.Send(a)
+
+		// B enters behind A => not yet at the head.
+		b := obTestMsg{messaging.MsgMeta{ID: 8, Src: "Comp.Bottom", Dst: "Other.Top"}}
+		comp.time = 110
+		port.Send(b)
+
+		Expect(tracer.starts).To(HaveLen(2))
+		startA := tracer.starts[0]
+		Expect(startA.Kind).To(Equal(OutgoingBufferTaskKind))
+		Expect(startA.ParentID).To(Equal(uint64(7)))
+		Expect(startA.What).To(Equal("obTestMsg"))
+		Expect(startA.Location).To(Equal("Comp.Bottom"))
+		Expect(startA.Time).To(Equal(timing.VTimeInPicoSec(100)))
+		startB := tracer.starts[1]
+		Expect(startB.ParentID).To(Equal(uint64(8)))
+		Expect(startB.Time).To(Equal(timing.VTimeInPicoSec(110)))
+
+		// A reached the head at send (empty buffer); B has not.
+		Expect(tracer.milestones).To(HaveLen(1))
+		Expect(tracer.milestones[0].TaskID).To(Equal(startA.ID))
+		Expect(tracer.milestones[0].Kind).To(Equal(MilestoneKindQueue))
+		Expect(tracer.milestones[0].What).To(Equal("Comp.Bottom"))
+		Expect(tracer.milestones[0].Time).To(Equal(timing.VTimeInPicoSec(100)))
+
+		// Neither task ends until its own message is drained.
+		Expect(tracer.ends).To(BeEmpty())
+
+		// Draining A ends A's buffer task and exposes B at the head.
+		comp.time = 150
+		Expect(port.RetrieveOutgoing()).NotTo(BeNil())
+
+		Expect(tracer.ends).To(HaveLen(1))
+		Expect(tracer.ends[0].ID).To(Equal(startA.ID))
+		Expect(tracer.ends[0].Time).To(Equal(timing.VTimeInPicoSec(150)))
+
+		Expect(tracer.milestones).To(HaveLen(2))
+		Expect(tracer.milestones[1].TaskID).To(Equal(startB.ID))
+		Expect(tracer.milestones[1].Kind).To(Equal(MilestoneKindQueue))
+		Expect(tracer.milestones[1].Time).To(Equal(timing.VTimeInPicoSec(150)))
+
+		// Draining B ends B's buffer task.
+		comp.time = 160
+		Expect(port.RetrieveOutgoing()).NotTo(BeNil())
+		Expect(tracer.ends).To(HaveLen(2))
+		Expect(tracer.ends[1].ID).To(Equal(startB.ID))
+		Expect(tracer.ends[1].Time).To(Equal(timing.VTimeInPicoSec(160)))
+	})
+
+	It("parents a response's buffer task to the task it responds to", func() {
+		rsp := obTestMsg{messaging.MsgMeta{ID: 9, RspTo: 7, Src: "Comp.Bottom", Dst: "Other.Top"}}
+
+		comp.time = 200
+		port.Send(rsp)
+
+		Expect(tracer.starts).To(HaveLen(1))
+		Expect(tracer.starts[0].ParentID).To(Equal(uint64(7)))
+	})
+
+	It("is a no-op when the owning component is not being traced", func() {
+		untraced := &obFakeComp{name: "Untraced"}
+		p2 := messaging.NewPort(untraced, 4, 4, "Untraced.Bottom")
+		p2.SetConnection(&obFakeConn{})
+		CollectOutgoingBufferTrace(p2)
+
+		untraced.time = 100
+		p2.Send(obTestMsg{messaging.MsgMeta{ID: 1, Src: "Untraced.Bottom", Dst: "Other.Top"}})
+		Expect(p2.RetrieveOutgoing()).NotTo(BeNil())
+
+		Expect(tracer.starts).To(BeEmpty())
+		Expect(tracer.ends).To(BeEmpty())
+		Expect(tracer.milestones).To(BeEmpty())
+	})
+})

--- a/tracing/registry.go
+++ b/tracing/registry.go
@@ -109,3 +109,46 @@ func forgetIncomingBufferTaskIDByMsgID(msgID uint64, domain NamedHookable) {
 	delete(incomingBufferTaskIDs, key)
 	incomingBufferTaskIDsMu.Unlock()
 }
+
+// The outgoing-buffer task ID registry maps (domain, message-ID) to the task ID
+// of the buffer task that tracks a message's residency in a port's outgoing
+// buffer (from send until the connection drains it). It is kept separate from
+// the incoming-buffer registry so that a message which is both received and
+// re-sent by the same component (same domain name, same message ID) gets a
+// distinct task on each side.
+
+type outgoingBufferTaskKey struct {
+	domain string
+	msgID  uint64
+}
+
+var (
+	outgoingBufferTaskIDs   = make(map[outgoingBufferTaskKey]uint64)
+	outgoingBufferTaskIDsMu sync.Mutex
+)
+
+func lookupOrCreateOutgoingBufferTaskID(
+	msg messaging.Msg, domain NamedHookable,
+) uint64 {
+	key := outgoingBufferTaskKey{domain: domain.Name(), msgID: msg.Meta().ID}
+
+	outgoingBufferTaskIDsMu.Lock()
+	defer outgoingBufferTaskIDsMu.Unlock()
+
+	if id, ok := outgoingBufferTaskIDs[key]; ok {
+		return id
+	}
+
+	id := timing.GetIDGenerator().Generate()
+	outgoingBufferTaskIDs[key] = id
+
+	return id
+}
+
+func forgetOutgoingBufferTaskIDByMsgID(msgID uint64, domain NamedHookable) {
+	key := outgoingBufferTaskKey{domain: domain.Name(), msgID: msgID}
+
+	outgoingBufferTaskIDsMu.Lock()
+	delete(outgoingBufferTaskIDs, key)
+	outgoingBufferTaskIDsMu.Unlock()
+}


### PR DESCRIPTION
## Problem

A `req_out` task starts the instant the sender pushes a message into its port's **outgoing buffer** — `TraceReqInitiate` runs right after `Send`. But the message may then sit in that buffer until the connection drains it onto the link. Until now that wait was invisible: the `req_out` rendered as a solid active bar even while the message was blocked behind the link, so a viewer couldn't tell "working" from "waiting on the network."

This is the gap visible in Daisen between a `req_out`'s start and when the receiver actually begins handling it.

## Change

Mirrors the existing **incoming**-buffer tracer for the outgoing side:

- **`tracing/outgoingbuffertracer.go`** — `outgoingBufferHook` opens an `outgoing_buffer` task on `HookPosPortMsgSend` and closes it on `HookPosPortMsgRetrieveOutgoing` (drain by the connection). Parent = the message's req_out (`msg.ID`, or `RspTo` for a response), located at the sending port, emitted on the port's owning component so it flows to that component's tracers. A reached-head `queue` milestone fires the instant the message becomes buffer head, splitting "queued behind others" from "waiting for the link."
- **Lock semantics** match the incoming side: `Send` fires its hook *under* the port lock (depth is mirrored locally, no callback into the port), `RetrieveOutgoing` fires *after* unlock (so `PeekOutgoing` is safe).
- **`tracing/registry.go`** — a separate outgoing-buffer task-ID registry, kept distinct from incoming so a received-and-re-sent message gets its own task on each side.
- **`tracing/api.go`** — `MsgIDAtOutgoingBuffer` / `ForgetMsgIDAtOutgoingBuffer` wrappers.
- **`simulation/simulation.go`** — `RegisterPort` now also calls `CollectOutgoingBufferTrace(p)`, so every port gets it automatically and it only materializes for traced components.

Daisen needs no change — it renders the kind generically, exactly like `incoming_buffer`.

## Verification

- `go build ./...` clean; `tracing`, `simulation`, `messaging` suites pass (incl. a new `outgoingbuffertracer_test.go` mirroring the incoming test: span, reached-head, response parenting, untraced no-op).
- End-to-end on a virtualmem trace: **100%** of `outgoing_buffer` tasks parent to a `req_out`, each nonzero wait nests inside its parent's window, and real blocking is captured — **144,585 nonzero waits, max ~3.6 µs** at 20k accesses.

## Follow-up (not in this PR)

~78% of buffer tasks are zero-duration (same-tick pass-through) — pure trace bloat. A zero-duration filter applied to **both** the incoming and outgoing tracers would cut trace size substantially; left out here to match the existing incoming tracer's behavior rather than change policy unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)