### PR TITLE
fix(datarecording): prevent concurrent recording data loss

### DIFF
--- a/datarecording/concurrency_test.go
+++ b/datarecording/concurrency_test.go
@@ -1,0 +1,154 @@
+package datarecording
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+type concurrentRecord struct {
+	ID       int
+	Location string `akita_data:"location"`
+}
+
+func TestConcurrentRecording(t *testing.T) {
+	for _, manualFlush := range []bool{false, true} {
+		t.Run(fmt.Sprintf("manual_flush=%t", manualFlush), func(t *testing.T) {
+			db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "records.sqlite3"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			recorder := NewDataRecorderWithDB(db).(*sqliteWriter)
+			recorder.batchSize = 32
+			recorder.CreateTable("first", concurrentRecord{})
+			recorder.CreateTable("second", concurrentRecord{})
+
+			const writers, perWriter = 4, 400
+			start := make(chan struct{})
+			var workers sync.WaitGroup
+			for writer := range writers {
+				workers.Go(func() {
+					<-start
+					insertConcurrentRecords(recorder, writer*perWriter, perWriter)
+				})
+			}
+			if manualFlush {
+				for range 2 {
+					workers.Go(func() {
+						<-start
+						for range 100 {
+							recorder.Flush()
+							runtime.Gosched()
+						}
+					})
+				}
+			}
+			close(start)
+			workers.Wait()
+			recorder.Flush()
+			recorder.Flush() // An empty flush must not replay the last batch.
+
+			assertConcurrentRecords(t, db, writers*perWriter)
+			if err := recorder.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func insertConcurrentRecords(recorder DataRecorder, firstID, count int) {
+	for i := range count {
+		id := firstID + i
+		tableName := "first"
+		if id%2 != 0 {
+			tableName = "second"
+		}
+		recorder.InsertData(tableName, concurrentRecord{
+			ID: id, Location: fmt.Sprintf("location-%d", id%7),
+		})
+		runtime.Gosched()
+	}
+}
+
+func assertConcurrentRecords(t *testing.T, db *sql.DB, expected int) {
+	t.Helper()
+	rows, err := db.Query(`
+		SELECT records.ID, location.Locale FROM (
+			SELECT ID, Location FROM first UNION ALL SELECT ID, Location FROM second
+		) AS records LEFT JOIN location ON records.Location = location.ID`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	seen := make(map[int]bool, expected)
+	for rows.Next() {
+		var id int
+		var location string
+		if err := rows.Scan(&id, &location); err != nil {
+			t.Fatal(err)
+		}
+		if id < 0 || id >= expected || seen[id] {
+			t.Fatalf("unexpected or duplicate ID %d", id)
+		}
+		if want := fmt.Sprintf("location-%d", id%7); location != want {
+			t.Fatalf("ID %d: location = %q, want %q", id, location, want)
+		}
+		seen[id] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(seen) != expected {
+		t.Fatalf("persisted %d distinct records, want %d", len(seen), expected)
+	}
+	t.Logf("Persisted all %d records exactly once with correct locations", expected)
+}
+
+func TestFlushRollsBackAndRetainsBatch(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "rollback.sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	recorder := NewDataRecorderWithDB(db)
+	recorder.CreateTable("first", concurrentRecord{})
+	recorder.CreateTable("second", concurrentRecord{})
+	_, err = db.Exec(`CREATE TRIGGER reject_row BEFORE INSERT ON first
+		WHEN NEW.ID = 1 BEGIN SELECT RAISE(ABORT, 'test insert failure'); END`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for id := range 2 {
+		recorder.InsertData("first", concurrentRecord{
+			ID: id, Location: fmt.Sprintf("location-%d", id),
+		})
+	}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("Flush did not report the injected insert failure")
+			}
+		}()
+		recorder.Flush()
+	}()
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM first").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("failed flush committed %d rows", count)
+	}
+	if _, err := db.Exec("DROP TRIGGER reject_row"); err != nil {
+		t.Fatal(err)
+	}
+	recorder.Flush()
+	assertConcurrentRecords(t, db, 2)
+	if err := recorder.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/datarecording/datarecorder.go
+++ b/datarecording/datarecorder.go
@@ -16,7 +16,9 @@ import (
 	"github.com/tebeka/atexit"
 )
 
-// DataRecorder is a backend that can record and store data
+// DataRecorder is a backend that can record and store data.
+// The SQLite implementation supports concurrent CreateTable, InsertData,
+// ListTables, and Flush calls. Stop producers before calling Close.
 type DataRecorder interface {
 	// CreateTable creates a new table with given filename
 	CreateTable(tableName string, sampleEntry any)
@@ -332,10 +334,10 @@ func (t *sqliteWriter) createIndex(tableName, fieldName string, unique bool) {
 
 func (t *sqliteWriter) InsertData(tableName string, entry any) {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	table, exists := t.tables[tableName]
 	if !exists {
-		t.mu.Unlock()
 		panic(fmt.Sprintf("table %s does not exist", tableName))
 	}
 
@@ -344,16 +346,14 @@ func (t *sqliteWriter) InsertData(tableName string, entry any) {
 	t.entryCount += 1
 
 	if t.entryCount >= t.batchSize {
-		t.mu.Unlock()
-		t.Flush()
-
-		return
+		t.flushLocked()
 	}
-
-	t.mu.Unlock()
 }
 
 func (t *sqliteWriter) ListTables() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	tables := make([]string, 0, len(t.tables))
 	for table := range t.tables {
 		tables = append(tables, table)
@@ -363,12 +363,24 @@ func (t *sqliteWriter) ListTables() []string {
 }
 
 func (t *sqliteWriter) Flush() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.flushLocked()
+}
+
+// flushLocked owns the buffers and location dictionary until the whole batch
+// commits. The caller must hold mu, including for automatic flushes.
+func (t *sqliteWriter) flushLocked() {
 	if t.entryCount == 0 {
 		return
 	}
 
-	t.mustExecute("BEGIN TRANSACTION")
-	defer t.mustExecute("COMMIT TRANSACTION")
+	tx, err := t.DB.BeginTx(context.Background(), nil)
+	if err != nil {
+		panic(err)
+	}
+	defer tx.Rollback()
 
 	for tableName, table := range t.tables {
 		if len(table.entries) == 0 {
@@ -379,25 +391,44 @@ func (t *sqliteWriter) Flush() {
 			continue
 		}
 
-		for _, task := range table.entries {
-			t.insertEntryForTable(task, table)
-		}
+		t.insertTableEntries(tx, table)
+	}
 
+	if locations, ok := t.tables["location"]; ok {
+		t.insertTableEntries(tx, locations)
+	}
+
+	if err := tx.Commit(); err != nil {
+		panic(err)
+	}
+
+	for _, table := range t.tables {
 		table.entries = nil
 	}
 
-	t.flushLocationTable()
-
 	t.entryCount = 0
+}
+
+// insertTableEntries writes one table through the batch's connection. Location
+// rows use the same insertion path after all other tables have interned theirs.
+func (t *sqliteWriter) insertTableEntries(tx *sql.Tx, table *table) {
+	if len(table.entries) == 0 {
+		return
+	}
+
+	stmt := tx.StmtContext(context.Background(), table.statement)
+	defer stmt.Close()
+
+	for _, task := range table.entries {
+		t.insertEntryForTable(task, table, stmt)
+	}
 }
 
 func (t *sqliteWriter) insertEntryForTable(
 	task any,
 	table *table,
+	stmt *sql.Stmt,
 ) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	v := []any{}
 
 	value := reflect.ValueOf(task)
@@ -422,7 +453,7 @@ func (t *sqliteWriter) insertEntryForTable(
 		}
 	}
 
-	_, err := table.statement.ExecContext(context.Background(), v...)
+	_, err := stmt.ExecContext(context.Background(), v...)
 	if err != nil {
 		panic(err)
 	}
@@ -459,45 +490,6 @@ func (t *sqliteWriter) fieldLocation(field reflect.StructField) bool {
 	return ok && strings.Contains(tag, "location")
 }
 
-func (t *sqliteWriter) flushLocationTable() {
-	table, exists := t.tables["location"]
-	if !exists {
-		return
-	}
-
-	if len(table.entries) == 0 {
-		return
-	}
-
-	for _, task := range table.entries {
-		v := []any{}
-
-		value := reflect.ValueOf(task)
-		vType := value.Type()
-
-		if vType != table.structType {
-			panic("entry type mismatch")
-		}
-
-		for i := 0; i < value.NumField(); i++ {
-			field := vType.Field(i)
-
-			if t.fieldIgnored(field) {
-				continue
-			}
-
-			v = append(v, value.Field(i).Interface())
-		}
-
-		_, err := table.statement.ExecContext(context.Background(), v...)
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	table.entries = nil
-}
-
 func (t *sqliteWriter) mustExecute(query string) sql.Result {
 	res, err := t.ExecContext(context.Background(), query)
 	if err != nil {
@@ -529,7 +521,10 @@ func (t *sqliteWriter) buildIndexes() {
 }
 
 func (t *sqliteWriter) Close() error {
-	t.Flush()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.flushLocked()
 	t.buildIndexes()
 
 	err := t.DB.Close()


### PR DESCRIPTION
Concurrent inserts and flushes can race while clearing recording buffers, dropping rows or overlapping SQLite transactions. Serialize each batch under the recorder mutex and write it through one `sql.Tx`; clear buffers only after commit, and roll back failed batches so their rows remain available for retry. Automatic flushes, explicit flushes, table enumeration, and close now use the same synchronization boundary. Public method signatures remain unchanged.

Regression coverage exercises four concurrent producers across two tables, automatic flushes with a small batch threshold, two concurrent explicit flushers, location interning, duplicate prevention, and a failed-insert rollback followed by a successful retry.

Validation:
- Full Go build and `go test -mod=readonly ./...`.
- Repository-pinned golangci-lint v2.13.2 across all packages.
- `go test -mod=readonly -race ./datarecording -count=10 -v`.
- Original 10,000-row concurrent insert/flush reproducer passes with the race detector; all rows persist.
- The new regression fails on the original recorder with data races and a transaction panic.

Producers wait while a batch is flushed. Callers must stop producers before closing the recorder, as documented.
