### PR TITLE
Support GPT-5.6 tool calls in Daisen

### DIFF
--- a/daisen2/README.md
+++ b/daisen2/README.md
@@ -21,13 +21,18 @@ the key blank for keyless local servers).
 
 The model field is backed by the provider's model list (fetched via the server
 from `{baseURL}/models`); use the refresh button to load it, then pick a model
-or type your own.
+or type your own. New configurations and the OpenAI preset default to
+`gpt-5.6-sol`; an existing saved model selection is preserved.
 
 GPT-5.6 models require `reasoning_effort: "none"` when function tools are used
 through OpenAI's `/chat/completions` endpoint. Daisen applies that compatibility
 setting automatically on GPT-5.6 tool turns. This preserves Daisen's tool loop;
 using GPT-5.6 reasoning together with tools would require a future Responses API
 provider implementation.
+
+If a provider rejects a tool-enabled request, Daisen still retries that turn
+without tools for compatibility, but now surfaces the provider error in the chat
+instead of silently hiding the fallback.
 
 The API key is sent on each request in the `X-Llm-Api-Key` header (not the body)
 and is never written to disk on the server. In the browser it is kept in

--- a/daisen2/README.md
+++ b/daisen2/README.md
@@ -23,6 +23,12 @@ The model field is backed by the provider's model list (fetched via the server
 from `{baseURL}/models`); use the refresh button to load it, then pick a model
 or type your own.
 
+GPT-5.6 models require `reasoning_effort: "none"` when function tools are used
+through OpenAI's `/chat/completions` endpoint. Daisen applies that compatibility
+setting automatically on GPT-5.6 tool turns. This preserves Daisen's tool loop;
+using GPT-5.6 reasoning together with tools would require a future Responses API
+provider implementation.
+
 The API key is sent on each request in the `X-Llm-Api-Key` header (not the body)
 and is never written to disk on the server. In the browser it is kept in
 `sessionStorage` and cleared when the tab closes; tick **Remember key on this

--- a/daisen2/internal/httpapi/agentloop.go
+++ b/daisen2/internal/httpapi/agentloop.go
@@ -171,12 +171,10 @@ func callProvider(
 	return assistantMessageFromOAI(m.Role, m.Content, m.ToolCalls), m.ToolCalls, m.Content, nil
 }
 
+var gpt56ModelID = regexp.MustCompile(`(^|[:/])gpt-5\.6($|[-:])`)
+
 func requiresNoReasoningForChatCompletionTools(model string) bool {
-	model = strings.ToLower(strings.TrimSpace(model))
-	if slash := strings.LastIndex(model, "/"); slash >= 0 {
-		model = model[slash+1:]
-	}
-	return model == "gpt-5.6" || strings.HasPrefix(model, "gpt-5.6-")
+	return gpt56ModelID.MatchString(strings.ToLower(strings.TrimSpace(model)))
 }
 
 // assistantMessageFromOAI converts a parsed OpenAI assistant message into the map
@@ -229,6 +227,11 @@ func runAgentLoop(
 		if err != nil && offerTools {
 			// The endpoint may not support tools — retry once without them so a
 			// non-tool model still answers (capability fallback).
+			emit(agentEvent{
+				Type: "thinking",
+				Text: "The tool-enabled provider request failed; retrying this turn without tools. " +
+					"Provider error: " + clip(err.Error(), 600),
+			})
 			msg, toolCalls, content, err = callProvider(ctx, cfg, messages, nil, false)
 		}
 		if err != nil {

--- a/daisen2/internal/httpapi/agentloop.go
+++ b/daisen2/internal/httpapi/agentloop.go
@@ -119,6 +119,15 @@ func callProvider(
 	if offerTools && len(toolSpecs) > 0 {
 		payload["tools"] = toolSpecs
 		payload["tool_choice"] = "auto"
+		// GPT-5.6 reasoning variants reject function tools on the Chat
+		// Completions endpoint unless reasoning is disabled. The Responses API
+		// supports reasoning together with tools, but Daisen's provider contract is
+		// intentionally OpenAI-compatible Chat Completions for now. Keep the
+		// compatibility adjustment scoped to GPT-5.6 tool turns so other providers
+		// and non-tool requests retain their native defaults.
+		if requiresNoReasoningForChatCompletionTools(cfg.Model) {
+			payload["reasoning_effort"] = "none"
+		}
 	}
 
 	bodyBytes, err := json.Marshal(payload)
@@ -160,6 +169,14 @@ func callProvider(
 
 	m := parsed.Choices[0].Message
 	return assistantMessageFromOAI(m.Role, m.Content, m.ToolCalls), m.ToolCalls, m.Content, nil
+}
+
+func requiresNoReasoningForChatCompletionTools(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if slash := strings.LastIndex(model, "/"); slash >= 0 {
+		model = model[slash+1:]
+	}
+	return model == "gpt-5.6" || strings.HasPrefix(model, "gpt-5.6-")
 }
 
 // assistantMessageFromOAI converts a parsed OpenAI assistant message into the map

--- a/daisen2/internal/httpapi/agentloop_test.go
+++ b/daisen2/internal/httpapi/agentloop_test.go
@@ -92,9 +92,12 @@ func TestRequiresNoReasoningForChatCompletionTools(t *testing.T) {
 		{model: "gpt-5.6-luna", want: true},
 		{model: "gpt-5.6-sol-2026-08-01", want: true},
 		{model: "openai/gpt-5.6-terra", want: true},
+		{model: "gpt-5.6:latest", want: true},
+		{model: "ft:gpt-5.6-sol:org::abc", want: true},
 		{model: " GPT-5.6-SOL ", want: true},
 		{model: "gpt-5.5", want: false},
 		{model: "gpt-5.60", want: false},
+		{model: "mygpt-5.6-sol", want: false},
 		{model: "mock", want: false},
 	}
 
@@ -160,6 +163,52 @@ func TestCallProviderGPT56UsesNoReasoningWithTools(t *testing.T) {
 				t.Fatalf("reasoning_effort = %v, want omitted", effort)
 			}
 		})
+	}
+}
+
+func TestRunAgentLoopSurfacesToolCapabilityFallback(t *testing.T) {
+	t.Setenv("DAISEN_ALLOW_PRIVATE_LLM_URL", "1")
+
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			io.WriteString(w, `{"error":{"message":"tools are unsupported"}}`)
+			return
+		}
+		io.WriteString(w, `{"choices":[{"message":{"role":"assistant","content":"fallback answer"}}]}`)
+	}))
+	defer srv.Close()
+
+	cfg := ProviderConfig{Provider: ProviderOpenAICompatible, BaseURL: srv.URL, Model: "strict-proxy-model"}
+	tools := []agentTool{{
+		name:        "synthetic_lookup",
+		description: "test tool",
+		parameters:  map[string]interface{}{"type": "object"},
+	}}
+	var events []agentEvent
+	if err := runAgentLoop(
+		context.Background(),
+		cfg,
+		[]map[string]interface{}{{"role": "user", "content": "test"}},
+		tools,
+		func(ev agentEvent) { events = append(events, ev) },
+	); err != nil {
+		t.Fatalf("runAgentLoop: %v", err)
+	}
+
+	if calls != 2 {
+		t.Fatalf("provider calls = %d, want tool request plus no-tools fallback", calls)
+	}
+	if len(events) != 2 || events[0].Type != "thinking" ||
+		!strings.Contains(events[0].Text, "retrying this turn without tools") ||
+		!strings.Contains(events[0].Text, "tools are unsupported") {
+		t.Fatalf("fallback event not surfaced before the answer: %#v", events)
+	}
+	if events[1].Type != "message" || events[1].Text != "fallback answer" {
+		t.Fatalf("unexpected fallback answer event: %#v", events[1])
 	}
 }
 

--- a/daisen2/internal/httpapi/agentloop_test.go
+++ b/daisen2/internal/httpapi/agentloop_test.go
@@ -83,6 +83,86 @@ func TestRunDataQuery(t *testing.T) {
 	}
 }
 
+func TestRequiresNoReasoningForChatCompletionTools(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{model: "gpt-5.6", want: true},
+		{model: "gpt-5.6-luna", want: true},
+		{model: "gpt-5.6-sol-2026-08-01", want: true},
+		{model: "openai/gpt-5.6-terra", want: true},
+		{model: " GPT-5.6-SOL ", want: true},
+		{model: "gpt-5.5", want: false},
+		{model: "gpt-5.60", want: false},
+		{model: "mock", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := requiresNoReasoningForChatCompletionTools(tt.model); got != tt.want {
+				t.Fatalf("requiresNoReasoningForChatCompletionTools(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCallProviderGPT56UsesNoReasoningWithTools(t *testing.T) {
+	t.Setenv("DAISEN_ALLOW_PRIVATE_LLM_URL", "1")
+
+	tests := []struct {
+		model               string
+		offerTools          bool
+		wantReasoningEffort bool
+	}{
+		{model: "gpt-5.6-sol", offerTools: true, wantReasoningEffort: true},
+		{model: "gpt-5.6-sol", offerTools: false, wantReasoningEffort: false},
+		{model: "gpt-5.5", offerTools: true, wantReasoningEffort: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			var got map[string]interface{}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				io.WriteString(w, `{"choices":[{"message":{"role":"assistant","content":"done"}}]}`)
+			}))
+			defer srv.Close()
+
+			cfg := ProviderConfig{Provider: ProviderOpenAICompatible, BaseURL: srv.URL, Model: tt.model}
+			toolSpecs := []interface{}{map[string]interface{}{
+				"type": "function",
+				"function": map[string]interface{}{
+					"name":       "synthetic_lookup",
+					"parameters": map[string]interface{}{"type": "object"},
+				},
+			}}
+
+			if _, _, _, err := callProvider(
+				context.Background(),
+				cfg,
+				[]map[string]interface{}{{"role": "user", "content": "test"}},
+				toolSpecs,
+				tt.offerTools,
+			); err != nil {
+				t.Fatalf("callProvider: %v", err)
+			}
+
+			effort, present := got["reasoning_effort"]
+			if tt.wantReasoningEffort {
+				if !present || effort != "none" {
+					t.Fatalf("reasoning_effort = %v (present %v), want none", effort, present)
+				}
+			} else if present {
+				t.Fatalf("reasoning_effort = %v, want omitted", effort)
+			}
+		})
+	}
+}
+
 // TestRunDataQueryRejectsCTEWrite guards the P1: a write smuggled through a CTE
 // passes the SELECT/WITH prefix check but must be rejected by the read-only
 // connection (PRAGMA query_only) without mutating the trace.

--- a/daisen2/static/src/components/chat/ChatSettings.tsx
+++ b/daisen2/static/src/components/chat/ChatSettings.tsx
@@ -122,7 +122,7 @@ export default function ChatSettings({
               type="text"
               autoComplete="off"
               value={settings.model}
-              placeholder="gpt-4o"
+              placeholder="gpt-5.6-sol"
               onChange={(event) => {
                 update({ model: event.target.value, presetId: "custom" });
                 setModelMenuOpen(true);

--- a/daisen2/static/src/hooks/useLLMSettings.ts
+++ b/daisen2/static/src/hooks/useLLMSettings.ts
@@ -8,7 +8,7 @@ export const PROVIDER_PRESETS = [
     id: "openai",
     label: "OpenAI",
     baseURL: "https://api.openai.com/v1/chat/completions",
-    model: "gpt-4o",
+    model: "gpt-5.6-sol",
   },
   {
     id: "openrouter",
@@ -38,7 +38,7 @@ const DEFAULT_SETTINGS: LLMSettings = {
   provider: "openai-compatible",
   presetId: "openai",
   baseURL: "https://api.openai.com/v1/chat/completions",
-  model: "gpt-4o",
+  model: "gpt-5.6-sol",
   apiKey: "",
   remember: false,
 };

--- a/daisen2/static/tests/llm-settings.test.mjs
+++ b/daisen2/static/tests/llm-settings.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("OpenAI defaults to GPT-5.6 Sol", async () => {
+  const source = await readFile(new URL("../src/hooks/useLLMSettings.ts", import.meta.url), "utf8");
+  const openAIPreset = source.match(/id: "openai",[\s\S]*?\n  \},/u)?.[0] ?? "";
+  const defaultSettings = source.match(/const DEFAULT_SETTINGS[\s\S]*?\n\};/u)?.[0] ?? "";
+
+  assert.match(openAIPreset, /model: "gpt-5\.6-sol"/u);
+  assert.match(defaultSettings, /model: "gpt-5\.6-sol"/u);
+});


### PR DESCRIPTION
## Summary

- send `reasoning_effort: "none"` on GPT-5.6 Chat Completions turns that offer function tools
- recognize provider-prefixed, tagged, snapshot, and fine-tuned GPT-5.6 model IDs
- surface the provider error when Daisen's compatibility fallback retries a turn without tools
- make `gpt-5.6-sol` the OpenAI preset and new-configuration default while preserving saved user selections
- add focused backend/frontend regression tests and document the compatibility behavior

## Root cause

OpenAI's `/v1/chat/completions` endpoint returns HTTP 400 when GPT-5.6 function tools are combined with the model's default reasoning effort:

> Function tools with reasoning_effort are not supported ... use /v1/responses or set reasoning_effort to 'none'.

Daisen then exercised its capability fallback and retried without tools, which made GPT-5.6 appear to answer normally while never invoking a tool. GPT-5.5 did not reject the original request.

Daisen currently standardizes on the OpenAI-compatible Chat Completions protocol, so this PR applies the endpoint-recommended `reasoning_effort: "none"` setting only to GPT-5.6 tool turns. Supporting GPT-5.6 reasoning and tools together would require a future Responses API provider implementation.

The no-tools capability fallback remains for OpenAI-compatible gateways, but it is no longer silent: the chat now reports the rejected tool request and provider error before retrying.

## Validation

- `go test ./daisen2/...`
- `npm test` in `daisen2/static` — 55 passed
- `npm run build` in `daisen2/static`
- live synthetic API comparison:
  - GPT-5.5: tool call succeeds unchanged
  - GPT-5.6 Luna/Sol/Terra: all reject the old payload and all call the tool with `reasoning_effort: "none"`
- browser verification against the supplied page-migration trace:
  - GPT-5.6 Sol made one `data_query` call and returned synthetic value 42
  - GPT-5.5 made one `data_query` call and returned synthetic value 43
  - a fresh configuration selects `gpt-5.6-sol` in the OpenAI settings panel
  - no browser console errors
  - no trace-table data was sent to the external model

Fixes #463
