### PR TITLE
Enforce one-location-one-kind in task tracing

### DIFF
--- a/mem/vm/mmuCache/milestone_test.go
+++ b/mem/vm/mmuCache/milestone_test.go
@@ -206,7 +206,7 @@ var _ = Describe("MMUCache milestones", func() {
 	bufTaskID := func(portName string) uint64 {
 		for _, s := range rec.starts {
 			if s.Kind == tracing.IncomingBufferTaskKind &&
-				s.Location == portName {
+				s.Location == portName+".incoming" {
 				return s.ID
 			}
 		}

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -9,8 +9,8 @@ structured traces without modifying component logic.
 ### Tasks
 
 A `Task` is the aggregate record a stateful tracer builds from the stream of
-trace events. It has a start and end time, a location (the component name), an
-optional parent, and lists of tags and milestones.
+trace events. It has a start and end time, a location (see [Locations](#locations)),
+an optional parent, and lists of tags and milestones.
 
 Components do not build a `Task` directly. They emit lightweight event structs;
 the emit functions stamp the event time from the domain's clock and fire a hook.
@@ -48,6 +48,32 @@ work rather than waiting — e.g. traversing an internal latency pipeline. The
 interval up to a `work` milestone is time spent working, not blocked. Per the
 coverage principles below, a `work` (or `subtask`) milestone must be paired with
 a child subtask that spans the interval.
+
+## Locations
+
+**One location, one kind.** A location is the row a viewer (Daisen) draws tasks
+on, and a row is read as a single sequential timeline. So every location must
+host exactly **one** Kind of task. When a single component or port runs more than
+one kind, the kinds overlap in time on one row and the timeline becomes
+ambiguous — therefore the location string is qualified to separate them:
+
+| Kind | Location | Example |
+|------|----------|---------|
+| `req_in` | `<component>.req_in` | `L2Cache.req_in` |
+| `req_out` | `<component>.req_out` | `L2Cache.req_out` |
+| `pipeline` | `<component>.<stage>` (the task's `What`) | `L2Cache.dir_pipeline`, `L2Cache.bank` |
+| `incoming_buffer` | `<port>.incoming` | `L2Cache.Top.incoming` |
+| `outgoing_buffer` | `<port>.outgoing` | `L2Cache.Bottom.outgoing` |
+
+The rule of thumb: a **component** disambiguates by *stage* (the request side it
+is on, or the named pipeline stage); a **port** disambiguates by *direction*
+(incoming vs outgoing buffer). This holds for every task: `StartTask` derives the
+location from the Kind (see `singleKindLocation`) when a caller leaves `Location`
+empty, the buffer hooks append the direction, and all of these strings are
+interned into the trace's `location` table.
+
+When you add a new task Kind to a component or port that already emits another
+kind, qualify its location the same way — never let two kinds share one location.
 
 ## Coverage principles
 
@@ -100,9 +126,12 @@ tracing.AddMilestone(domain, tracing.Milestone{
 tracing.EndTask(domain, tracing.TaskEnd{ID: id})
 ```
 
-`TaskStart.Location` is optional and defaults to `domain.Name()`; set it
-explicitly for network tracing. `StartTask` requires a non-empty `ID`, `Kind`,
-and `What` (and a named domain) or it panics; tag and milestone `ID`s are
+`TaskStart.Location` is optional: when left empty `StartTask` derives a
+single-kind location from the Kind (`singleKindLocation` — see
+[Locations](#locations)), so `req_in`/`req_out`/`pipeline` are each placed on
+their own row. Set it explicitly to override (e.g. network tracing, or the port
+buffer hooks that append a direction). `StartTask` requires a non-empty `ID`,
+`Kind`, and `What` (and a named domain) or it panics; tag and milestone `ID`s are
 auto-generated when left zero.
 
 ### Message Tracing Helpers

--- a/tracing/api.go
+++ b/tracing/api.go
@@ -29,7 +29,8 @@ var (
 )
 
 // StartTask notifies the hooks that hook to the domain about the start of a
-// task. When the task's Location is empty it defaults to the domain name.
+// task. When the task's Location is empty it is derived by [singleKindLocation]
+// so that each location hosts exactly one Kind of task.
 func StartTask(domain NamedHookable, t TaskStart) {
 	if domain.NumHooks() == 0 {
 		return
@@ -39,7 +40,7 @@ func StartTask(domain NamedHookable, t TaskStart) {
 	domainMustHaveName(domain)
 
 	if t.Location == "" {
-		t.Location = domain.Name()
+		t.Location = singleKindLocation(domain.Name(), t.Kind, t.What)
 	}
 
 	t.Time = domain.CurrentTime()
@@ -49,6 +50,29 @@ func StartTask(domain NamedHookable, t TaskStart) {
 		Item:   t,
 		Pos:    HookPosTaskStart,
 	})
+}
+
+// singleKindLocation derives a task's location so that one location only ever
+// holds one Kind of task — the invariant that keeps a Daisen row sequential and
+// unambiguous (see "One location, one kind" in README.md). It is consulted only
+// when the caller leaves Location empty; callers that qualify the location
+// themselves (the port buffer hooks append a direction) keep their own value.
+//
+//   - req_in and req_out share a component, so they are split by appending the
+//     kind: "<component>.req_in" and "<component>.req_out".
+//   - a pipeline subtask already names its stage in What as "<component>.<stage>"
+//     (e.g. "L2Cache.dir_pipeline"), so that name is the location and each stage
+//     is its own row.
+//   - any other kind keeps the bare component name.
+func singleKindLocation(componentName, kind, what string) string {
+	switch kind {
+	case ReqInTaskKind, ReqOutTaskKind:
+		return componentName + "." + kind
+	case PipelineTaskKind:
+		return what
+	default:
+		return componentName
+	}
 }
 
 func allRequiredFieldsMustBeNotEmpty(
@@ -231,7 +255,7 @@ func TraceReqInitiate(
 	StartTask(domain, TaskStart{
 		ID:       msg.Meta().ID,
 		ParentID: taskParentID,
-		Kind:     "req_out",
+		Kind:     ReqOutTaskKind,
 		What:     msgTypeName(msg),
 		Detail:   msg,
 	})
@@ -251,7 +275,7 @@ func TraceReqReceive(
 	StartTask(domain, TaskStart{
 		ID:       MsgIDAtReceiver(msg, domain),
 		ParentID: msg.Meta().ID,
-		Kind:     "req_in",
+		Kind:     ReqInTaskKind,
 		What:     msgTypeName(msg),
 		Detail:   msg,
 	})

--- a/tracing/dbtracer_roundtrip_test.go
+++ b/tracing/dbtracer_roundtrip_test.go
@@ -24,8 +24,9 @@ func (d *roundTripDomain) CurrentTime() timing.VTimeInPicoSec { return d.now }
 
 // TestDBTracerLocationRoundTrip writes a trace through the real DBTracer and
 // reads it back with the same SQL shape daisen uses, confirming that the
-// interned location id resolves to the component name and that milestones and
-// tags inherit the task's location.
+// interned location id resolves to the task's single-kind location (a req_in
+// task lands at "<component>.req_in") and that milestones and tags inherit the
+// task's location.
 func TestDBTracerLocationRoundTrip(t *testing.T) {
 	dbFile := writeRoundTripTrace(t)
 
@@ -74,7 +75,7 @@ func writeRoundTripTrace(t *testing.T) string {
 }
 
 // assertTaskLocation checks that trace.Location (an interned id) joins back to
-// the component name and that the task times round-trip.
+// the task's single-kind location and that the task times round-trip.
 func assertTaskLocation(t *testing.T, db *sql.DB) {
 	t.Helper()
 
@@ -88,8 +89,8 @@ func assertTaskLocation(t *testing.T, db *sql.DB) {
 	if err != nil {
 		t.Fatalf("query trace: %v", err)
 	}
-	if location != "GPU[0].L1Cache" {
-		t.Fatalf("location = %q, want GPU[0].L1Cache", location)
+	if location != "GPU[0].L1Cache.req_in" {
+		t.Fatalf("location = %q, want GPU[0].L1Cache.req_in", location)
 	}
 	if start != 10 || end != 20 {
 		t.Fatalf("times = (%v,%v), want (10,20)", start, end)

--- a/tracing/incomingbuffertracer.go
+++ b/tracing/incomingbuffertracer.go
@@ -103,7 +103,10 @@ func (h *incomingBufferHook) onDeliver(
 		ParentID: parentID,
 		Kind:     IncomingBufferTaskKind,
 		What:     msgTypeName(msg),
-		Location: port.Name(),
+		// A port holds both an incoming and an outgoing buffer, so the
+		// direction qualifies the location — one location, one kind (see
+		// README.md). The incoming buffer is "<port>.incoming".
+		Location: port.Name() + ".incoming",
 	})
 
 	if atHead {

--- a/tracing/incomingbuffertracer_test.go
+++ b/tracing/incomingbuffertracer_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Incoming buffer tracer", func() {
 		Expect(startA.Kind).To(Equal(IncomingBufferTaskKind))
 		Expect(startA.ParentID).To(Equal(uint64(7)))
 		Expect(startA.What).To(Equal("ibTestMsg"))
-		Expect(startA.Location).To(Equal("Comp.Top"))
+		Expect(startA.Location).To(Equal("Comp.Top.incoming"))
 		Expect(startA.Time).To(Equal(timing.VTimeInPicoSec(100)))
 		startB := tracer.starts[1]
 		Expect(startB.ParentID).To(Equal(uint64(8)))

--- a/tracing/outgoingbuffertracer.go
+++ b/tracing/outgoingbuffertracer.go
@@ -101,7 +101,10 @@ func (h *outgoingBufferHook) onSend(
 		ParentID: parentID,
 		Kind:     OutgoingBufferTaskKind,
 		What:     msgTypeName(msg),
-		Location: port.Name(),
+		// A port holds both an incoming and an outgoing buffer, so the
+		// direction qualifies the location — one location, one kind (see
+		// README.md). The outgoing buffer is "<port>.outgoing".
+		Location: port.Name() + ".outgoing",
 	})
 
 	if atHead {

--- a/tracing/outgoingbuffertracer_test.go
+++ b/tracing/outgoingbuffertracer_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Outgoing buffer tracer", func() {
 		Expect(startA.Kind).To(Equal(OutgoingBufferTaskKind))
 		Expect(startA.ParentID).To(Equal(uint64(7)))
 		Expect(startA.What).To(Equal("obTestMsg"))
-		Expect(startA.Location).To(Equal("Comp.Bottom"))
+		Expect(startA.Location).To(Equal("Comp.Bottom.outgoing"))
 		Expect(startA.Time).To(Equal(timing.VTimeInPicoSec(100)))
 		startB := tracer.starts[1]
 		Expect(startB.ParentID).To(Equal(uint64(8)))

--- a/tracing/task.go
+++ b/tracing/task.go
@@ -13,7 +13,7 @@ type TaskStart struct {
 	ParentID uint64
 	Kind     string
 	What     string
-	Location string // optional; defaults to the domain name when empty
+	Location string // optional; when empty, derived by singleKindLocation
 	Time     timing.VTimeInPicoSec
 	Detail   any
 }
@@ -30,7 +30,21 @@ type TaskEnd struct {
 // retrieve) and closes it at pipeline exit. This attributes the pipeline latency
 // that would otherwise be an unaccounted gap between the buffer task (which ends
 // at retrieve) and the post-pipeline processing milestones on req_in.
+//
+// A pipeline subtask's What is "<component>.<stage>" (e.g. "L2Cache.bank"); that
+// already-qualified name becomes its location, so each stage is its own
+// single-kind row (see "One location, one kind" in README.md).
 const PipelineTaskKind = "pipeline"
+
+// ReqInTaskKind is the Kind of the receiver-side task that spans a component's
+// handling of an incoming request, from admission to completion. It is opened by
+// [TraceReqReceive] and located at "<component>.req_in".
+const ReqInTaskKind = "req_in"
+
+// ReqOutTaskKind is the Kind of the sender-side task that spans a request a
+// component has issued, from send until the response arrives. It is opened by
+// [TraceReqInitiate] and located at "<component>.req_out".
+const ReqOutTaskKind = "req_out"
 
 // A TaskTag is a categorical label attached to a task while it is processed,
 // for example "read-hit" or "write-miss". Tags inherit their location from the


### PR DESCRIPTION
## Problem

A trace `Location` is the row a viewer (Daisen) draws tasks on, and a row is read as a single sequential timeline. So every location should host exactly **one** task `Kind`. It didn't: `req_in`/`req_out`/`pipeline` all defaulted to the bare component name, and a port's incoming and outgoing buffers both used the port name. In a representative trace **23 of 25 locations mixed multiple kinds** (96% of rows), so different kinds overlapped in time on one row.

## Fix

Qualify each location so it maps to a single kind — a **component** by *stage*, a **port** by *direction*:

| Kind | Location |
|------|----------|
| `req_in` | `<component>.req_in` |
| `req_out` | `<component>.req_out` |
| `pipeline` | `<component>.<stage>` (the task's `What`, e.g. `L2Cache.bank`) |
| `incoming_buffer` | `<port>.incoming` |
| `outgoing_buffer` | `<port>.outgoing` |

- `singleKindLocation` (in `tracing/api.go`) centralizes the component policy in `StartTask` when `Location` is empty; the port buffer hooks append the direction explicitly.
- New `ReqInTaskKind` / `ReqOutTaskKind` constants so the emit helpers and the switch share one source.
- The principle is documented in a new **Locations** section of `tracing/README.md`.
- All location strings continue to be interned into the trace's `location` table.

## Verification

- `go build ./...` clean; full `go test ./...` passes (41 packages); `go vet ./tracing/...` clean.
- End-to-end against the `mem/acceptancetests/virtualmem` harness (same component set as the trace that surfaced the issue): a freshly generated trace has **0 multi-kind locations** across 54 single-kind locations, down from **23/25** violating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)