### PR TITLE
ci: run regular tests on GitHub-hosted runners (parallel mem acceptance on Github-Large-1)

### DIFF
--- a/.github/workflows/akita_test.yml
+++ b/.github/workflows/akita_test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   daisen2_compile:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
         run: npm run build
 
   monitoring2_compile:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
         run: npm run build
 
   akita_build_lint_test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
     # counts vs DRAMSim3 & Ramulator2) and Tier 6 (read latency within 15%),
     # which compare against the committed reference data in mem/dram/validation/.
     # No C++ oracle build needed; mem/dram has no generated mocks.
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -94,7 +94,7 @@ jobs:
         run: go test ./mem/dram/ -count=1
 
   noc_acceptance_test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [akita_build_lint_test]
     steps:
@@ -121,7 +121,7 @@ jobs:
         run: python3 acceptance_test.py
 
   mem_acceptance_test:
-    runs-on: self-hosted
+    runs-on: Github-Large-1
     timeout-minutes: 60
     needs: [akita_build_lint_test]
     steps:


### PR DESCRIPTION
## Why

MGPUSim MI300 calibration jobs saturate the shared self-hosted runners, so Akita's regular PR CI sits queued. Move the functional jobs to GitHub-hosted runners.

## Changes (`.github/workflows/akita_test.yml`)

| Job | Runner |
|---|---|
| daisen2 compile, monitoring2 compile, build+lint+test, DRAM validation, NoC acceptance | `ubuntu-latest` |
| mem acceptance | `group: Github-Large-1` |

`mem_acceptance_test` runs the parallel-engine variants (`mem/acceptance_test.py` invokes the binaries with `-parallel`, which call `WithParallelEngine()`), so it needs real cores → `Github-Large-1`. `noc_acceptance_test` does not use the parallel engine, so it stays free.

## Notes

- The Python-install step already falls back to apt (`dnf ... || apt-get ...`), and ubuntu-latest ships gcc, so CGO builds (daisen2's go-sqlite3) still work.
- For `pull_request` runs GitHub uses the workflow from the PR's own branch, so open PRs pick this up after merging/rebasing `main` (or by applying it to their branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
