### PR TITLE
tracing: milestone coverage principles — document + enforce across mem components

### DIFF
--- a/mem/cache/writeback/bankstage.go
+++ b/mem/cache/writeback/bankstage.go
@@ -113,11 +113,48 @@ func (s *bankStage) pullFromDirBuffer(next *State, spec Spec) bool {
 }
 
 func (s *bankStage) acceptIntoPipeline(next *State, spec Spec, transIdx int) {
+	trans := &next.Transactions[transIdx]
+
+	// Open the bank subtask spanning this data-array pipeline traversal, a child
+	// of the req_in, so the ".bank" work milestone has a corresponding child bar
+	// and the bank latency is not an unexplained tail before the response. A
+	// transaction that visits the bank more than once (e.g. evict then fill)
+	// opens one subtask per visit, each closed in finishBank.
+	if trans.hasReqMeta() {
+		pid := timing.GetIDGenerator().Generate()
+		trans.BankPID = pid
+		tracing.StartTask(s.cache.comp, tracing.TaskStart{
+			ID:       pid,
+			ParentID: tracing.MsgIDAtReceiver(trans.reqMeta(), s.cache.comp),
+			Kind:     tracing.PipelineTaskKind,
+			What:     s.cache.comp.Name() + ".bank",
+		})
+	}
+
 	if spec.BankLatency > 0 {
 		next.BankPipelines[s.bankID].Accept(transIdx)
 	} else {
 		// Bypass pipeline: put directly in post-pipeline buffer
 		next.BankPostPipelineBufs[s.bankID].PushTyped(transIdx)
+	}
+}
+
+// finishBank closes the transaction's current bank subtask and records the bank
+// access as work on its req_in, so the bank-pipeline traversal renders as a
+// child bar paired with a work milestone (per the tracing coverage principles).
+func (s *bankStage) finishBank(trans *transactionState) {
+	if !trans.hasReqMeta() {
+		return
+	}
+
+	tracing.AddMilestone(s.cache.comp, tracing.Milestone{
+		TaskID: tracing.MsgIDAtReceiver(trans.reqMeta(), s.cache.comp),
+		Kind:   tracing.MilestoneKindWork,
+		What:   s.cache.comp.Name() + ".bank",
+	})
+	if trans.BankPID != 0 {
+		tracing.EndTask(s.cache.comp, tracing.TaskEnd{ID: trans.BankPID})
+		trans.BankPID = 0
 	}
 }
 
@@ -187,6 +224,7 @@ func (s *bankStage) finalizeReadHit(transIdx int, trans *transactionState) bool 
 	dataReady.TrafficClass = "memprotocol.DataReadyRsp"
 	s.cache.topPort().Send(dataReady)
 
+	s.finishBank(trans)
 	tracing.TraceReqComplete(s.cache.comp, trans.ReadMeta)
 
 	return true
@@ -224,6 +262,7 @@ func (s *bankStage) finalizeWriteHit(transIdx int, trans *transactionState) bool
 	done.TrafficClass = "memprotocol.WriteDoneRsp"
 	s.cache.topPort().Send(done)
 
+	s.finishBank(trans)
 	tracing.TraceReqComplete(s.cache.comp, trans.WriteMeta)
 
 	return true
@@ -286,6 +325,8 @@ func (s *bankStage) finalizeBankWriteFetched(
 
 	next.BankInflightTransCounts[s.bankID]--
 
+	s.finishBank(trans)
+
 	return true
 }
 
@@ -330,6 +371,8 @@ func (s *bankStage) finalizeBankEviction(
 
 	next.BankInflightTransCounts[s.bankID]--
 	next.BankDownwardInflightTransCounts[s.bankID]--
+
+	s.finishBank(trans)
 
 	return true
 }

--- a/mem/cache/writeback/comp.go
+++ b/mem/cache/writeback/comp.go
@@ -252,6 +252,13 @@ type transactionState struct {
 	// attributed to a pipeline subtask.
 	DirPipelinePID uint64 `json:"dir_pipeline_pid"`
 
+	// BankPID is the tracing task ID of the bank (data-array) pipeline subtask
+	// (a child of the request's req_in). It is set when the transaction is
+	// accepted into the bank pipeline and consumed when the bank finalizes the
+	// access, pairing with the ".bank" work milestone so the bank latency shows
+	// as a child bar instead of an unexplained tail before the response.
+	BankPID uint64 `json:"bank_pid"`
+
 	// MSHR entry reference (into mshrState.Entries)
 	MSHREntryIndex int  `json:"mshr_entry_index"`
 	HasMSHREntry   bool `json:"has_mshr_entry"`
@@ -287,6 +294,14 @@ func (t *transactionState) reqMeta() messaging.MsgMeta {
 		return t.FlushMeta
 	}
 	panic("no request")
+}
+
+// hasReqMeta reports whether the transaction carries a primary request, i.e.
+// whether reqMeta is safe to call and there is a req_in task to attribute work
+// to. Every transaction that reaches the bank in a real run has one (it passed
+// through the directory); it guards against synthetic bank-only transactions.
+func (t *transactionState) hasReqMeta() bool {
+	return t.HasRead || t.HasWrite || t.HasFlush
 }
 
 // Resources holds the shared resources and wiring referenced by the writeback

--- a/mem/cache/writeback/ctrlmiddleware.go
+++ b/mem/cache/writeback/ctrlmiddleware.go
@@ -270,12 +270,12 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 
 // endInflightTasks completes the req_in tracing task of every in-flight
 // transaction, finalizes its downstream fetch and eviction-writeback req_out
-// tasks, and closes its directory-pipeline subtask, so a hard Reset that drops
-// the transaction table leaves no started-never-ended task and no leaked
-// receiver-registry entry. A slot already marked Removed can still hold an
-// in-flight eviction (its req_in long since completed), so every slot is
+// tasks, and closes its directory-pipeline and bank subtasks, so a hard Reset
+// that drops the transaction table leaves no started-never-ended task and no
+// leaked receiver-registry entry. A slot already marked Removed can still hold
+// an in-flight eviction (its req_in long since completed), so every slot is
 // visited and the req_in end is idempotent. Mirrors bank/mshr-stage (req_in),
-// write-buffer stage (req_out), and the directory pipeline (subtask) completion.
+// write-buffer stage (req_out), and the directory/bank pipelines (subtasks).
 func (m *ctrlMiddleware) endInflightTasks() {
 	comp := m.pipeline.comp
 
@@ -296,6 +296,10 @@ func (m *ctrlMiddleware) endInflightTasks() {
 
 		if trans.DirPipelinePID != 0 {
 			tracing.EndTaskOnReset(comp, trans.DirPipelinePID)
+		}
+
+		if trans.BankPID != 0 {
+			tracing.EndTaskOnReset(comp, trans.BankPID)
 		}
 	}
 }

--- a/mem/cache/writeback/mshrstage.go
+++ b/mem/cache/writeback/mshrstage.go
@@ -111,6 +111,16 @@ func (s *mshrStage) respondRead(
 	dataReady.TrafficClass = "memprotocol.DataReadyRsp"
 	s.cache.topPort().Send(dataReady)
 
+	// This request waited for the fetched line to be written into the bank by
+	// the fetcher and resolved through this MSHR stage. It never visited the
+	// bank itself (only the fetcher did), so that wait is a dependency, not its
+	// own work — record it so the interval since the fill-data milestone is not
+	// an unexplained tail before the response.
+	tracing.AddMilestone(s.cache.comp, tracing.Milestone{
+		TaskID: tracing.MsgIDAtReceiver(&trans.ReadMeta, s.cache.comp),
+		Kind:   tracing.MilestoneKindDependency,
+		What:   s.cache.comp.Name() + ".fill",
+	})
 	tracing.TraceReqComplete(s.cache.comp, trans.ReadMeta)
 }
 
@@ -124,6 +134,14 @@ func (s *mshrStage) respondWrite(trans *transactionState) {
 	writeDoneRsp.TrafficClass = "memprotocol.WriteDoneRsp"
 	s.cache.topPort().Send(writeDoneRsp)
 
+	// See respondRead: the wait for the fetched line to land in the bank and
+	// resolve through this MSHR stage is a dependency on the fetcher, not this
+	// request's own bank work.
+	tracing.AddMilestone(s.cache.comp, tracing.Milestone{
+		TaskID: tracing.MsgIDAtReceiver(&trans.WriteMeta, s.cache.comp),
+		Kind:   tracing.MilestoneKindDependency,
+		What:   s.cache.comp.Name() + ".fill",
+	})
 	tracing.TraceReqComplete(s.cache.comp, trans.WriteMeta)
 }
 

--- a/mem/cache/writethroughcache/bankstage.go
+++ b/mem/cache/writethroughcache/bankstage.go
@@ -1,6 +1,7 @@
 package writethroughcache
 
 import (
+	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -54,6 +55,21 @@ func (s *bankStage) extractFromBuf() bool {
 	}
 
 	transIdx := bankBuf.Pop()
+	trans := &next.Transactions[transIdx]
+
+	// Open the bank subtask: the transaction is entering the bank (data-array)
+	// pipeline, so its bank read/write gets its own child bar under the req_in,
+	// mirroring the directory pipeline subtask. The bank latency then shows as
+	// real work rather than an unexplained gap before completion.
+	pid := timing.GetIDGenerator().Generate()
+	trans.BankTaskID = pid
+	tracing.StartTask(s.cache.comp, tracing.TaskStart{
+		ID:       pid,
+		ParentID: reqInTaskIDOf(s.cache.comp, trans),
+		Kind:     tracing.PipelineTaskKind,
+		What:     s.cache.comp.Name() + ".bank",
+	})
+
 	bankPipeline.Accept(transIdx)
 
 	return true
@@ -104,7 +120,7 @@ func (s *bankStage) finalizeReadHitTrans(
 	bankPostBuf := &next.BankPostBufs[s.bankID]
 	bankPostBuf.Pop()
 
-	tracing.EndTask(s.cache.comp, tracing.TaskEnd{ID: trans.ID})
+	s.finishBank(trans)
 
 	return true
 }
@@ -141,10 +157,10 @@ func (s *bankStage) finalizeWriteTrans(
 	bankPostBuf.Pop()
 
 	trans.BankDone = true
+	s.finishBank(trans)
 
 	if !trans.Done && writeTransIsReady(trans) {
 		trans.Done = true
-		tracing.EndTask(s.cache.comp, tracing.TaskEnd{ID: trans.ID})
 	}
 
 	return true
@@ -167,6 +183,8 @@ func (s *bankStage) finalizeWriteFetchedTrans(
 	bankPostBuf := &next.BankPostBufs[s.bankID]
 	bankPostBuf.Pop()
 
+	s.finishBank(trans)
+
 	// The merged line is now in storage. Any MSHR-coalesced write whose
 	// data was folded into this fill can be considered "fill-done"; if
 	// its bottom WriteDoneRsp has also arrived, finalize it here.
@@ -178,7 +196,6 @@ func (s *bankStage) finalizeWriteFetchedTrans(
 		offset := trans.ReadAddress - nextBlock.Tag
 		trans.Data = trans.Data[offset : offset+trans.ReadAccessByteSize]
 		trans.Done = true
-		tracing.EndTask(s.cache.comp, tracing.TaskEnd{ID: trans.ID})
 		return true
 	}
 
@@ -187,7 +204,6 @@ func (s *bankStage) finalizeWriteFetchedTrans(
 	trans.BankDone = true
 	if !trans.Done && writeTransIsReady(trans) {
 		trans.Done = true
-		tracing.EndTask(s.cache.comp, tracing.TaskEnd{ID: trans.ID})
 	}
 
 	return true
@@ -210,9 +226,34 @@ func (s *bankStage) completeMSHRFillWaiters(fetcherIdx int) {
 
 		waiter.MSHRFillDone = true
 
+		// The waiter coalesced onto the fetcher and never visits the bank
+		// itself; its merged data reached storage via the fetcher's bank
+		// write. That is a dependency it was blocked on — not its own work —
+		// so it gets a dependency milestone, not the bank subtask.
+		tracing.AddMilestone(s.cache.comp, tracing.Milestone{
+			TaskID: reqInTaskIDOf(s.cache.comp, waiter),
+			Kind:   tracing.MilestoneKindDependency,
+			What:   s.cache.comp.Name() + ".fill",
+		})
+
 		if writeTransIsReady(waiter) {
 			waiter.Done = true
-			tracing.EndTask(s.cache.comp, tracing.TaskEnd{ID: waiter.ID})
 		}
 	}
+}
+
+// finishBank closes the transaction's bank subtask and records the bank access
+// as work on the request's req_in task. The subtask is the child bar for the
+// bank (data-array) pipeline traversal; the milestone marks, on the request's
+// own task, that the bank read/write — the cache's last processing phase before
+// it responds — is done. Keeping both mirrors the directory pipeline, which
+// also pairs a subtask with a work milestone, so every "work" interval on the
+// req_in has a corresponding child bar.
+func (s *bankStage) finishBank(trans *transactionState) {
+	tracing.AddMilestone(s.cache.comp, tracing.Milestone{
+		TaskID: reqInTaskIDOf(s.cache.comp, trans),
+		Kind:   tracing.MilestoneKindWork,
+		What:   s.cache.comp.Name() + ".bank",
+	})
+	tracing.EndTask(s.cache.comp, tracing.TaskEnd{ID: trans.BankTaskID})
 }

--- a/mem/cache/writethroughcache/bottomparser.go
+++ b/mem/cache/writethroughcache/bottomparser.go
@@ -80,7 +80,6 @@ func (p *bottomParser) processDoneRsp(msg messaging.Msg) bool {
 
 	if !trans.Done && writeTransIsReady(trans) {
 		trans.Done = true
-		tracing.EndTask(p.cache.comp, tracing.TaskEnd{ID: trans.ID})
 	}
 
 	p.cache.bottomPort().RetrieveIncoming()
@@ -205,7 +204,6 @@ func (p *bottomParser) finalizeMSHRTransExcept(
 			offset := trans.ReadAddress - blockTag
 			trans.Data = data[offset : offset+trans.ReadAccessByteSize]
 			trans.Done = true
-			tracing.EndTask(p.cache.comp, tracing.TaskEnd{ID: trans.ID})
 			continue
 		}
 
@@ -214,7 +212,6 @@ func (p *bottomParser) finalizeMSHRTransExcept(
 		// satisfied (e.g. WriteDoneRsp landed first).
 		if !trans.Done && writeTransIsReady(trans) {
 			trans.Done = true
-			tracing.EndTask(p.cache.comp, tracing.TaskEnd{ID: trans.ID})
 		}
 	}
 }

--- a/mem/cache/writethroughcache/comp.go
+++ b/mem/cache/writethroughcache/comp.go
@@ -114,6 +114,13 @@ type transactionState struct {
 	// directory pipeline and closed when it leaves the post-pipeline buffer.
 	DirPipelineTaskID uint64 `json:"dir_pipeline_task_id"`
 
+	// BankTaskID is the ID of the pipeline subtask that records the
+	// transaction's traversal of the bank (data-array) pipeline — the bank
+	// read/write work. Like DirPipelineTaskID it is a child of the request's
+	// req_in task, opened when the transaction is accepted into the bank
+	// pipeline and closed when the bank finalizes the access.
+	BankTaskID uint64 `json:"bank_task_id"`
+
 	// WaitForMSHRFill / MSHRFillDone / MSHRFillFetcherIdx track an
 	// MSHR-coalesced write whose data is merged into another transaction's
 	// fetched line. The coalesced write never visits the bank itself, so

--- a/mem/cache/writethroughcache/ctrlmiddleware.go
+++ b/mem/cache/writethroughcache/ctrlmiddleware.go
@@ -175,14 +175,13 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 }
 
 // endInflightTasks completes the req_in tracing task of every in-flight
-// transaction, ends its cache_transaction task, finalizes its downstream
-// read/write req_out tasks, and closes its directory-pipeline subtask, so a hard
-// Reset that drops the transaction table leaves no started-never-ended task and
-// no leaked receiver-registry entry. A slot already marked Removed can still
-// hold a downstream write whose response will be ignored, so every slot is
-// visited and the already-ended req_in/cache_transaction ends are idempotent.
-// Mirrors respondStage (req_in), bankstage/bottomparser (cache_transaction),
-// bottomparser (req_out), and the directory pipeline (subtask) completion.
+// transaction, finalizes its downstream read/write req_out tasks, and closes
+// its directory-pipeline and bank subtasks, so a hard Reset that drops the
+// transaction table leaves no started-never-ended task and no leaked
+// receiver-registry entry. A slot already marked Removed can still hold a
+// downstream write whose response will be ignored, so every slot is visited and
+// the already-ended req_in end is idempotent. Mirrors respondStage (req_in),
+// bottomparser (req_out), and the directory/bank pipelines (subtasks).
 func (m *ctrlMiddleware) endInflightTasks() {
 	comp := m.pipeline.comp
 
@@ -196,8 +195,6 @@ func (m *ctrlMiddleware) endInflightTasks() {
 			tracing.EndReqInOnReset(comp, trans.WriteMeta.ID)
 		}
 
-		tracing.EndTaskOnReset(comp, trans.ID)
-
 		if trans.HasReadToBottom {
 			tracing.EndTaskOnReset(comp, trans.ReadToBottomMeta.ID)
 		}
@@ -208,6 +205,10 @@ func (m *ctrlMiddleware) endInflightTasks() {
 
 		if trans.DirPipelineTaskID != 0 {
 			tracing.EndTaskOnReset(comp, trans.DirPipelineTaskID)
+		}
+
+		if trans.BankTaskID != 0 {
+			tracing.EndTaskOnReset(comp, trans.BankTaskID)
 		}
 	}
 }

--- a/mem/cache/writethroughcache/directory.go
+++ b/mem/cache/writethroughcache/directory.go
@@ -100,18 +100,28 @@ func (d *directory) processPostPipeline() (madeProgress bool) {
 	return madeProgress
 }
 
-// reqInTaskID returns the ID of the transaction's req_in task, used to parent
-// the directory pipeline subtask. The req_in task is keyed by the original
-// request's message ID at the cache (see tracing.TraceReqReceive in intake),
-// so reconstructing a message carrying that meta recovers the same ID.
+// reqInTaskID returns the ID of the transaction's req_in task — the cache's
+// single receiver-side task for the request. The cache no longer opens a
+// separate cache_transaction child, so this req_in task is what carries the
+// transaction's hit/miss tags, its processing milestones, and its downstream
+// req_out children, in addition to parenting the directory pipeline subtask.
 func (d *directory) reqInTaskID(trans *transactionState) uint64 {
+	return reqInTaskIDOf(d.cache.comp, trans)
+}
+
+// reqInTaskIDOf recovers a transaction's req_in task ID from its stored request
+// meta, for any stage that has the component but not a *directory. The req_in
+// task is keyed by the original request's message ID at the cache (see
+// tracing.TraceReqReceive in intake), so reconstructing a message carrying that
+// meta recovers the same ID.
+func reqInTaskIDOf(comp *Comp, trans *transactionState) uint64 {
 	if trans.HasRead {
 		return tracing.MsgIDAtReceiver(
-			memprotocol.ReadReq{MsgMeta: trans.ReadMeta}, d.cache.comp)
+			memprotocol.ReadReq{MsgMeta: trans.ReadMeta}, comp)
 	}
 
 	return tracing.MsgIDAtReceiver(
-		memprotocol.WriteReq{MsgMeta: trans.WriteMeta}, d.cache.comp)
+		memprotocol.WriteReq{MsgMeta: trans.WriteMeta}, comp)
 }
 
 func (d *directory) processRead(trans *transactionState, transIdx int) bool {
@@ -151,12 +161,12 @@ func (d *directory) processMSHRHit(
 
 	if trans.HasRead {
 		tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-			TaskID: trans.ID,
+			TaskID: d.reqInTaskID(trans),
 			What:   "read-mshr-hit",
 		})
 	} else {
 		tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-			TaskID: trans.ID,
+			TaskID: d.reqInTaskID(trans),
 			What:   "write-mshr-hit",
 		})
 	}
@@ -197,7 +207,7 @@ func (d *directory) processReadHit(
 	dirPostBuf := &next.DirPostBuf
 	dirPostBuf.Pop()
 	tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-		TaskID: trans.ID,
+		TaskID: d.reqInTaskID(trans),
 		What:   "read-hit",
 	})
 
@@ -229,7 +239,7 @@ func (d *directory) processReadMiss(trans *transactionState, transIdx int) bool 
 	dirPostBuf := &next.DirPostBuf
 	dirPostBuf.Pop()
 	tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-		TaskID: trans.ID,
+		TaskID: d.reqInTaskID(trans),
 		What:   "read-miss",
 	})
 
@@ -305,7 +315,7 @@ func (d *directory) writeBottom(trans *transactionState) bool {
 	trans.WriteToBottomData = trans.WriteData
 	trans.WriteToBottomDirtyMask = trans.WriteDirtyMask
 
-	tracing.TraceReqInitiate(d.cache.comp, writeToBottom, trans.ID)
+	tracing.TraceReqInitiate(d.cache.comp, writeToBottom, d.reqInTaskID(trans))
 
 	return true
 }
@@ -339,7 +349,7 @@ func (d *directory) fetchFromBottom(
 
 	d.cache.bottomPort().Send(readToBottom)
 
-	tracing.TraceReqInitiate(d.cache.comp, readToBottom, trans.ID)
+	tracing.TraceReqInitiate(d.cache.comp, readToBottom, d.reqInTaskID(trans))
 
 	trans.HasReadToBottom = true
 	trans.ReadToBottomMeta = readToBottom.MsgMeta

--- a/mem/cache/writethroughcache/intake.go
+++ b/mem/cache/writethroughcache/intake.go
@@ -89,14 +89,6 @@ func (s *intake) createTransaction(msg messaging.Msg) int {
 			ReadAccessByteSize: m.AccessByteSize,
 			ReadPID:            m.PID,
 		}
-
-		tracing.StartTask(s.cache.comp, tracing.TaskStart{
-			ID:       t.ID,
-			ParentID: tracing.MsgIDAtReceiver(m, s.cache.comp),
-			Kind:     "cache_transaction",
-			What:     "read",
-			Location: s.cache.comp.Name() + ".Local",
-		})
 	case memprotocol.WriteReq:
 		t = transactionState{
 			ID:             timing.GetIDGenerator().Generate(),
@@ -114,14 +106,6 @@ func (s *intake) createTransaction(msg messaging.Msg) int {
 				t.WriteDirtyMask[i] = true
 			}
 		}
-
-		tracing.StartTask(s.cache.comp, tracing.TaskStart{
-			ID:       t.ID,
-			ParentID: tracing.MsgIDAtReceiver(m, s.cache.comp),
-			Kind:     "cache_transaction",
-			What:     "write",
-			Location: s.cache.comp.Name() + ".Local",
-		})
 	default:
 		log.Panicf("cannot process request of type %s\n",
 			reflect.TypeOf(msg))

--- a/mem/cache/writethroughcache/milestone_test.go
+++ b/mem/cache/writethroughcache/milestone_test.go
@@ -191,17 +191,18 @@ var _ = Describe("Cache milestones", func() {
 		Expect(ok).To(BeTrue())
 		Expect(reqInStart.ID).ToNot(BeZero())
 
-		// The directory pipeline subtask exists and is parented to req_in
-		// (not to the cache_transaction task), per the buffer-task convention.
+		// The directory pipeline subtask exists and is parented to req_in,
+		// per the buffer-task convention.
 		pipeStart, ok := rec.firstStart(tracing.PipelineTaskKind)
 		Expect(ok).To(BeTrue())
 		Expect(pipeStart.What).To(Equal("Cache.dir_pipeline"))
 		Expect(pipeStart.ParentID).To(Equal(reqInStart.ID))
 
-		// The cache_transaction task is distinct from the pipeline subtask.
-		ctStart, ok := rec.firstStart("cache_transaction")
-		Expect(ok).To(BeTrue())
-		Expect(pipeStart.ParentID).ToNot(Equal(ctStart.ID))
+		// The cache no longer opens a separate cache_transaction task: the
+		// req_in is the single task that carries the request's tags, its
+		// processing milestones, and its downstream req_out children.
+		_, ok = rec.firstStart("cache_transaction")
+		Expect(ok).To(BeFalse())
 	})
 
 	It("records the dir_pipeline work and bottom data milestones on req_in "+
@@ -287,19 +288,22 @@ var _ = Describe("Cache milestones", func() {
 		engine.Run()
 		Expect(drainResponses()).To(HaveLen(1))
 
-		// The partial write hit opened exactly one cache_transaction; the
-		// write-hit tag the directory now emits on writethroughWriteHit must
-		// hang off that transaction.
-		ctStart, ok := rec.firstStart("cache_transaction")
+		// The req_in is now the cache's single task for the request, so the
+		// write-hit tag the directory emits on writethroughWriteHit hangs off
+		// the req_in — there is no separate cache_transaction.
+		reqInStart, ok := rec.firstStart("req_in")
 		Expect(ok).To(BeTrue())
-		Expect(ctStart.What).To(Equal("write"))
+		Expect(reqInStart.What).To(Equal("WriteReq"))
+
+		_, ctOK := rec.firstStart("cache_transaction")
+		Expect(ctOK).To(BeFalse())
 
 		writeHitTags := rec.tagsWith("write-hit")
 		Expect(writeHitTags).ToNot(BeEmpty())
 
 		found := false
 		for _, t := range writeHitTags {
-			if t.TaskID == ctStart.ID {
+			if t.TaskID == reqInStart.ID {
 				found = true
 			}
 		}
@@ -308,12 +312,95 @@ var _ = Describe("Cache milestones", func() {
 		// The write-through write dispatched a downstream WriteReq whose
 		// WriteDoneRsp came back during this run. processDoneRsp records a
 		// dependency milestone on the write's req_in (not the ack).
-		reqInStart, ok := rec.firstStart("req_in")
-		Expect(ok).To(BeTrue())
 		Expect(rec.hasMilestone(reqInStart.ID, "Cache.Bottom")).To(BeTrue())
 		for _, m := range rec.milestonesOn(reqInStart.ID) {
 			if m.What == "Cache.Bottom" {
 				Expect(m.Kind).To(Equal(tracing.MilestoneKindDependency))
+			}
+		}
+	})
+
+	It("tags a write-through full-line write miss with write-miss only", func() {
+		buildCache("write-through")
+
+		// A full-line write to a cold line is a write miss handled by the
+		// full-line fast path, which installs a victim way and writes it. That
+		// install must not also stamp a write-hit tag: the transaction is a
+		// miss and the visualization shows one categorical label, not two
+		// contradictory ones.
+		fullLine := make([]byte, 64)
+		for i := range fullLine {
+			fullLine[i] = byte(i)
+		}
+		miss := memprotocol.WriteReq{Address: 0x100, Data: fullLine}
+		miss.ID = timing.GetIDGenerator().Generate()
+		miss.Src = cuPort.AsRemote()
+		miss.Dst = c.GetPortByName("Top").AsRemote()
+		miss.TrafficBytes = 64 + 12
+		miss.TrafficClass = "req"
+		c.GetPortByName("Top").Deliver(miss)
+		engine.Run()
+		Expect(drainResponses()).To(HaveLen(1))
+
+		reqInStart, ok := rec.firstStart("req_in")
+		Expect(ok).To(BeTrue())
+		Expect(reqInStart.What).To(Equal("WriteReq"))
+
+		// The req_in (the cache's single task for the request) carries
+		// write-miss...
+		missTagged := false
+		for _, t := range rec.tagsWith("write-miss") {
+			if t.TaskID == reqInStart.ID {
+				missTagged = true
+			}
+		}
+		Expect(missTagged).To(BeTrue())
+
+		// ...and must NOT also carry write-hit.
+		for _, t := range rec.tagsWith("write-hit") {
+			Expect(t.TaskID).ToNot(Equal(reqInStart.ID))
+		}
+	})
+
+	It("records the bank access as a subtask parented to req_in, paired "+
+		"with a work milestone", func() {
+		buildCache("write-through")
+
+		// A full-line write to a cold line installs a victim way and writes
+		// the bank, so the transaction traverses the bank pipeline and must
+		// open a bank subtask.
+		fullLine := make([]byte, 64)
+		w := memprotocol.WriteReq{Address: 0x100, Data: fullLine}
+		w.ID = timing.GetIDGenerator().Generate()
+		w.Src = cuPort.AsRemote()
+		w.Dst = c.GetPortByName("Top").AsRemote()
+		w.TrafficBytes = 64 + 12
+		w.TrafficClass = "req"
+		c.GetPortByName("Top").Deliver(w)
+		engine.Run()
+		Expect(drainResponses()).To(HaveLen(1))
+
+		reqInStart, ok := rec.firstStart("req_in")
+		Expect(ok).To(BeTrue())
+
+		// The bank access is a pipeline subtask (What ".bank") parented to the
+		// req_in: every "work" interval has a corresponding child bar.
+		var bankStart tracing.TaskStart
+		found := false
+		for _, s := range rec.starts {
+			if s.Kind == tracing.PipelineTaskKind && s.What == "Cache.bank" {
+				bankStart = s
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue())
+		Expect(bankStart.ParentID).To(Equal(reqInStart.ID))
+
+		// The req_in still carries the matching work milestone for that bar.
+		Expect(rec.hasMilestone(reqInStart.ID, "Cache.bank")).To(BeTrue())
+		for _, m := range rec.milestonesOn(reqInStart.ID) {
+			if m.What == "Cache.bank" {
+				Expect(m.Kind).To(Equal(tracing.MilestoneKindWork))
 			}
 		}
 	})

--- a/mem/cache/writethroughcache/reset_leak_test.go
+++ b/mem/cache/writethroughcache/reset_leak_test.go
@@ -14,12 +14,11 @@ import (
 )
 
 // TestResetEndsInflightTracingTasks drives a read miss into the writethrough
-// cache so the transaction has all three tiers of tracing tasks open — the
-// req_in for the top request, the cache_transaction, and the downstream
-// req_out for the bottom fetch — then issues a Reset and asserts every task is
-// ended. A mid-flight Reset drops the transaction table, so each started task
-// must be ended by endInflightTasks or it leaks (and, for a req_in, leaks a
-// receiver-registry entry too).
+// cache so the transaction has both of its tracing tasks open — the req_in for
+// the top request and the downstream req_out for the bottom fetch — then issues
+// a Reset and asserts every task is ended. A mid-flight Reset drops the
+// transaction table, so each started task must be ended by endInflightTasks or
+// it leaks (and, for a req_in, leaks a receiver-registry entry too).
 func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	engine := timing.NewSerialEngine()
 	storage := mem.NewStorage(4 * mem.GB)
@@ -67,9 +66,9 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	rec := &tracingtest.LeakRecorder{}
 	tracing.CollectTrace(comp, rec)
 
-	// Admit a read miss. intake opens the req_in and the cache_transaction
-	// task; the directory then issues a bottom fetch (req_out) that is never
-	// answered, leaving the transaction in flight with all three tiers open.
+	// Admit a read miss. intake opens the req_in; the directory then issues a
+	// bottom fetch (req_out) that is never answered, leaving the transaction in
+	// flight with both its req_in and req_out tracing tasks open.
 	read := memprotocol.ReadReq{Address: 0, AccessByteSize: 4}
 	read.ID = timing.GetIDGenerator().Generate()
 	read.Src = messaging.RemotePort("Agent")
@@ -108,11 +107,11 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 		t.Fatal("expected an in-flight transaction with a bottom read")
 	}
 
-	// req_in + cache_transaction + req_out.
-	if rec.NumStarted() < 3 {
-		t.Fatalf("expected req_in, cache_transaction and req_out to be "+
-			"opened, got %d task starts: %s",
-			rec.NumStarted(), rec.OpenSummary())
+	// Before the Reset the transaction's req_in and its downstream req_out are
+	// open (the dir_pipeline subtask already closed when the fetch was issued).
+	if open := rec.OpenTasks(); len(open) < 2 {
+		t.Fatalf("expected req_in and req_out to be open, got %d: %s",
+			len(open), rec.OpenSummary())
 	}
 
 	// Reset while the transaction is in flight.

--- a/mem/cache/writethroughcache/writepolicy.go
+++ b/mem/cache/writethroughcache/writepolicy.go
@@ -115,7 +115,7 @@ func (d *directory) writearoundWriteHit(
 	bankBuf.PushTyped(postCoalesceIdx)
 
 	tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-		TaskID: trans.ID,
+		TaskID: d.reqInTaskID(trans),
 		What:   "write-hit",
 	})
 
@@ -131,7 +131,7 @@ func (d *directory) writearoundWriteMiss(
 ) bool {
 	if ok := d.writeBottom(trans); ok {
 		tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-			TaskID: trans.ID,
+			TaskID: d.reqInTaskID(trans),
 			What:   "write-miss",
 		})
 
@@ -174,7 +174,7 @@ func (d *directory) writeevictWriteHit(
 	nextBlock.IsValid = false
 
 	tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-		TaskID: trans.ID,
+		TaskID: d.reqInTaskID(trans),
 		What:   "write-hit",
 	})
 
@@ -190,7 +190,7 @@ func (d *directory) writeevictWriteMiss(
 ) bool {
 	if ok := d.writeBottom(trans); ok {
 		tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-			TaskID: trans.ID,
+			TaskID: d.reqInTaskID(trans),
 			What:   "write-miss",
 		})
 
@@ -207,6 +207,30 @@ func (d *directory) writeevictWriteMiss(
 // --- write-through policy ---
 
 func (d *directory) writethroughWriteHit(
+	trans *transactionState,
+	setID, wayID int,
+	postCoalesceIdx int,
+) bool {
+	if !d.writethroughInstallLine(trans, setID, wayID, postCoalesceIdx) {
+		return false
+	}
+
+	tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
+		TaskID: d.reqInTaskID(trans),
+		What:   "write-hit",
+	})
+
+	return true
+}
+
+// writethroughInstallLine installs the write's line into (setID, wayID) and
+// dispatches the bank write, popping the directory post-buffer on success. It
+// emits no hit/miss tag: the caller owns that, because the same install backs
+// both a genuine write hit and the full-line write-miss fast path (which
+// allocates a victim way and writes it as if hit). Returns false without
+// mutating state when the block is busy, the bank buffer is full, or the
+// write-through to lower memory cannot be issued.
+func (d *directory) writethroughInstallLine(
 	trans *transactionState,
 	setID, wayID int,
 	postCoalesceIdx int,
@@ -247,11 +271,6 @@ func (d *directory) writethroughWriteHit(
 
 	bankBuf.PushTyped(postCoalesceIdx)
 
-	tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-		TaskID: trans.ID,
-		What:   "write-hit",
-	})
-
 	dirPostBuf := &next.DirPostBuf
 	dirPostBuf.Pop()
 
@@ -269,7 +288,7 @@ func (d *directory) writethroughWriteMiss(
 	ok := d.writethroughFullLineWriteMiss(trans, postCoalesceIdx)
 	if ok {
 		tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-			TaskID: trans.ID,
+			TaskID: d.reqInTaskID(trans),
 			What:   "write-miss",
 		})
 	}
@@ -338,7 +357,7 @@ func (d *directory) writethroughPartialWriteMiss(
 	dirPostBuf := &next.DirPostBuf
 	dirPostBuf.Pop()
 	tracing.AddTaskTag(d.cache.comp, tracing.TaskTag{
-		TaskID: trans.ID,
+		TaskID: d.reqInTaskID(trans),
 		What:   "write-miss",
 	})
 
@@ -358,7 +377,10 @@ func (d *directory) writethroughFullLineWriteMiss(
 	victimSetID, victimWayID := cache.DirectoryFindVictim(
 		&next.DirectoryState, spec.NumSets, int(blockSize), cacheLineID)
 
-	_ = next // suppress unused warning
-
-	return d.writethroughWriteHit(trans, victimSetID, victimWayID, postCoalesceIdx)
+	// Install the line via the shared core, not writethroughWriteHit: this is a
+	// miss, so writethroughWriteMiss owns the write-miss tag. Calling the hit
+	// handler here would also stamp a contradictory write-hit tag on the same
+	// transaction.
+	return d.writethroughInstallLine(
+		trans, victimSetID, victimWayID, postCoalesceIdx)
 }

--- a/mem/vm/gmmu/comp.go
+++ b/mem/vm/gmmu/comp.go
@@ -42,6 +42,12 @@ type transactionState struct {
 	DeviceID   uint64               `json:"device_id"`
 	Page       pageState            `json:"page"`
 	CycleLeft  int                  `json:"cycle_left"`
+	// WalkTaskID is the pipeline subtask that spans the local page-table-walk
+	// latency (the CycleLeft countdown), a child of the req_in. It pairs with
+	// the ".walk" work milestone so the walk renders as a child bar rather than
+	// a bare work interval; it is closed on both the local-hit and remote-fetch
+	// exits of the countdown.
+	WalkTaskID uint64 `json:"walk_task_id"`
 }
 
 // devicePageAccess records pages accessed by a single device.

--- a/mem/vm/gmmu/ctrlmiddleware.go
+++ b/mem/vm/gmmu/ctrlmiddleware.go
@@ -155,6 +155,12 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 func (m *ctrlMiddleware) endInflightTasks() {
 	for _, walking := range m.comp.State.WalkingTranslations {
 		tracing.EndReqInOnReset(m.comp, walking.ReqID)
+		// These walks have not yet reached an exit, so their walk subtask is
+		// still open. (Remote walks in RemoteMemReqs already closed theirs in
+		// processRemoteMemReq.)
+		if walking.WalkTaskID != 0 {
+			tracing.EndTaskOnReset(m.comp, walking.WalkTaskID)
+		}
 	}
 
 	for reqOutID, walking := range m.comp.State.RemoteMemReqs {

--- a/mem/vm/gmmu/walkmw.go
+++ b/mem/vm/gmmu/walkmw.go
@@ -89,16 +89,31 @@ func (m *walkMW) startWalking(req vmprotocol.TranslationReq) {
 	spec := m.comp.Spec()
 	state := &m.comp.State
 
+	recvTaskID := tracing.MsgIDAtReceiver(req, m.comp)
+	walkTaskID := timing.GetIDGenerator().Generate()
+
 	ts := transactionState{
 		ReqID:      req.ID,
-		RecvTaskID: tracing.MsgIDAtReceiver(req, m.comp),
+		RecvTaskID: recvTaskID,
 		ReqSrc:     req.Src,
 		ReqDst:     req.Dst,
 		PID:        uint64(req.PID),
 		VAddr:      req.VAddr,
 		DeviceID:   req.DeviceID,
 		CycleLeft:  spec.Latency,
+		WalkTaskID: walkTaskID,
 	}
+
+	// Open the walk subtask spanning the page-table-walk latency, a child of the
+	// req_in, so the ".walk" work milestone has a corresponding bar. It is closed
+	// on the local-hit (doPageWalkHit) and remote-fetch (processRemoteMemReq)
+	// exits.
+	tracing.StartTask(m.comp, tracing.TaskStart{
+		ID:       walkTaskID,
+		ParentID: recvTaskID,
+		Kind:     tracing.PipelineTaskKind,
+		What:     m.comp.Name() + ".walk",
+	})
 
 	state.WalkingTranslations = append(
 		state.WalkingTranslations, ts)
@@ -192,6 +207,16 @@ func (m *walkMW) processRemoteMemReq(
 	// handleTranslationRsp when the remote response returns.
 	tracing.TraceReqInitiate(m.comp, req, walking.RecvTaskID)
 
+	// The local walk countdown finished and the page is remote: attribute the
+	// countdown as work on the req_in and close the walk subtask that spanned
+	// it. The downstream req_out (opened above) then covers the remote fetch.
+	tracing.AddMilestone(m.comp, tracing.Milestone{
+		TaskID: walking.RecvTaskID,
+		Kind:   tracing.MilestoneKindWork,
+		What:   m.comp.Name() + ".walk",
+	})
+	tracing.EndTask(m.comp, tracing.TaskEnd{ID: walking.WalkTaskID})
+
 	state.ToRemoveFromPTW = append(state.ToRemoveFromPTW, walkingIndex)
 
 	return true
@@ -235,12 +260,14 @@ func (m *walkMW) doPageWalkHit(
 	state.ToRemoveFromPTW = append(state.ToRemoveFromPTW, walkingIndex)
 
 	// The local page walk counted down CycleLeft before reaching here; record
-	// that processing latency as work on the original req_in.
+	// that processing latency as work on the original req_in and close the walk
+	// subtask that spanned it, so the work milestone has a corresponding bar.
 	tracing.AddMilestone(m.comp, tracing.Milestone{
 		TaskID: walking.RecvTaskID,
 		Kind:   tracing.MilestoneKindWork,
 		What:   m.comp.Name() + ".walk",
 	})
+	tracing.EndTask(m.comp, tracing.TaskEnd{ID: walking.WalkTaskID})
 
 	tracing.TraceReqComplete(
 		m.comp,

--- a/mem/vm/mmu/comp.go
+++ b/mem/vm/mmu/comp.go
@@ -29,6 +29,11 @@ type transactionState struct {
 	TransLatency uint64               `json:"trans_latency"`
 	Page         vm.Page              `json:"page"`
 	CycleLeft    int                  `json:"cycle_left"`
+	// WalkTaskID is the pipeline subtask that spans the local page-table-walk
+	// latency (the CycleLeft countdown), a child of the req_in. It pairs with
+	// the ".walk" work milestone so the walk renders as a child bar rather than
+	// a bare work interval.
+	WalkTaskID uint64 `json:"walk_task_id"`
 }
 
 // State contains mutable runtime data for the MMU.

--- a/mem/vm/mmu/ctrlmiddleware.go
+++ b/mem/vm/mmu/ctrlmiddleware.go
@@ -138,14 +138,17 @@ func (m *ctrlMiddleware) handleReset(req memcontrolprotocol.Req) bool {
 	return true
 }
 
-// endInflightTasks completes the req_in tracing task of every page walk still
-// in flight, so a hard Reset that drops WalkingTranslations leaves no
-// started-never-ended task and no leaked receiver-registry entry. The MMU walk
-// is local, so there is no downstream req_out to finalize. Mirrors the
-// completion in translationMW.traceReqComplete.
+// endInflightTasks completes the req_in tracing task and the walk subtask of
+// every page walk still in flight, so a hard Reset that drops
+// WalkingTranslations leaves no started-never-ended task and no leaked
+// receiver-registry entry. The MMU walk is local, so there is no downstream
+// req_out to finalize. Mirrors the completion in translationMW.doPageWalkHit.
 func (m *ctrlMiddleware) endInflightTasks() {
 	for _, walking := range m.comp.State.WalkingTranslations {
 		tracing.EndReqInOnReset(m.comp, walking.ReqID)
+		if walking.WalkTaskID != 0 {
+			tracing.EndTaskOnReset(m.comp, walking.WalkTaskID)
+		}
 	}
 }
 

--- a/mem/vm/mmu/translationmw.go
+++ b/mem/vm/mmu/translationmw.go
@@ -132,13 +132,16 @@ func (m *translationMW) doPageWalkHit(walkingIndex int) bool {
 	state.ToRemoveFromPTW = append(state.ToRemoveFromPTW, walkingIndex)
 
 	// The page walk is fully local (a CycleLeft countdown, no downstream
-	// req_out): label that latency interval as work on the req_in, instead of
-	// leaving it an unattributed gap. walking.RecvTaskID is the req_in id.
+	// req_out): label that latency interval as work on the req_in and close the
+	// walk subtask that spanned it, so the work milestone has a corresponding
+	// child bar instead of an unattributed gap. walking.RecvTaskID is the
+	// req_in id.
 	tracing.AddMilestone(m.comp, tracing.Milestone{
 		TaskID: walking.RecvTaskID,
 		Kind:   tracing.MilestoneKindWork,
 		What:   m.comp.Name() + ".walk",
 	})
+	tracing.EndTask(m.comp, tracing.TaskEnd{ID: walking.WalkTaskID})
 
 	m.traceReqComplete(walking.RecvTaskID, walking.ReqID)
 
@@ -186,9 +189,12 @@ func (m *translationMW) startWalking(req vmprotocol.TranslationReq) {
 	spec := m.comp.Spec()
 	state := &m.comp.State
 
+	recvTaskID := tracing.MsgIDAtReceiver(req, m.comp)
+	walkTaskID := timing.GetIDGenerator().Generate()
+
 	ts := transactionState{
 		ReqID:        req.ID,
-		RecvTaskID:   tracing.MsgIDAtReceiver(req, m.comp),
+		RecvTaskID:   recvTaskID,
 		ReqSrc:       req.Src,
 		ReqDst:       req.Dst,
 		PID:          uint32(req.PID),
@@ -196,7 +202,18 @@ func (m *translationMW) startWalking(req vmprotocol.TranslationReq) {
 		DeviceID:     req.DeviceID,
 		TransLatency: req.TransLatency,
 		CycleLeft:    spec.Latency,
+		WalkTaskID:   walkTaskID,
 	}
+
+	// Open the walk subtask spanning the page-table-walk latency, a child of the
+	// req_in, so the ".walk" work milestone emitted at walk completion has a
+	// corresponding bar (no bare work interval).
+	tracing.StartTask(m.comp, tracing.TaskStart{
+		ID:       walkTaskID,
+		ParentID: recvTaskID,
+		Kind:     tracing.PipelineTaskKind,
+		What:     m.comp.Name() + ".walk",
+	})
 
 	state.WalkingTranslations = append(state.WalkingTranslations, ts)
 }

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -45,7 +45,41 @@ Each milestone carries a `MilestoneKind`:
 `MilestoneKindWork` is the exception to the "milestone = blocking resolved"
 reading: it marks the end of an interval the component spent doing productive
 work rather than waiting — e.g. traversing an internal latency pipeline. The
-interval up to a `work` milestone is time spent working, not blocked.
+interval up to a `work` milestone is time spent working, not blocked. Per the
+coverage principles below, a `work` (or `subtask`) milestone must be paired with
+a child subtask that spans the interval.
+
+## Coverage principles
+
+A `req_in` processing task's milestones and subtasks must, together, account for
+the task's **entire** lifetime. Two rules keep traces honest — a reviewer should
+never have to ask "why is the bar still running with no reason?" or "what work is
+this, and why so long?".
+
+**P1 — Full coverage (no unexplained gaps).** Every interval between a task's
+start and end is attributed: the span ending at each milestone is the time the
+task spent on that milestone's reason, so consecutive milestones tile the whole
+lifetime. In particular the *last* milestone must land at (within ~one cycle of)
+the task end. A gap between the last milestone and the end means a processing
+phase is going unrecorded — the bar runs on with no reason. Emit a milestone for
+that phase (or open a subtask for it, per P2).
+
+**P2 — Work is a subtask (`work`/`subtask` ⇒ child subtask).** A `work` or
+`subtask` milestone asserts the task spent that interval doing internal work
+rather than blocked. Such an interval must be backed by a **child subtask** — a
+`StartTask` parented to the `req_in`, normally `PipelineTaskKind` — that spans
+it, so the trace shows *what* the work was, not merely that time elapsed. A bare
+`work`/`subtask` milestone with no corresponding child subtask is a violation:
+either open the subtask, or — if the interval was really a wait — reclassify the
+milestone (`data`, `dependency`, `hardware_resource`, …).
+
+So a pipelined component pairs each internal-latency phase with **both** a
+subtask bar (the child) and a `work` milestone (on the parent) at the phase's
+end — see *Pipeline subtasks*. The write-through cache is the reference
+implementation: its directory-lookup and data-array (bank) latencies each open a
+`pipeline` subtask under the `req_in` and close with a matching `work` milestone,
+so they render as labelled child bars instead of unexplained gaps, and the only
+bare spans left are the inherent single-cycle buffer-admission and response ticks.
 
 ## Emit API
 

--- a/tracing/task.go
+++ b/tracing/task.go
@@ -54,11 +54,21 @@ const (
 	MilestoneKindDependency       MilestoneKind = "dependency"
 	MilestoneKindOther            MilestoneKind = "other"
 	MilestoneKindTranslation      MilestoneKind = "translation"
-	MilestoneKindSubTask          MilestoneKind = "subtask"
+	// MilestoneKindSubTask marks a wait on a child subtask. Like
+	// MilestoneKindWork it asserts internal activity, so it requires a
+	// corresponding child subtask to exist (see "Coverage principles" in the
+	// package README).
+	MilestoneKindSubTask MilestoneKind = "subtask"
 	// MilestoneKindWork marks the end of an interval the component spent doing
 	// productive work rather than blocked on a resource — e.g. traversing an
 	// internal latency pipeline. The interval from the previous milestone (or
 	// task start) to a work milestone is time the task was working, not waiting.
+	//
+	// Coverage principle: a work milestone must be paired with a child subtask
+	// (parented to the req_in, e.g. PipelineTaskKind) spanning the same interval,
+	// so the trace shows what the work was instead of leaving an unexplained gap.
+	// A bare work milestone with no subtask is a convention violation. See
+	// "Coverage principles" in the package README.
 	MilestoneKindWork MilestoneKind = "work"
 )
 


### PR DESCRIPTION
## Summary

Establishes two **milestone coverage principles** for the task-tracing model, documents them, and makes every `mem` component's `req_in` comply — so a viewer can always account for a request's full lifetime in Daisen, with no unexplained gaps and every work interval shown as a labelled child bar.

**The principles** (now in `tracing/README.md` → *Coverage principles*):
- **P1 — Full coverage.** A task's milestones tile its whole lifetime; the last milestone lands within ~one cycle of the task end. A trailing gap means a phase is going unrecorded.
- **P2 — Work is a subtask.** A `work`/`subtask` milestone must be backed by a child subtask spanning it, so the trace shows *what* the work was, not merely that time elapsed.

## Changes

**`tracing`** — document the principles; reference them from the `MilestoneKindWork`/`MilestoneKindSubTask` docs.

**`mem/cache/writethroughcache`** (the reference implementation)
- Fix a contradictory tag: a full-line write *miss* was stamped both `write-hit` and `write-miss` (the full-line fast path reused the write-hit handler). Extract a tag-free `installLine` core.
- Remove the redundant `cache_transaction` task — the `req_in` is now the single per-request task carrying tags, milestones, and the downstream `req_out` children (no near-duplicate bar).
- Trace the bank (data-array) access as a `pipeline` subtask + `work/<cache>.bank` milestone, so the bank latency is a child bar instead of a tail.

**`mem/vm/mmu`, `mem/vm/gmmu`** — the local page-table walk emitted a bare `work/.walk` milestone; open a `pipeline` walk subtask spanning the `CycleLeft` countdown (closed on the local-hit and, for gmmu, remote-fetch exits, and on reset).

**`mem/cache/writeback`** — the post-fill bank write left a ~13µs tail with no milestone/subtask. Trace the bank access as a `pipeline` subtask + `work/.bank` milestone (mirroring write-through); MSHR-coalesced waiters (which never visit the bank) get a `dependency/.fill` milestone at the MSHR response.

## Verification

An audit checker over a full `virtualmem` trace (agent → ROB → AT → TLB/L2TLB/MMU and L1 write-through → L2 writeback → MemCtrl) reports **zero P1/P2 violations on every component's `req_in`** after these changes (the violators above were IoMMU/mmu P2, writeback P1; L1/TLB/L2TLB/AT/ROB were already compliant).

- `go build ./...` clean; `go vet` clean on touched packages.
- Package tests pass (`writethroughcache`, `writeback`, `mmu`, `gmmu`), including new/updated tracing assertions.
- Correctness fuzzers pass: `writebackcache`, `writethroughcache`, `virtualmem`.
- **0 dangling (started-never-ended) tasks** in the regenerated trace; reset paths close the new subtasks.

### Notes
- `gmmu` is not exercised by the `virtualmem` trace, so its fix is verified by build + unit tests and by mirroring the `mmu` fix; not yet confirmed empirically in a trace.
- A separate, secondary finding (incoming/outgoing **buffer** tasks in AT/TLB leaving admission/link-drain waits unmilestoned) is **out of scope** here and can be addressed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)