### PR TITLE
fix(mem): validate storage ranges before accessing data

### DIFF
--- a/mem/storage.go
+++ b/mem/storage.go
@@ -75,13 +75,9 @@ func NewStorageWithUnitSize(capacity uint64, unitSize uint64) *Storage {
 }
 
 // createOrGetStorageUnit retrieves a storage unit if the unit has been created
-// before. Otherwise it initializes a storage unit in the storage object
-func (s *Storage) createOrGetStorageUnit(address uint64) (*storageUnit, error) {
-	if address > s.capacity {
-		return nil, errors.New(
-			"accessing physical address beyond the storage capacity")
-	}
-
+// before. Otherwise it initializes a storage unit in the storage object.
+// The caller must validate the access range first.
+func (s *Storage) createOrGetStorageUnit(address uint64) *storageUnit {
 	baseAddr, _ := s.parseAddress(address)
 
 	s.Lock()
@@ -93,7 +89,7 @@ func (s *Storage) createOrGetStorageUnit(address uint64) (*storageUnit, error) {
 		s.data[baseAddr] = unit
 	}
 
-	return unit, nil
+	return unit
 }
 
 func (s *Storage) parseAddress(addr uint64) (baseAddr, inUnitAddr uint64) {
@@ -103,20 +99,36 @@ func (s *Storage) parseAddress(addr uint64) (baseAddr, inUnitAddr uint64) {
 	return
 }
 
-func (s *Storage) Read(address uint64, len uint64) ([]byte, error) {
+func (s *Storage) validateRange(address, length uint64) error {
+	if length == 0 {
+		return errors.New("storage access length must be greater than zero")
+	}
+	// Subtraction avoids overflowing address + length.
+	if address > s.capacity || length > s.capacity-address {
+		return errors.New("accessing physical address beyond the storage capacity")
+	}
+
+	return nil
+}
+
+// Read returns length bytes starting at address. It returns an error for an
+// empty range or a range extending beyond capacity, before allocating data or
+// storage units. A nonempty range may end exactly at capacity.
+func (s *Storage) Read(address uint64, length uint64) ([]byte, error) {
+	if err := s.validateRange(address, length); err != nil {
+		return nil, err
+	}
+
 	currAddr := address
-	lenLeft := len
+	lenLeft := length
 	dataOffset := uint64(0)
-	res := make([]byte, len)
+	res := make([]byte, length)
 
-	for currAddr < address+len {
-		unit, err := s.createOrGetStorageUnit(currAddr)
-		if err != nil {
-			return nil, err
-		}
+	for lenLeft > 0 {
+		unit := s.createOrGetStorageUnit(currAddr)
 
-		baseAddr, inUnitAddr := s.parseAddress(currAddr)
-		lenLeftInUnit := baseAddr + s.unitSize - currAddr
+		_, inUnitAddr := s.parseAddress(currAddr)
+		lenLeftInUnit := s.unitSize - inUnitAddr
 
 		var lenToRead uint64
 		if lenLeft < lenLeftInUnit {
@@ -136,19 +148,23 @@ func (s *Storage) Read(address uint64, len uint64) ([]byte, error) {
 	return res, nil
 }
 
+// Write stores data starting at address. It returns an error for empty data or
+// a range extending beyond capacity, without allocating storage units or
+// changing stored bytes. A nonempty range may end exactly at capacity.
 func (s *Storage) Write(address uint64, data []byte) error {
+	if err := s.validateRange(address, uint64(len(data))); err != nil {
+		return err
+	}
+
 	currAddr := address
 	dataOffset := uint64(0)
 
 	for dataOffset < uint64(len(data)) {
-		unit, err := s.createOrGetStorageUnit(currAddr)
-		if err != nil {
-			return err
-		}
+		unit := s.createOrGetStorageUnit(currAddr)
 
 		_, inUnitAddr := s.parseAddress(currAddr)
 		lenLeftInData := uint64(len(data)) - dataOffset
-		lenLeftInUnit := currAddr/s.unitSize*s.unitSize + s.unitSize - currAddr
+		lenLeftInUnit := s.unitSize - inUnitAddr
 
 		var lenToWrite uint64
 		if lenLeftInData < lenLeftInUnit {

--- a/mem/storage_range_test.go
+++ b/mem/storage_range_test.go
@@ -1,0 +1,119 @@
+package mem
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func TestStorageRejectsInvalidRanges(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity uint64
+		address  uint64
+		length   uint64
+	}{
+		{"empty at start", 10, 0, 0},
+		{"empty at capacity", 10, 10, 0},
+		{"empty beyond capacity", 10, 11, 0},
+		{"empty at maximum address", 10, math.MaxUint64, 0},
+		{"zero capacity", 0, 0, 1},
+		{"empty zero capacity", 0, 0, 0},
+		{"start at capacity", 10, 10, 1},
+		{"start beyond capacity", 10, 11, 1},
+		{"cross capacity within unit", 10, 9, 2},
+		{"cross capacity across units", 10, 2, 12},
+		{"start at aligned capacity", 12, 12, 1},
+		{"cross aligned capacity", 12, 2, 12},
+		{"overflow end address", math.MaxUint64, math.MaxUint64 - 1, 4},
+		{"maximum address", math.MaxUint64, math.MaxUint64, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, operation := range []string{"read", "write"} {
+				t.Run(operation, func(t *testing.T) {
+					testInvalidStorageRange(t, tt.capacity, tt.address, tt.length, operation)
+				})
+			}
+		})
+	}
+}
+
+func testInvalidStorageRange(t *testing.T, capacity, address, length uint64, operation string) {
+	t.Helper()
+
+	s := NewStorageWithUnitSize(capacity, 4)
+	original := []byte{1, 2, 3, 4}
+	if capacity >= 4 {
+		if err := s.Write(0, original); err != nil {
+			t.Fatal(err)
+		}
+	}
+	unitsBefore := len(s.data)
+
+	var err error
+	if operation == "read" {
+		var data []byte
+		data, err = s.Read(address, length)
+		if err != nil && data != nil {
+			t.Errorf("rejected read returned data: %v", data)
+		}
+	} else {
+		err = s.Write(address, make([]byte, length))
+	}
+	if err == nil {
+		t.Error("invalid range succeeded")
+	}
+	if len(s.data) != unitsBefore {
+		t.Errorf("invalid range allocated units: %d -> %d", unitsBefore, len(s.data))
+	}
+	if unitsBefore > 0 && !bytes.Equal(s.data[0].data, original) {
+		t.Errorf("invalid range changed stored bytes: %v", s.data[0].data)
+	}
+}
+
+func TestStorageRejectsHugeReadBeforeAllocation(t *testing.T) {
+	s := NewStorageWithUnitSize(10, 4)
+	data, err := s.Read(1, math.MaxUint64)
+	if err == nil || data != nil {
+		t.Fatalf("huge out-of-range read returned (%v, %v)", data, err)
+	}
+	if len(s.data) != 0 {
+		t.Fatal("rejected read allocated storage units")
+	}
+}
+
+func TestStorageValidBoundaryRanges(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity uint64
+		unitSize uint64
+		address  uint64
+		data     []byte
+	}{
+		{"last byte", 10, 4, 9, []byte{1}},
+		{"end in partial unit", 10, 4, 6, []byte{1, 2, 3, 4}},
+		{"end at unit boundary", 12, 4, 8, []byte{1, 2, 3, 4}},
+		{"cross multiple units", 10, 4, 1, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		{"unit larger than capacity", 3, 8, 0, []byte{1, 2, 3}},
+		{"near maximum capacity", math.MaxUint64, 4, math.MaxUint64 - 4, []byte{1, 2, 3, 4}},
+		{"non-power-of-two unit", math.MaxUint64, 7, math.MaxUint64 - 4, []byte{1, 2, 3, 4}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewStorageWithUnitSize(tt.capacity, tt.unitSize)
+			data, err := s.Read(tt.address, uint64(len(tt.data)))
+			if err != nil || !bytes.Equal(data, make([]byte, len(tt.data))) {
+				t.Fatalf("untouched boundary read = (%v, %v)", data, err)
+			}
+			if err := s.Write(tt.address, tt.data); err != nil {
+				t.Fatal(err)
+			}
+			data, err = s.Read(tt.address, uint64(len(tt.data)))
+			if err != nil || !bytes.Equal(data, tt.data) {
+				t.Fatalf("boundary round trip = (%v, %v), want %v", data, err, tt.data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Storage reads and writes previously checked only each unit's starting address. A request could cross capacity, and an overflowing write could wrap to address zero and overwrite existing data. Validate the complete range before allocating or copying, using subtraction to avoid overflow; rejected writes leave bytes and allocated units unchanged.

Zero-length reads and writes now return errors, as explicitly requested. Public method signatures are unchanged, the existing out-of-capacity error text is preserved, and nonempty accesses ending exactly at capacity remain valid.

Validation: reproduced partial writes and wraparound corruption on the base implementation; regression coverage checks empty operations, zero capacity, aligned and partial final units, cross-unit accesses, huge invalid reads before allocation, and valid/invalid ranges near MaxUint64. Local Go build, full Go suite, mem race tests, and golangci-lint v2.13.2 pass.
