### PR TITLE
daisen2: reader builds task/milestone/tag indexes on demand

### DIFF
--- a/daisen2/internal/httpapi/componenttimeline.go
+++ b/daisen2/internal/httpapi/componenttimeline.go
@@ -314,6 +314,17 @@ func (r *SQLiteTraceReader) BlockingReasonOccupancy( //nolint:funlen // one cohe
 			`ON trace(Location, StartTime, EndTime, ID)`,
 	)
 
+	// The milestone side of the join (m.TaskID = t.ID, windowed by Time). The sim
+	// no longer indexes milestones, so build the (TaskID, Time) index here too —
+	// otherwise this chart, opened before any task click, scans the whole milestone
+	// table. Same index the per-task milestone loader builds (single-flight: at most
+	// one build across both paths).
+	r.ensureIndex(
+		ctx,
+		"Building index idx_milestone_TaskID_Time",
+		"CREATE INDEX IF NOT EXISTS idx_milestone_TaskID_Time ON milestone(TaskID, Time)",
+	)
+
 	// Guard the exact scan (see ComponentTimeline): the trace×milestone join is
 	// even costlier, so decline it for a scope the rowid sample only appeared to
 	// empty because it is dense and modulo-skewed.

--- a/daisen2/internal/httpapi/trace.go
+++ b/daisen2/internal/httpapi/trace.go
@@ -53,12 +53,14 @@ func (s *Server) httpTrace(w http.ResponseWriter, r *http.Request) {
 		queryParentID, _ = strconv.ParseUint(pidStr, 10, 64)
 	}
 
-	// A bare global-Kind probe (e.g. useSimulationRange's /api/trace?kind=Simulation)
-	// only needs the matched task's time span, not its steps. Loading milestones/tags
-	// for it would build the full (TaskID, Time) milestone+tag indexes at dashboard
-	// start — minutes on a large trace — for a task that typically has no steps. Skip
-	// step loading for it.
-	kindOnlyProbe := r.FormValue("kind") != "" && r.FormValue("scope") == "" &&
+	// The startup range probe (useSimulationRange's /api/trace?kind=Simulation) is a
+	// bare global-Kind query with NO time range; it only needs the matched task's
+	// span, not its steps, so loading milestones/tags for it would needlessly build
+	// the full (TaskID, Time) milestone+tag indexes at dashboard start. The Task
+	// chart's kind-filter browse also sends a global Kind query, but WITH a time
+	// range, and uses the results' steps — so the no-time-range guard keeps
+	// milestones for it.
+	rangeProbe := r.FormValue("kind") != "" && !useTimeRange && r.FormValue("scope") == "" &&
 		r.FormValue("where") == "" && queryID == 0 && queryParentID == 0
 
 	query := TaskQuery{
@@ -71,7 +73,7 @@ func (s *Server) httpTrace(w http.ResponseWriter, r *http.Request) {
 		EndTime:          endTime,
 		EnableTimeRange:  useTimeRange,
 		EnableParentTask: false,
-		EnableMilestones: !kindOnlyProbe,
+		EnableMilestones: !rangeProbe,
 	}
 
 	tasks := s.traceReader.ListTasks(r.Context(), query)
@@ -381,11 +383,12 @@ func (r *SQLiteTraceReader) ensureTaskQueryIndexes(ctx context.Context, query Ta
 			"CREATE INDEX IF NOT EXISTS idx_trace_ParentID ON trace(ParentID)")
 	}
 
-	// A global Kind lookup with no location scope — e.g. the startup
-	// "kind=Simulation" range probe — would otherwise full-scan the trace. Build a
-	// tiny PARTIAL index on just that Kind value rather than a full Kind index,
-	// which would be ~1 GB for a handful of distinct values.
-	if query.Kind != "" && query.Scope == "" && query.Where == "" &&
+	// Only the startup range probe — a global Kind lookup with NO time range — builds
+	// a partial Kind index (tiny, on just that value). The Task chart's kind-filter
+	// browse sends a global Kind query per keystroke WITH a time range; gating on
+	// !EnableTimeRange avoids spamming a partial index for every typed prefix (that
+	// browse scans instead, which is fine for an interactive, controlled filter).
+	if query.Kind != "" && !query.EnableTimeRange && query.Scope == "" && query.Where == "" &&
 		query.ID == 0 && query.ParentID == 0 && safeKindPattern.MatchString(query.Kind) {
 		ident := kindIdentReplace.Replace(query.Kind)
 		r.ensureIndex(ctx, "Building partial index idx_trace_kind_"+ident,

--- a/daisen2/internal/httpapi/trace.go
+++ b/daisen2/internal/httpapi/trace.go
@@ -53,6 +53,14 @@ func (s *Server) httpTrace(w http.ResponseWriter, r *http.Request) {
 		queryParentID, _ = strconv.ParseUint(pidStr, 10, 64)
 	}
 
+	// A bare global-Kind probe (e.g. useSimulationRange's /api/trace?kind=Simulation)
+	// only needs the matched task's time span, not its steps. Loading milestones/tags
+	// for it would build the full (TaskID, Time) milestone+tag indexes at dashboard
+	// start — minutes on a large trace — for a task that typically has no steps. Skip
+	// step loading for it.
+	kindOnlyProbe := r.FormValue("kind") != "" && r.FormValue("scope") == "" &&
+		r.FormValue("where") == "" && queryID == 0 && queryParentID == 0
+
 	query := TaskQuery{
 		ID:               queryID,
 		ParentID:         queryParentID,
@@ -63,7 +71,7 @@ func (s *Server) httpTrace(w http.ResponseWriter, r *http.Request) {
 		EndTime:          endTime,
 		EnableTimeRange:  useTimeRange,
 		EnableParentTask: false,
-		EnableMilestones: true,
+		EnableMilestones: !kindOnlyProbe,
 	}
 
 	tasks := s.traceReader.ListTasks(r.Context(), query)

--- a/daisen2/internal/httpapi/trace.go
+++ b/daisen2/internal/httpapi/trace.go
@@ -350,7 +350,46 @@ func (r *SQLiteTraceReader) ListComponents(ctx context.Context) []string {
 }
 
 // ListTasks returns a list of tasks in the trace according to the given query.
+var (
+	// safeKindPattern restricts the Kind values a partial index may be built for
+	// to characters that appear in real task kinds, so the value can be embedded
+	// as a SQL literal in the index DDL with no injection risk.
+	safeKindPattern  = regexp.MustCompile(`^[A-Za-z0-9_ .\[\]\-]+$`)
+	kindIdentReplace = strings.NewReplacer(" ", "_", ".", "_", "[", "_", "]", "_", "-", "_")
+)
+
+// ensureTaskQueryIndexes builds, on demand, the secondary indexes a given task
+// query needs. The simulation writes the trace without any secondary indexes on
+// trace/milestone/tag (it never queries the data — see the entry structs in
+// akita's tracing.dbtracer), so the reader owns them and builds only what an
+// access pattern actually uses, once per trace.
+func (r *SQLiteTraceReader) ensureTaskQueryIndexes(ctx context.Context, query TaskQuery) {
+	if query.ID != 0 {
+		r.ensureIndex(ctx, "Building index idx_trace_ID",
+			"CREATE INDEX IF NOT EXISTS idx_trace_ID ON trace(ID)")
+	}
+	if query.ParentID != 0 {
+		r.ensureIndex(ctx, "Building index idx_trace_ParentID",
+			"CREATE INDEX IF NOT EXISTS idx_trace_ParentID ON trace(ParentID)")
+	}
+
+	// A global Kind lookup with no location scope — e.g. the startup
+	// "kind=Simulation" range probe — would otherwise full-scan the trace. Build a
+	// tiny PARTIAL index on just that Kind value rather than a full Kind index,
+	// which would be ~1 GB for a handful of distinct values.
+	if query.Kind != "" && query.Scope == "" && query.Where == "" &&
+		query.ID == 0 && query.ParentID == 0 && safeKindPattern.MatchString(query.Kind) {
+		ident := kindIdentReplace.Replace(query.Kind)
+		r.ensureIndex(ctx, "Building partial index idx_trace_kind_"+ident,
+			fmt.Sprintf(
+				"CREATE INDEX IF NOT EXISTS idx_trace_kind_%s ON trace(Kind) WHERE Kind = '%s'",
+				ident, query.Kind))
+	}
+}
+
 func (r *SQLiteTraceReader) ListTasks(ctx context.Context, query TaskQuery) []Task {
+	r.ensureTaskQueryIndexes(ctx, query)
+
 	sqlStr, args := r.prepareTaskQueryStr(query)
 
 	rows, err := r.QueryContext(ctx, sqlStr, args...)
@@ -368,8 +407,8 @@ func (r *SQLiteTraceReader) ListTasks(ctx context.Context, query TaskQuery) []Ta
 	}
 
 	if query.EnableMilestones {
-		r.loadMilestonesForTasks(tasks)
-		r.loadTagsForTasks(tasks)
+		r.loadMilestonesForTasks(ctx, tasks)
+		r.loadTagsForTasks(ctx, tasks)
 		sortTaskSteps(tasks)
 	}
 
@@ -539,10 +578,15 @@ func (s *Server) httpTraceTimeRange(w http.ResponseWriter, r *http.Request) {
 }
 
 // loadMilestonesForTasks loads milestones for the given tasks from the database.
-func (r *SQLiteTraceReader) loadMilestonesForTasks(tasks []Task) {
+func (r *SQLiteTraceReader) loadMilestonesForTasks(ctx context.Context, tasks []Task) {
 	if len(tasks) == 0 {
 		return
 	}
+
+	// Built by the reader (the sim no longer indexes milestones). A composite
+	// (TaskID, Time) serves both the TaskID IN-filter and the ORDER BY TaskID,Time.
+	r.ensureIndex(ctx, "Building index idx_milestone_TaskID_Time",
+		"CREATE INDEX IF NOT EXISTS idx_milestone_TaskID_Time ON milestone(TaskID, Time)")
 
 	// Build a map for quick task lookup
 	taskMap := make(map[uint64]*Task)
@@ -614,10 +658,14 @@ func (r *SQLiteTraceReader) loadMilestoneBatch(taskMap map[uint64]*Task, ids []u
 // milestones. A tag's location is inherited from its task, so the tag table
 // stores none; tags also carry no Kind, so they are labelled "tag" to stay
 // distinguishable from milestones in the merged stream.
-func (r *SQLiteTraceReader) loadTagsForTasks(tasks []Task) {
+func (r *SQLiteTraceReader) loadTagsForTasks(ctx context.Context, tasks []Task) {
 	if len(tasks) == 0 {
 		return
 	}
+
+	// Built by the reader (the sim no longer indexes tags).
+	r.ensureIndex(ctx, "Building index idx_tag_TaskID_Time",
+		"CREATE INDEX IF NOT EXISTS idx_tag_TaskID_Time ON tag(TaskID, Time)")
 
 	taskMap := make(map[uint64]*Task)
 	taskIDs := make([]uint64, 0, len(tasks))


### PR DESCRIPTION
The reader builds the few secondary indexes its queries actually use, on demand,
so the simulation can write the trace without any (see the companion akita
`tracing`/`datarecording` change, **#437**, which strips the index tags from the
entry structs).

Via the existing single-flight `ensureIndex`:
- `idx_trace_ID` — before a task-by-id lookup
- `idx_trace_ParentID` — before a parent→children lookup
- `idx_milestone_TaskID_Time` / `idx_tag_TaskID_Time` — before loading a task's
  milestones/tags; the composite `(TaskID, Time)` serves both the `TaskID IN`
  filter and the `ORDER BY TaskID, Time`
- a tiny **partial** index per global Kind value (e.g. `idx_trace_kind_Simulation`
  for the startup `kind=Simulation` range probe) instead of a ~1 GB full Kind index

An audit of the query plans showed every other trace/milestone column is filtered
only alongside `Location` (served by the Location-led covering indexes already
built here) or via `TaskID`, so no standalone `Location`/`StartTime`/`EndTime`/
`Kind`/`What` index is needed. `ensureIndex` short-circuits on an already-built
index, so the per-task-click calls are free after the first build.

**Coupling:** pairs with akita **#437**. #437 makes the sim write traces without
secondary indexes; this makes the reader build the ones it needs. They should
merge together — otherwise a trace written by the new sim would have no index for
task-by-id / parent-child / milestone / tag / Kind lookups until this lands.

Verified end-to-end: a sim trace shipping with only `idx_location_ID` gains
exactly these indexes as the matching queries run, with correct results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
