### PR TITLE
build(deps): Bump postcss from 8.5.15 to 8.5.23 in /doc-site

### DIFF
--- a/doc-site/package-lock.json
+++ b/doc-site/package-lock.json
@@ -15098,9 +15098,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -15782,9 +15782,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15801,7 +15801,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Finishes the dependency bump dependabot proposed in #461 and then closed itself.

### Why this was reopened manually

Dependabot closed #461 with "Looks like postcss is no longer updatable, so this is no longer needed." That does not hold up:

- postcss **8.5.23** is published.
- The highest floor among the ~120 packages in `doc-site` that depend on postcss is `^8.5.4`, so nothing caps the range.

It most likely raced with the nine dependency PRs that rewrote `doc-site/package-lock.json` in the preceding ~30 minutes.

### The change

Produced with `npm update postcss --package-lock-only`, giving the same lockfile-only diff dependabot originally proposed (`+7/-7`):

| Package | From | To |
|---|---|---|
| postcss | 8.5.15 | 8.5.23 |
| nanoid (postcss dep) | 3.3.12 | 3.3.16 |

No `package.json` change — postcss is a transitive dependency here.

### Verification

`npm ci && npm run build` in `doc-site/` both succeed. This is worth calling out because **PR CI does not build `doc-site`** — `daisen2_compile` and `monitoring2_compile` cover the other two frontends, and `deploy-docs.yml` only runs on push to `main`. So doc-site dependency bumps are currently validated only after they merge.

The build emits pre-existing broken-link and broken-anchor warnings (`checkpointing.md`, `tutorial/migration` anchors). Those are unrelated to this change and do not fail the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)