### PR TITLE
Contain Go simulation failures and isolate run-owned state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ mock_*_test.go
 *.sqlite3-wal
 *.sqlite3-journal
 .history
+
+# Simulation output completion markers
+*.complete

--- a/daisen2/cmd/daisen2/main.go
+++ b/daisen2/cmd/daisen2/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -31,7 +32,10 @@ func main() {
 		log.Fatal("Must specify a SQLite file with -sqlite flag")
 	}
 
-	server := daisen2.NewReplayServer(*sqliteFileName, *httpFlag)
+	server, err := daisen2.NewReplayServer(*sqliteFileName, *httpFlag)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	url := fmt.Sprintf("http://localhost%s", *httpFlag)
 	if len(*httpFlag) > 0 && (*httpFlag)[0] != ':' {
@@ -48,7 +52,10 @@ func main() {
 		log.Printf("Serving at %s — pass --open to open it in a browser tab", url)
 	}
 
-	server.Start()
+	err = server.Start()
+	if err := errors.Join(err, server.Stop()); err != nil {
+		log.Fatal(err)
+	}
 }
 
 // openBrowserInBackground opens url in the user's default browser without raising

--- a/daisen2/daisen2.go
+++ b/daisen2/daisen2.go
@@ -6,6 +6,6 @@ import "github.com/sarchlab/akita/v5/daisen2/internal/httpapi"
 type ProgressBar = httpapi.ProgressBar
 type Server = httpapi.Server
 
-func NewReplayServer(sqliteFile, addr string) *Server {
+func NewReplayServer(sqliteFile, addr string) (*Server, error) {
 	return httpapi.NewReplayServer(sqliteFile, addr)
 }

--- a/daisen2/internal/httpapi/agentloop.go
+++ b/daisen2/internal/httpapi/agentloop.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -150,12 +151,18 @@ func callProvider(
 	}
 	defer resp.Body.Close()
 
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, maxChatResponseBytes))
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxChatResponseBytes))
+	if err != nil {
+		return nil, nil, "", err
+	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, nil, "", fmt.Errorf("provider returned %d: %s",
-			resp.StatusCode, strings.TrimSpace(string(raw)))
+		return nil, nil, "", providerResponseError(resp.StatusCode, string(raw), offerTools)
 	}
 
+	return decodeProviderResponse(raw)
+}
+
+func decodeProviderResponse(raw []byte) (map[string]interface{}, []oaiToolCall, string, error) {
 	var parsed oaiResponse
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return nil, nil, "", fmt.Errorf("decoding provider response: %w", err)
@@ -224,7 +231,7 @@ func runAgentLoop(
 		offerTools := toolCallCount < maxAgentToolCalls
 
 		msg, toolCalls, content, err := callProvider(ctx, cfg, messages, specs, offerTools)
-		if err != nil && offerTools {
+		if errors.Is(err, errToolsUnsupported) && offerTools {
 			// The endpoint may not support tools — retry once without them so a
 			// non-tool model still answers (capability fallback).
 			emit(agentEvent{
@@ -769,4 +776,16 @@ func daisenViewTool(capture captureRequester) agentTool {
 			return toolResult{text: "Rendered the view: " + url, images: []string{img}}, nil
 		},
 	}
+}
+
+var errToolsUnsupported = errors.New("provider does not support tools")
+
+func providerResponseError(status int, body string, tools bool) error {
+	message := strings.ToLower(body)
+	if tools && (status == http.StatusBadRequest || status == http.StatusUnprocessableEntity) &&
+		strings.Contains(message, "tool") &&
+		(strings.Contains(message, "unsupported") || strings.Contains(message, "not support")) {
+		return fmt.Errorf("%w: %s", errToolsUnsupported, strings.TrimSpace(body))
+	}
+	return fmt.Errorf("provider returned %d: %s", status, strings.TrimSpace(body))
 }

--- a/daisen2/internal/httpapi/chat.go
+++ b/daisen2/internal/httpapi/chat.go
@@ -335,7 +335,10 @@ func (openAICompatibleProvider) ListModels(ctx context.Context, cfg ProviderConf
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxModelsResponseBytes))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxModelsResponseBytes))
+	if err != nil {
+		return nil, err
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("models endpoint returned %d: %s",
 			resp.StatusCode, strings.TrimSpace(string(body)))

--- a/daisen2/internal/httpapi/codetools.go
+++ b/daisen2/internal/httpapi/codetools.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"path"
@@ -90,15 +91,23 @@ func runCodeSearch(src *sourcefs.Source, query, filter string) (string, error) {
 	var body strings.Builder
 	matches := 0
 	truncated := false
-	for _, p := range sortedFilePaths(fsys) {
+	paths, err := sortedFilePaths(fsys)
+	if err != nil {
+		return "", err
+	}
+	for _, p := range paths {
 		if filter != "" && !strings.Contains(p, filter) {
 			continue
 		}
 		data, err := fs.ReadFile(fsys, p)
 		if err != nil {
-			continue
+			return "", err
 		}
-		if appendFileMatches(re, p, data, &body, &matches) {
+		hitCap, err := appendFileMatches(re, p, data, &body, &matches)
+		if err != nil {
+			return "", err
+		}
+		if hitCap {
 			truncated = true
 			break
 		}
@@ -111,7 +120,7 @@ func runCodeSearch(src *sourcefs.Source, query, filter string) (string, error) {
 // stops searching further files).
 func appendFileMatches(
 	re *regexp.Regexp, p string, data []byte, body *strings.Builder, matches *int,
-) bool {
+) (bool, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
 	lineNo := 0
@@ -122,16 +131,16 @@ func appendFileMatches(
 			continue
 		}
 		if *matches >= codeSearchMaxMatches {
-			return true
+			return true, nil
 		}
 		entry := fmt.Sprintf("%s:%d: %s\n", p, lineNo, clipLine(strings.TrimSpace(line)))
 		if body.Len()+len(entry) > codeSearchMaxBytes {
-			return true
+			return true, nil
 		}
 		body.WriteString(entry)
 		*matches++
 	}
-	return false
+	return false, scanner.Err()
 }
 
 func formatSearchResult(query, filter, body string, matches int, truncated bool) string {
@@ -195,6 +204,9 @@ func runCodeRead(src *sourcefs.Source, p string, start, end int) (string, error)
 	}
 
 	data, err := fs.ReadFile(src.FS(), clean)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return "", err
+	}
 	if err != nil {
 		return fmt.Sprintf("File not found: %q. Use code_search to find the right path "+
 			"(recorded roots: %v).", p, src.Roots), nil
@@ -447,17 +459,20 @@ func humanBytes(n int) string {
 	}
 }
 
-func sortedFilePaths(fsys fs.FS) []string {
+func sortedFilePaths(fsys fs.FS) ([]string, error) {
 	var paths []string
-	_ = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
 			return nil
 		}
 		paths = append(paths, p)
 		return nil
 	})
 	sort.Strings(paths)
-	return paths
+	return paths, err
 }
 
 func normalizeReadPath(p string) (string, error) {

--- a/daisen2/internal/httpapi/componentinfo.go
+++ b/daisen2/internal/httpapi/componentinfo.go
@@ -45,7 +45,12 @@ func (s *Server) httpComponentNames(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, s.traceReader.ListComponents(r.Context()))
+	components, err := s.traceReader.ListComponents(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, components)
 }
 
 func (s *Server) httpComponentInfo(w http.ResponseWriter, r *http.Request) {
@@ -75,39 +80,55 @@ func (s *Server) httpComponentInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var compInfo *ComponentInfo
-
-	switch infoType {
-	case "ReqInCount":
-		compInfo = s.calculateReqIn(
-			r.Context(), compName, startTime, endTime, int(numDots))
-	case "ReqCompleteCount":
-		compInfo = s.calculateReqComplete(
-			r.Context(), compName, startTime, endTime, int(numDots))
-	case "AvgLatency":
-		compInfo = s.calculateAvgLatency(
-			r.Context(), compName, startTime, endTime, int(numDots))
-	case "ConcurrentTask":
-		compInfo = s.calculateConcurrentTask(
-			r.Context(), compName, infoType, startTime, endTime, numDots)
-	case "ConcurrentTaskMilestones":
+	if infoType == "ConcurrentTaskMilestones" {
 		s.httpConcurrentTaskMilestones(w, r, compName, infoType, startTime, endTime, int(numDots))
 		return
-	case "RequestBufferPressure":
-		compInfo = s.calculateRequestBufferPressure(
-			r.Context(), compName, infoType, startTime, endTime, numDots)
-	case "ResponseBufferPressure":
-		compInfo = s.calculateResponseBufferPressure(
-			r.Context(), compName, infoType, startTime, endTime, numDots)
-	case "PendingReqOut":
-		compInfo = s.calculatePendingReqOut(
-			r.Context(), compName, infoType, startTime, endTime, numDots)
-	default:
+	}
+	ctx := r.Context()
+	compInfo, err := readTrace(ctx, func() *ComponentInfo {
+		return s.computeMetric(ctx, compName, infoType, startTime, endTime, numDots)
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if compInfo == nil {
 		http.Error(w, "unknown info_type", http.StatusBadRequest)
 		return
 	}
 
 	writeJSON(w, compInfo)
+}
+
+func (s *Server) computeMetric(
+	ctx context.Context, compName, infoType string,
+	startTime, endTime float64, numDots int64,
+) *ComponentInfo {
+	switch infoType {
+	case "ReqInCount":
+		return s.calculateReqIn(
+			ctx, compName, startTime, endTime, int(numDots))
+	case "ReqCompleteCount":
+		return s.calculateReqComplete(
+			ctx, compName, startTime, endTime, int(numDots))
+	case "AvgLatency":
+		return s.calculateAvgLatency(
+			ctx, compName, startTime, endTime, int(numDots))
+	case "ConcurrentTask":
+		return s.calculateConcurrentTask(
+			ctx, compName, infoType, startTime, endTime, numDots)
+	case "RequestBufferPressure":
+		return s.calculateRequestBufferPressure(
+			ctx, compName, infoType, startTime, endTime, numDots)
+	case "ResponseBufferPressure":
+		return s.calculateResponseBufferPressure(
+			ctx, compName, infoType, startTime, endTime, numDots)
+	case "PendingReqOut":
+		return s.calculatePendingReqOut(
+			ctx, compName, infoType, startTime, endTime, numDots)
+	default:
+		return nil
+	}
 }
 
 // httpConcurrentTaskMilestones writes the blocking-reason chart — the one metric
@@ -136,8 +157,15 @@ func (s *Server) httpConcurrentTaskMilestones(
 	// (default) keeps the finer kind-what grouping, mirroring component_timeline so
 	// the legend matches the client's colorMode.
 	groupByKind := r.FormValue("group") == "kind"
-	stackedInfo := s.calculateConcurrentTaskMilestones(
-		r.Context(), scope, infoType, startTime, endTime, numDots, sample, groupByKind)
+	ctx := r.Context()
+	stackedInfo, err := readTrace(ctx, func() *StackedComponentInfo {
+		return s.calculateConcurrentTaskMilestones(
+			ctx, scope, infoType, startTime, endTime, numDots, sample, groupByKind)
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	writeJSON(w, stackedInfo)
 }
 
@@ -403,7 +431,7 @@ func (s *Server) fillBinnedEventRate(
 		if ctx.Err() != nil {
 			return
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 	defer rows.Close()
 
@@ -414,7 +442,7 @@ func (s *Server) fillBinnedEventRate(
 			if ctx.Err() != nil {
 				return
 			}
-			panic(err)
+			panic(traceReadError{err})
 		}
 
 		if bin >= 0 && bin < len(data) {
@@ -425,7 +453,7 @@ func (s *Server) fillBinnedEventRate(
 		if ctx.Err() != nil {
 			return
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 }
 
@@ -458,7 +486,7 @@ func (s *Server) fillBinnedAverageLatency(
 		if ctx.Err() != nil {
 			return
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 	defer rows.Close()
 
@@ -469,7 +497,7 @@ func (s *Server) fillBinnedAverageLatency(
 			if ctx.Err() != nil {
 				return
 			}
-			panic(err)
+			panic(traceReadError{err})
 		}
 
 		if bin >= 0 && bin < len(data) {
@@ -480,7 +508,7 @@ func (s *Server) fillBinnedAverageLatency(
 		if ctx.Err() != nil {
 			return
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 }
 

--- a/daisen2/internal/httpapi/componentinfo_test.go
+++ b/daisen2/internal/httpapi/componentinfo_test.go
@@ -12,7 +12,9 @@ func newTestTraceReader(t *testing.T) *SQLiteTraceReader {
 
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	t.Cleanup(func() {
 		_ = reader.Close()
 	})
@@ -235,7 +237,10 @@ func TestListTasksLoadsMilestonesOnlyWhenRequested(t *testing.T) {
 	reader := newTestTraceReader(t)
 	insertTraceRows(t, reader)
 
-	tasks := reader.ListTasks(context.Background(), TaskQuery{Where: "A"})
+	tasks, readErr := reader.ListTasks(context.Background(), TaskQuery{Where: "A"})
+	if readErr != nil {
+		panic(readErr)
+	}
 	if len(tasks) == 0 {
 		t.Fatal("expected tasks")
 	}
@@ -243,7 +248,13 @@ func TestListTasksLoadsMilestonesOnlyWhenRequested(t *testing.T) {
 		t.Fatalf("milestones loaded without EnableMilestones: %+v", tasks[0].Steps)
 	}
 
-	tasks = reader.ListTasks(context.Background(), TaskQuery{Where: "A", EnableMilestones: true})
+	{
+		var readErr error
+		tasks, readErr = reader.ListTasks(context.Background(), TaskQuery{Where: "A", EnableMilestones: true})
+		if readErr != nil {
+			panic(readErr)
+		}
+	}
 	if len(tasks[0].Steps) != 1 {
 		t.Fatalf("expected one milestone, got %+v", tasks[0].Steps)
 	}

--- a/daisen2/internal/httpapi/componenttimeline_test.go
+++ b/daisen2/internal/httpapi/componenttimeline_test.go
@@ -13,7 +13,9 @@ import (
 func TestComponentTimelineScopeAggregatesSubtree(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -54,7 +56,9 @@ func TestComponentTimelineScopeAggregatesSubtree(t *testing.T) {
 func TestLocationTimelineMatchesOnlyExactLocation(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -95,7 +99,9 @@ func TestLocationTimelineMatchesOnlyExactLocation(t *testing.T) {
 func TestCountTasksInScope(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -143,7 +149,9 @@ func TestCountTasksInScope(t *testing.T) {
 func TestComponentTimelineGroupByKind(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -188,7 +196,9 @@ func TestComponentTimelineGroupByKind(t *testing.T) {
 func TestComponentTimelineRespectsHalfOpenBins(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -241,7 +251,9 @@ func TestComponentTimelineRespectsHalfOpenBins(t *testing.T) {
 func TestBlockingReasonOccupancyBinsMilestoneIntervals(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -290,7 +302,9 @@ func TestBlockingReasonOccupancyBinsMilestoneIntervals(t *testing.T) {
 func TestBlockingReasonOccupancyGroupsByKindWhat(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -325,7 +339,9 @@ func TestBlockingReasonOccupancyGroupsByKindWhat(t *testing.T) {
 func TestComponentTimelineScopeIsCaseSensitive(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {

--- a/daisen2/internal/httpapi/dbinfo.go
+++ b/daisen2/internal/httpapi/dbinfo.go
@@ -309,12 +309,13 @@ func (r *SQLiteTraceReader) objectSizesFromEmbeddedQuery(ctx context.Context, qu
 		var name string
 		var bytes sql.NullInt64
 		if err := rows.Scan(&name, &bytes); err != nil {
-			continue
+			return nil, false
 		}
 		sizes[name] = bytes.Int64
 	}
 	if err := rows.Err(); err != nil {
 		log.Printf("dbstat query: %v", err)
+		return nil, false
 	}
 
 	return sizes, true

--- a/daisen2/internal/httpapi/ensureindex_test.go
+++ b/daisen2/internal/httpapi/ensureindex_test.go
@@ -112,3 +112,23 @@ func TestDBFileBytesSumsSidecars(t *testing.T) {
 		t.Fatalf("dbFileBytes without sidecars = %d, want %d", got, want)
 	}
 }
+
+func TestEnsureIndexSurvivesRequestCancellation(t *testing.T) {
+	reader := NewSQLiteTraceReader(filepath.Join(t.TempDir(), "trace.sqlite3"))
+	if err := reader.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	if _, err := reader.Exec("CREATE TABLE trace (Location INTEGER)"); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	reader.ensureIndex(ctx, "test", "CREATE INDEX idx_cancelled_request ON trace(Location)")
+	if !reader.indexExists(context.Background(), "idx_cancelled_request") {
+		t.Fatal("request cancellation discarded the shared covering index")
+	}
+	if _, ok := reader.builtIndexes.Load("idx_cancelled_request"); !ok {
+		t.Fatal("successful index build was not recorded")
+	}
+}

--- a/daisen2/internal/httpapi/ensureindex_test.go
+++ b/daisen2/internal/httpapi/ensureindex_test.go
@@ -14,7 +14,9 @@ import (
 func TestEnsureIndexBuildsOnceAndInvalidatesDBInfo(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 
 	if _, err := reader.Exec(`CREATE TABLE trace (
 		ID INTEGER, Location INTEGER, StartTime REAL, EndTime REAL, Kind TEXT, What TEXT)`); err != nil {

--- a/daisen2/internal/httpapi/overview_test.go
+++ b/daisen2/internal/httpapi/overview_test.go
@@ -14,7 +14,9 @@ func newTestReader(t *testing.T) *SQLiteTraceReader {
 
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 
 	return reader
 }

--- a/daisen2/internal/httpapi/readerror.go
+++ b/daisen2/internal/httpapi/readerror.go
@@ -1,0 +1,30 @@
+package httpapi
+
+import "context"
+
+// traceReadError unwinds private SQL decoding helpers to the public reader API.
+// Invariant panics remain panics; operational errors never become partial data.
+type traceReadError struct{ error }
+
+func readTrace[T any](ctx context.Context, fn func() T) (result T, err error) {
+	if err = ctx.Err(); err != nil {
+		return result, err
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			if e, ok := p.(traceReadError); ok {
+				var zero T
+				result = zero
+				err = e.error
+			} else {
+				panic(p)
+			}
+		}
+	}()
+	result = fn()
+	if err = ctx.Err(); err != nil {
+		var zero T
+		return zero, err
+	}
+	return result, nil
+}

--- a/daisen2/internal/httpapi/readerror_test.go
+++ b/daisen2/internal/httpapi/readerror_test.go
@@ -1,0 +1,51 @@
+package httpapi
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+func TestTraceReaderReturnsFailureInsteadOfPartialResults(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewSQLiteTraceReader("")
+	r.DB = db
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if result, err := r.ListTasks(context.Background(), TaskQuery{}); err == nil || result != nil {
+		t.Fatalf("task query failure lost: %v %v", result, err)
+	}
+	if result, err := r.ListComponents(context.Background()); err == nil || result != nil {
+		t.Fatalf("component query failure lost: %v %v", result, err)
+	}
+	if _, _, err := r.TimeRange(context.Background()); err == nil {
+		t.Fatal("time range query failure lost")
+	}
+	if _, err := r.ListSegments(context.Background()); err == nil {
+		t.Fatal("query failure reported as absent optional segments")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := r.ListTasks(ctx, TaskQuery{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation lost: %v", err)
+	}
+}
+
+func TestProviderFallbackOnlyForUnsupportedTools(t *testing.T) {
+	for _, status := range []int{401, 429, 500, 503} {
+		if errors.Is(providerResponseError(status, "tools are unsupported", true), errToolsUnsupported) {
+			t.Fatalf("retried operational failure %d", status)
+		}
+	}
+	if errors.Is(providerResponseError(400, "invalid temperature", true), errToolsUnsupported) {
+		t.Fatal("unrelated validation error triggered tool fallback")
+	}
+	if !errors.Is(providerResponseError(400, "tools are unsupported", true), errToolsUnsupported) {
+		t.Fatal("missing explicit capability fallback")
+	}
+}

--- a/daisen2/internal/httpapi/resourceblocking.go
+++ b/daisen2/internal/httpapi/resourceblocking.go
@@ -177,9 +177,9 @@ func (r *SQLiteTraceReader) ResourceBlockingOccupancy( //nolint:funlen // one co
 // task's wait for the resource. Used only when the resource's task set is small.
 func (r *SQLiteTraceReader) TasksBlockingOn(
 	ctx context.Context, what string, start, end float64, limit int,
-) []Task {
+) ([]Task, error) {
 	if what == "" || limit < 1 {
-		return []Task{}
+		return []Task{}, nil
 	}
 	r.ensureIndex(ctx, "Building index idx_milestone_Kind_What",
 		"CREATE INDEX IF NOT EXISTS idx_milestone_Kind_What ON milestone(Kind, What, TaskID)")
@@ -213,23 +213,25 @@ func (r *SQLiteTraceReader) TasksBlockingOn(
 		WHERE w = ? AND hi > ? AND lo < ?
 		LIMIT ?`, what, start, end, what, what, start, end, limit)
 	if err != nil {
-		return []Task{}
+		return nil, err
 	}
 
 	ids := []uint64{}
 	for rows.Next() {
 		var id uint64
-		if err := rows.Scan(&id); err == nil {
-			ids = append(ids, id)
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return nil, err
 		}
+		ids = append(ids, id)
 	}
 	if err := rows.Err(); err != nil {
 		_ = rows.Close()
-		return []Task{}
+		return nil, err
 	}
 	_ = rows.Close()
 	if len(ids) == 0 {
-		return []Task{}
+		return []Task{}, nil
 	}
 
 	return r.ListTasks(ctx, TaskQuery{IDs: ids, EnableMilestones: true})
@@ -257,7 +259,12 @@ func (s *Server) httpResourceTasks(w http.ResponseWriter, r *http.Request) {
 			limit = n
 		}
 	}
-	writeJSON(w, s.traceReader.TasksBlockingOn(r.Context(), what, start, end, limit))
+	tasks, err := s.traceReader.TasksBlockingOn(r.Context(), what, start, end, limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, tasks)
 }
 
 func (s *Server) httpResourceBlocking(w http.ResponseWriter, r *http.Request) {

--- a/daisen2/internal/httpapi/resourceblocking_test.go
+++ b/daisen2/internal/httpapi/resourceblocking_test.go
@@ -13,7 +13,9 @@ import (
 func TestResourceBlockingOccupancy(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -60,7 +62,9 @@ func TestResourceBlockingOccupancy(t *testing.T) {
 func TestTasksBlockingOn(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -85,7 +89,10 @@ func TestTasksBlockingOn(t *testing.T) {
 		(3, 3, 30, 'hardware_resource', 'R2'),
 		(4, 4, 40, 'hardware_resource', 'R1')`)
 
-	tasks := reader.TasksBlockingOn(context.Background(), "R1", 0, 100, 10)
+	tasks, readErr := reader.TasksBlockingOn(context.Background(), "R1", 0, 100, 10)
+	if readErr != nil {
+		panic(readErr)
+	}
 
 	if len(tasks) != 2 {
 		t.Fatalf("expected 2 tasks blocked on R1, got %d: %+v", len(tasks), tasks)

--- a/daisen2/internal/httpapi/server.go
+++ b/daisen2/internal/httpapi/server.go
@@ -5,6 +5,7 @@ package httpapi
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -39,20 +40,22 @@ type Server struct {
 
 // NewReplayServer creates a new Server in replay mode. It reads trace data
 // from the given SQLite file and serves it on the given address.
-func NewReplayServer(sqliteFile, addr string) *Server {
+func NewReplayServer(sqliteFile, addr string) (*Server, error) {
 	if sqliteFile == "" {
-		panic("must specify a SQLite file")
+		return nil, fmt.Errorf("must specify a SQLite file")
 	}
 
 	reader := NewSQLiteTraceReader(sqliteFile)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		return nil, err
+	}
 
 	return &Server{
 		addr:        addr,
 		traceReader: reader,
 		fs:          static.GetAssets(),
 		codeSource:  loadCodeSource(reader),
-	}
+	}, nil
 }
 
 // loadCodeSource reads the source recorded in the trace (if any) and logs what
@@ -76,22 +79,23 @@ func loadCodeSource(reader *SQLiteTraceReader) *sourcefs.Source {
 
 // Start starts the HTTP server in replay mode. It listens on the configured
 // address and blocks until the server is shut down.
-func (s *Server) Start() {
+func (s *Server) Start() error {
 	mux := s.setupRoutes()
-	s.startReplayServer(mux)
+	return s.startReplayServer(mux)
 }
 
 // Stop gracefully shuts down the HTTP server.
-func (s *Server) Stop() {
+func (s *Server) Stop() error {
+	var err error
 	if s.httpServer != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-
-		err := s.httpServer.Shutdown(ctx)
-		if err != nil {
-			log.Printf("Error shutting down server: %v", err)
-		}
+		err = s.httpServer.Shutdown(ctx)
 	}
+	if s.traceReader != nil && s.traceReader.DB != nil {
+		err = errors.Join(err, s.traceReader.Close())
+	}
+	return err
 }
 
 func (s *Server) setupRoutes() *http.ServeMux {
@@ -137,7 +141,7 @@ func (s *Server) setupRoutes() *http.ServeMux {
 	return mux
 }
 
-func (s *Server) startReplayServer(mux *http.ServeMux) {
+func (s *Server) startReplayServer(mux *http.ServeMux) error {
 	s.httpServer = &http.Server{
 		Addr:    s.addr,
 		Handler: mux,
@@ -147,8 +151,9 @@ func (s *Server) startReplayServer(mux *http.ServeMux) {
 
 	err := s.httpServer.ListenAndServe()
 	if err != nil && err != http.ErrServerClosed {
-		dieOnErr(err)
+		return err
 	}
+	return nil
 }
 
 // httpTraceInfo returns a stable identifier for the loaded trace, used by the
@@ -190,10 +195,4 @@ func (s *Server) serveIndex(w http.ResponseWriter, _ *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = w.Write(p)
-}
-
-func dieOnErr(err error) {
-	if err != nil {
-		log.Panic(err)
-	}
 }

--- a/daisen2/internal/httpapi/topblocking_test.go
+++ b/daisen2/internal/httpapi/topblocking_test.go
@@ -13,7 +13,9 @@ func seedBlockingTrace(t *testing.T) *SQLiteTraceReader {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	t.Cleanup(func() { reader.Close() })
 
 	exec := func(query string) {

--- a/daisen2/internal/httpapi/trace.go
+++ b/daisen2/internal/httpapi/trace.go
@@ -261,7 +261,7 @@ func (r *SQLiteTraceReader) ensureIndex(ctx context.Context, activityLabel, ddl 
 	}
 
 	id := r.activity.Begin("index", activityLabel, "covering index")
-	_, err := r.ExecContext(ctx, ddl)
+	_, err := r.ExecContext(context.WithoutCancel(ctx), ddl)
 	r.activity.End(id)
 	if err != nil {
 		log.Printf("optional trace index: %v", err)

--- a/daisen2/internal/httpapi/trace.go
+++ b/daisen2/internal/httpapi/trace.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/sarchlab/akita/v5/internal/sqlitefile"
 	"github.com/sarchlab/akita/v5/timing"
 )
 
@@ -289,7 +290,11 @@ func NewSQLiteTraceReader(filename string) *SQLiteTraceReader {
 
 // Init establishes a connection to the database.
 func (r *SQLiteTraceReader) Init() error {
-	db, err := sql.Open("sqlite3", r.filename)
+	dsn, err := sqlitefile.DSN(r.filename)
+	if err != nil {
+		return err
+	}
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return err
 	}
@@ -316,7 +321,11 @@ func (r *SQLiteTraceReader) Init() error {
 // setting WAL here would fail on any non-WAL file and panic — hence no such
 // pragma below.
 func (r *SQLiteTraceReader) InitReadOnly() error {
-	db, err := sql.Open("sqlite3", r.filename+"?mode=ro")
+	dsn, err := sqlitefile.DSN(r.filename)
+	if err != nil {
+		return err
+	}
+	db, err := sql.Open("sqlite3", dsn+"?mode=ro")
 	if err != nil {
 		return err
 	}

--- a/daisen2/internal/httpapi/trace.go
+++ b/daisen2/internal/httpapi/trace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 	"sort"
@@ -27,7 +28,12 @@ func (s *Server) httpTrace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, s.traceReader.ListTasks(r.Context(), query))
+	tasks, err := s.traceReader.ListTasks(r.Context(), query)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, tasks)
 }
 
 // buildTraceQuery parses the /api/trace request parameters into a TaskQuery.
@@ -255,8 +261,12 @@ func (r *SQLiteTraceReader) ensureIndex(ctx context.Context, activityLabel, ddl 
 	}
 
 	id := r.activity.Begin("index", activityLabel, "covering index")
-	_, _ = r.ExecContext(context.WithoutCancel(ctx), ddl)
+	_, err := r.ExecContext(ctx, ddl)
 	r.activity.End(id)
+	if err != nil {
+		log.Printf("optional trace index: %v", err)
+		return
+	}
 
 	if name != "" {
 		r.builtIndexes.Store(name, struct{}{})
@@ -278,19 +288,25 @@ func NewSQLiteTraceReader(filename string) *SQLiteTraceReader {
 }
 
 // Init establishes a connection to the database.
-func (r *SQLiteTraceReader) Init() {
+func (r *SQLiteTraceReader) Init() error {
 	db, err := sql.Open("sqlite3", r.filename)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Enable WAL mode for concurrent read access.
 	_, err = db.Exec("PRAGMA journal_mode=WAL")
 	if err != nil {
-		panic(err)
+		_ = db.Close()
+		return err
 	}
 
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return err
+	}
 	r.DB = db
+	return nil
 }
 
 // InitReadOnly establishes a read-only connection to the database. It is used to
@@ -299,13 +315,18 @@ func (r *SQLiteTraceReader) Init() {
 // mode itself. With the native driver "mode=ro" is a true read-only open, so
 // setting WAL here would fail on any non-WAL file and panic — hence no such
 // pragma below.
-func (r *SQLiteTraceReader) InitReadOnly() {
+func (r *SQLiteTraceReader) InitReadOnly() error {
 	db, err := sql.Open("sqlite3", r.filename+"?mode=ro")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return err
+	}
 	r.DB = db
+	return nil
 }
 
 func naturalLess(a, b string) bool {
@@ -331,7 +352,10 @@ func naturalLess(a, b string) bool {
 }
 
 // ListComponents returns a list of components in the trace.
-func (r *SQLiteTraceReader) ListComponents(ctx context.Context) []string {
+func (r *SQLiteTraceReader) ListComponents(ctx context.Context) ([]string, error) {
+	return readTrace(ctx, func() []string { return r.listComponents(ctx) })
+}
+func (r *SQLiteTraceReader) listComponents(ctx context.Context) []string {
 	var components []string
 
 	// The shared location table holds exactly the set of component names used
@@ -341,13 +365,13 @@ func (r *SQLiteTraceReader) ListComponents(ctx context.Context) []string {
 		if ctx.Err() != nil {
 			return nil
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 
 	defer func() {
 		err := rows.Close()
 		if err != nil && ctx.Err() == nil {
-			panic(err)
+			panic(traceReadError{err})
 		}
 	}()
 
@@ -359,7 +383,7 @@ func (r *SQLiteTraceReader) ListComponents(ctx context.Context) []string {
 			if ctx.Err() != nil {
 				return nil
 			}
-			panic(err)
+			panic(traceReadError{err})
 		}
 
 		components = append(components, component)
@@ -368,7 +392,7 @@ func (r *SQLiteTraceReader) ListComponents(ctx context.Context) []string {
 		if ctx.Err() != nil {
 			return nil
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 
 	sort.Slice(components, func(i, j int) bool {
@@ -417,14 +441,17 @@ func (r *SQLiteTraceReader) ensureTaskQueryIndexes(ctx context.Context, query Ta
 	}
 }
 
-func (r *SQLiteTraceReader) ListTasks(ctx context.Context, query TaskQuery) []Task {
+func (r *SQLiteTraceReader) ListTasks(ctx context.Context, query TaskQuery) ([]Task, error) {
+	return readTrace(ctx, func() []Task { return r.listTasks(ctx, query) })
+}
+func (r *SQLiteTraceReader) listTasks(ctx context.Context, query TaskQuery) []Task {
 	r.ensureTaskQueryIndexes(ctx, query)
 
 	sqlStr, args := r.prepareTaskQueryStr(query)
 
 	rows, err := r.QueryContext(ctx, sqlStr, args...)
 	if err != nil {
-		panic(err)
+		panic(traceReadError{err})
 	}
 
 	defer rows.Close()
@@ -439,7 +466,7 @@ func (r *SQLiteTraceReader) ListTasks(ctx context.Context, query TaskQuery) []Ta
 		if ctx.Err() != nil {
 			return tasks
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 
 	if query.EnableMilestones {
@@ -492,7 +519,7 @@ func (r *SQLiteTraceReader) listTaskIntervals(
 		if ctx.Err() != nil {
 			return nil
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 	defer rows.Close()
 
@@ -503,7 +530,7 @@ func (r *SQLiteTraceReader) listTaskIntervals(
 			if ctx.Err() != nil {
 				return tasks
 			}
-			panic(err)
+			panic(traceReadError{err})
 		}
 		tasks = append(tasks, Task{
 			StartTime: timing.VTimeInPicoSec(s),
@@ -514,7 +541,7 @@ func (r *SQLiteTraceReader) listTaskIntervals(
 		if ctx.Err() != nil {
 			return tasks
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 
 	return tasks
@@ -532,7 +559,15 @@ func sortTaskSteps(tasks []Task) {
 }
 
 // TimeRange returns the min task start time and max task end time in the trace.
-func (r *SQLiteTraceReader) TimeRange(ctx context.Context) (TraceTimeRange, bool) {
+func (r *SQLiteTraceReader) TimeRange(ctx context.Context) (TraceTimeRange, bool, error) {
+	type result struct {
+		value TraceTimeRange
+		found bool
+	}
+	value, err := readTrace(ctx, func() result { v, ok := r.timeRange(ctx); return result{v, ok} })
+	return value.value, value.found, err
+}
+func (r *SQLiteTraceReader) timeRange(ctx context.Context) (TraceTimeRange, bool) {
 	if timeRange, ok := r.execInfoTimeRange(ctx); ok {
 		return timeRange, true
 	}
@@ -545,7 +580,7 @@ func (r *SQLiteTraceReader) TimeRange(ctx context.Context) (TraceTimeRange, bool
 		if ctx.Err() != nil {
 			return TraceTimeRange{}, false
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 
 	if !startTime.Valid || !endTime.Valid || startTime.Float64 >= endTime.Float64 {
@@ -559,13 +594,22 @@ func (r *SQLiteTraceReader) TimeRange(ctx context.Context) (TraceTimeRange, bool
 }
 
 func (r *SQLiteTraceReader) execInfoTimeRange(ctx context.Context) (TraceTimeRange, bool) {
+	var exists int
+	if err := r.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='exec_info'",
+	).Scan(&exists); err != nil {
+		panic(traceReadError{err})
+	}
+	if exists == 0 {
+		return TraceTimeRange{}, false
+	}
 	rows, err := r.QueryContext(ctx, `
 		SELECT Property, Value
 		FROM exec_info
 		WHERE Property IN ('Start Virtual Time', 'End Virtual Time')
 	`)
 	if err != nil {
-		return TraceTimeRange{}, false
+		panic(traceReadError{err})
 	}
 	defer rows.Close()
 
@@ -575,12 +619,12 @@ func (r *SQLiteTraceReader) execInfoTimeRange(ctx context.Context) (TraceTimeRan
 		var property, value string
 		err := rows.Scan(&property, &value)
 		if err != nil {
-			return TraceTimeRange{}, false
+			panic(traceReadError{err})
 		}
 
 		parsed, err := strconv.ParseFloat(value, 64)
 		if err != nil {
-			return TraceTimeRange{}, false
+			panic(traceReadError{err})
 		}
 
 		switch property {
@@ -593,7 +637,7 @@ func (r *SQLiteTraceReader) execInfoTimeRange(ctx context.Context) (TraceTimeRan
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return TraceTimeRange{}, false
+		panic(traceReadError{err})
 	}
 
 	if !hasStart || !hasEnd || timeRange.StartTime >= timeRange.EndTime {
@@ -609,7 +653,11 @@ func (s *Server) httpTraceTimeRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	timeRange, ok := s.traceReader.TimeRange(r.Context())
+	timeRange, ok, err := s.traceReader.TimeRange(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	if !ok {
 		http.Error(w, "trace time range not available", http.StatusNotFound)
 		return
@@ -671,7 +719,7 @@ func (r *SQLiteTraceReader) loadMilestoneBatch(ctx context.Context, taskMap map[
 		if ctx.Err() != nil || strings.Contains(err.Error(), "no such table") {
 			return
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 	defer rows.Close()
 
@@ -685,7 +733,7 @@ func (r *SQLiteTraceReader) loadMilestoneBatch(ctx context.Context, taskMap map[
 			if ctx.Err() != nil {
 				return
 			}
-			panic(err)
+			panic(traceReadError{err})
 		}
 
 		if task, exists := taskMap[taskID]; exists {
@@ -701,7 +749,7 @@ func (r *SQLiteTraceReader) loadMilestoneBatch(ctx context.Context, taskMap map[
 		if ctx.Err() != nil {
 			return
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 }
 
@@ -755,7 +803,7 @@ func (r *SQLiteTraceReader) loadTagBatch(ctx context.Context, taskMap map[uint64
 		if ctx.Err() != nil || strings.Contains(err.Error(), "no such table") {
 			return
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 	defer rows.Close()
 
@@ -769,7 +817,7 @@ func (r *SQLiteTraceReader) loadTagBatch(ctx context.Context, taskMap map[uint64
 			if ctx.Err() != nil {
 				return
 			}
-			panic(err)
+			panic(traceReadError{err})
 		}
 
 		if task, exists := taskMap[taskID]; exists {
@@ -784,7 +832,7 @@ func (r *SQLiteTraceReader) loadTagBatch(ctx context.Context, taskMap map[uint64
 		if ctx.Err() != nil {
 			return
 		}
-		panic(err)
+		panic(traceReadError{err})
 	}
 }
 
@@ -802,7 +850,7 @@ func (r *SQLiteTraceReader) scanTaskFromRow(rows *sql.Rows) Task {
 		&endTime,
 	)
 	if err != nil {
-		panic(err)
+		panic(traceReadError{err})
 	}
 
 	t.StartTime = timing.VTimeInPicoSec(uint64(startTime))
@@ -951,15 +999,22 @@ func (r *SQLiteTraceReader) hasSegmentsTable(ctx context.Context) bool {
 	query := `SELECT name FROM sqlite_master WHERE type='table' AND name='daisen$segments'`
 	rows, err := r.QueryContext(ctx, query)
 	if err != nil {
-		return false
+		panic(traceReadError{err})
 	}
 	defer rows.Close()
 
-	return rows.Next()
+	found := rows.Next()
+	if err := rows.Err(); err != nil {
+		panic(traceReadError{err})
+	}
+	return found
 }
 
 // ListSegments returns all segments from the daisen$segments table
-func (r *SQLiteTraceReader) ListSegments(ctx context.Context) SegmentsResponse {
+func (r *SQLiteTraceReader) ListSegments(ctx context.Context) (SegmentsResponse, error) {
+	return readTrace(ctx, func() SegmentsResponse { return r.listSegments(ctx) })
+}
+func (r *SQLiteTraceReader) listSegments(ctx context.Context) SegmentsResponse {
 	response := SegmentsResponse{
 		Enabled:  false,
 		Segments: []Segment{},
@@ -974,7 +1029,7 @@ func (r *SQLiteTraceReader) ListSegments(ctx context.Context) SegmentsResponse {
 	query := `SELECT StartTime, EndTime FROM "daisen$segments" ORDER BY StartTime`
 	rows, err := r.QueryContext(ctx, query)
 	if err != nil {
-		return response
+		panic(traceReadError{err})
 	}
 	defer rows.Close()
 
@@ -982,12 +1037,12 @@ func (r *SQLiteTraceReader) ListSegments(ctx context.Context) SegmentsResponse {
 		var segment Segment
 		err := rows.Scan(&segment.StartTime, &segment.EndTime)
 		if err != nil {
-			continue
+			panic(traceReadError{err})
 		}
 		response.Segments = append(response.Segments, segment)
 	}
 	if err := rows.Err(); err != nil {
-		return response
+		panic(traceReadError{err})
 	}
 
 	return response
@@ -999,5 +1054,10 @@ func (s *Server) httpSegments(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, s.traceReader.ListSegments(r.Context()))
+	segments, err := s.traceReader.ListSegments(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, segments)
 }

--- a/daisen2/internal/httpapi/trace_test.go
+++ b/daisen2/internal/httpapi/trace_test.go
@@ -4,9 +4,43 @@ import (
 	"context"
 	"database/sql"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestTraceReaderUsesLiteralFilename(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "trace.sqlite3")
+	path := base + "?mode=memory#literal.sqlite3"
+	r := NewSQLiteTraceReader(path)
+	if err := r.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Exec("CREATE TABLE proof (value INTEGER); INSERT INTO proof VALUES (42)"); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("literal recording missing: %v", err)
+	}
+	if _, err := os.Stat(base); !os.IsNotExist(err) {
+		t.Fatalf("opened an unintended path: %v", err)
+	}
+	r = NewSQLiteTraceReader(path)
+	if err := r.InitReadOnly(); err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	var value int
+	if err := r.QueryRow("SELECT value FROM proof").Scan(&value); err != nil || value != 42 {
+		t.Fatalf("wrong read-only recording: value=%d err=%v", value, err)
+	}
+	if _, err := r.Exec("INSERT INTO proof VALUES (43)"); err == nil {
+		t.Fatal("read-only connection allowed a write")
+	}
+}
 
 // TestInitReadOnlyReadsNonWALTrace is a regression test: a read-only connection
 // must not try to set the journal mode. With the native driver "mode=ro" is a

--- a/daisen2/internal/httpapi/trace_test.go
+++ b/daisen2/internal/httpapi/trace_test.go
@@ -36,10 +36,13 @@ func TestInitReadOnlyReadsNonWALTrace(t *testing.T) {
 	}
 
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.InitReadOnly() // must not panic
+	if err := reader.InitReadOnly(); err != nil {
+		panic(err)
+	} // must not panic
 	defer reader.Close()
 
-	timeRange, ok := reader.TimeRange(context.Background())
+	timeRange, ok, readErr := reader.TimeRange(context.Background())
+	assertReadOK(t, readErr)
 	if !ok {
 		t.Fatal("expected a trace time range from the read-only reader")
 	}
@@ -51,7 +54,9 @@ func TestInitReadOnlyReadsNonWALTrace(t *testing.T) {
 func TestSQLiteTraceReaderTimeRange(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	_, err := reader.Exec(`CREATE TABLE trace (
@@ -76,7 +81,8 @@ func TestSQLiteTraceReaderTimeRange(t *testing.T) {
 		t.Fatalf("insert trace rows: %v", err)
 	}
 
-	timeRange, ok := reader.TimeRange(context.Background())
+	timeRange, ok, readErr := reader.TimeRange(context.Background())
+	assertReadOK(t, readErr)
 	if !ok {
 		t.Fatal("expected a trace time range")
 	}
@@ -88,7 +94,9 @@ func TestSQLiteTraceReaderTimeRange(t *testing.T) {
 func TestSQLiteTraceReaderMergesTagsAndMilestonesIntoSteps(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(query string) {
@@ -111,8 +119,9 @@ func TestSQLiteTraceReaderMergesTagsAndMilestonesIntoSteps(t *testing.T) {
 	exec(`INSERT INTO milestone VALUES (10, 1, 5000, 'data', 'arrived')`)
 	exec(`INSERT INTO tag VALUES (20, 1, 3000, 'read-hit')`)
 
-	tasks := reader.ListTasks(context.Background(),
+	tasks, readErr := reader.ListTasks(context.Background(),
 		TaskQuery{ID: 1, EnableMilestones: true})
+	assertReadOK(t, readErr)
 
 	if len(tasks) != 1 {
 		t.Fatalf("expected 1 task, got %d", len(tasks))
@@ -143,7 +152,9 @@ func TestSQLiteTraceReaderMergesTagsAndMilestonesIntoSteps(t *testing.T) {
 func TestSQLiteTraceReaderTimeRangePrefersExecInfoVirtualTime(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	_, err := reader.Exec(`CREATE TABLE trace (
@@ -180,7 +191,8 @@ func TestSQLiteTraceReaderTimeRangePrefersExecInfoVirtualTime(t *testing.T) {
 		t.Fatalf("insert exec_info rows: %v", err)
 	}
 
-	timeRange, ok := reader.TimeRange(context.Background())
+	timeRange, ok, readErr := reader.TimeRange(context.Background())
+	assertReadOK(t, readErr)
 	if !ok {
 		t.Fatal("expected a trace time range")
 	}
@@ -199,7 +211,9 @@ func TestSQLiteTraceReaderTimeRangePrefersExecInfoVirtualTime(t *testing.T) {
 func TestListTasksScopeAggregatesSubtree(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -222,13 +236,14 @@ func TestListTasksScopeAggregatesSubtree(t *testing.T) {
 		(3, 0, 'k', 'c', 3, 0, 10),
 		(4, 0, 'k', 'd', 2, 100, 110)`)
 
-	tasks := reader.ListTasks(context.Background(), TaskQuery{
+	tasks, readErr := reader.ListTasks(context.Background(), TaskQuery{
 		Scope:            "ROB",
 		StartTime:        0,
 		EndTime:          50,
 		EnableTimeRange:  true,
 		EnableMilestones: true,
 	})
+	assertReadOK(t, readErr)
 
 	// ROB + ROB.req_in overlapping [0,50): tasks 1 and 2. The sibling "ROBOT.x"
 	// (task 3) is excluded by the dot boundary; task 4 (ROB.req_in but at t=100)
@@ -245,12 +260,13 @@ func TestListTasksScopeAggregatesSubtree(t *testing.T) {
 	}
 
 	// A leaf scope matches only itself, not the subtree.
-	leaf := reader.ListTasks(context.Background(), TaskQuery{
+	leaf, readErr := reader.ListTasks(context.Background(), TaskQuery{
 		Scope:           "ROB.req_in",
 		StartTime:       0,
 		EndTime:         50,
 		EnableTimeRange: true,
 	})
+	assertReadOK(t, readErr)
 	if len(leaf) != 1 || leaf[0].ID != 2 {
 		t.Fatalf("scope ROB.req_in = %+v, want exactly task id 2", leaf)
 	}
@@ -263,7 +279,9 @@ func TestListTasksScopeAggregatesSubtree(t *testing.T) {
 func TestListTasksParentIDsSelectsChildrenOfManyParents(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -287,7 +305,8 @@ func TestListTasksParentIDsSelectsChildrenOfManyParents(t *testing.T) {
 		(20, 2, 'c', 'c', 1, 0, 5),
 		(30, 3, 'c', 'd', 1, 0, 5)`)
 
-	tasks := reader.ListTasks(context.Background(), TaskQuery{ParentIDs: []uint64{1, 2}})
+	tasks, readErr := reader.ListTasks(context.Background(), TaskQuery{ParentIDs: []uint64{1, 2}})
+	assertReadOK(t, readErr)
 	got := map[uint64]bool{}
 	for _, tk := range tasks {
 		got[tk.ID] = true
@@ -296,7 +315,9 @@ func TestListTasksParentIDsSelectsChildrenOfManyParents(t *testing.T) {
 		t.Fatalf("ParentIDs{1,2} returned ids %v, want {10,11,20}", got)
 	}
 
-	if one := reader.ListTasks(context.Background(), TaskQuery{ParentID: 1}); len(one) != 2 {
+	if one, readErr := reader.ListTasks(context.Background(), TaskQuery{ParentID: 1}); readErr != nil {
+		panic(readErr)
+	} else if len(one) != 2 {
 		t.Fatalf("ParentID 1 returned %d tasks, want 2", len(one))
 	}
 }
@@ -316,7 +337,9 @@ func TestBuildTraceQueryRejectsInvalidTime(t *testing.T) {
 func TestListTasksTreatsKindAsBoundValue(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "trace.sqlite3")
 	reader := NewSQLiteTraceReader(dbPath)
-	reader.Init()
+	if err := reader.Init(); err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 
 	exec := func(q string) {
@@ -333,8 +356,16 @@ func TestListTasksTreatsKindAsBoundValue(t *testing.T) {
 		(1, 0, 'read', 'a', 1, 0, 10),
 		(2, 0, 'write', 'b', 1, 0, 10)`)
 
-	tasks := reader.ListTasks(context.Background(), TaskQuery{Kind: "read' OR 1=1 --"})
+	tasks, readErr := reader.ListTasks(context.Background(), TaskQuery{Kind: "read' OR 1=1 --"})
+	assertReadOK(t, readErr)
 	if len(tasks) != 0 {
 		t.Fatalf("malicious kind matched %d tasks, want 0", len(tasks))
+	}
+}
+
+func assertReadOK(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/datarecording/README.md
+++ b/datarecording/README.md
@@ -10,10 +10,10 @@ The `DataRecorder` interface writes structured data into SQLite tables:
 
 ```go
 type DataRecorder interface {
-    CreateTable(tableName string, sampleEntry any)
-    InsertData(tableName string, entry any)
+    CreateTable(tableName string, sampleEntry any) error
+    InsertData(tableName string, entry any) error
     ListTables() []string
-    Flush()
+    Flush() error
     Close() error
 }
 ```
@@ -21,8 +21,11 @@ type DataRecorder interface {
 ### Creating a Recorder
 
 ```go
-recorder := datarecording.NewDataRecorder("my_simulation")
-defer recorder.Close()
+recorder, err := datarecording.NewDataRecorder("my_simulation")
+if err != nil {
+    return err
+}
+defer recorder.Close() // fallback cleanup; check Close explicitly on success
 ```
 
 This creates a SQLite file `my_simulation.sqlite3`. Simulation-level metadata
@@ -43,7 +46,9 @@ type MyEntry struct {
     Location  string  `akita_data:"location"` // auto-mapped to int IDs
 }
 
-recorder.CreateTable("my_results", MyEntry{})
+if err := recorder.CreateTable("my_results", MyEntry{}); err != nil {
+    return err
+}
 ```
 
 #### Struct Tags
@@ -61,12 +66,14 @@ complex, string).
 ### Inserting Data
 
 ```go
-recorder.InsertData("my_results", MyEntry{
+if err := recorder.InsertData("my_results", MyEntry{
     ID:       1,
     Category: "latency",
     Value:    42.5,
     Location: "Cache.L1",
-})
+}); err != nil {
+    return err
+}
 ```
 
 Data is batched internally (default 100,000 entries) and flushed automatically
@@ -77,7 +84,10 @@ or via `Flush()`.
 The `DataReader` interface reads from SQLite databases:
 
 ```go
-reader := datarecording.NewReader("my_simulation.sqlite3")
+reader, err := datarecording.NewReader("my_simulation.sqlite3")
+if err != nil {
+    return err
+}
 defer reader.Close()
 
 reader.MapTable("my_results", MyEntry{})
@@ -103,3 +113,15 @@ results, totalCount, err := reader.Query(ctx, "my_results", datarecording.QueryP
 
 Results are returned as `[]any` where each element is a pointer to the
 mapped struct type.
+
+## Recording failures
+
+Creation refuses an existing output file. Check errors from every write and
+from `Close`; a failed final flush or index build invalidates requested output.
+A failed flush retains its batch for retry. `Close` releases the database even
+on failure and cannot be retried. There is no process-wide exit handler.
+
+Inside managed simulation callbacks, `MustRecord(err)` turns an I/O error into
+a contained simulation failure. Standalone clients handle the error directly.
+The simulation's `Terminate` publishes a `.complete` marker after successful
+recording and close; see [output validity](../simulation/ERROR_HANDLING.md).

--- a/datarecording/concurrency_test.go
+++ b/datarecording/concurrency_test.go
@@ -24,8 +24,8 @@ func TestConcurrentRecording(t *testing.T) {
 			t.Cleanup(func() { _ = db.Close() })
 			recorder := NewDataRecorderWithDB(db).(*sqliteWriter)
 			recorder.batchSize = 32
-			recorder.CreateTable("first", concurrentRecord{})
-			recorder.CreateTable("second", concurrentRecord{})
+			MustRecord(recorder.CreateTable("first", concurrentRecord{}))
+			MustRecord(recorder.CreateTable("second", concurrentRecord{}))
 
 			const writers, perWriter = 4, 400
 			start := make(chan struct{})
@@ -41,7 +41,7 @@ func TestConcurrentRecording(t *testing.T) {
 					workers.Go(func() {
 						<-start
 						for range 100 {
-							recorder.Flush()
+							MustRecord(recorder.Flush())
 							runtime.Gosched()
 						}
 					})
@@ -49,8 +49,8 @@ func TestConcurrentRecording(t *testing.T) {
 			}
 			close(start)
 			workers.Wait()
-			recorder.Flush()
-			recorder.Flush() // An empty flush must not replay the last batch.
+			MustRecord(recorder.Flush())
+			MustRecord(recorder.Flush()) // An empty flush must not replay the last batch.
 
 			assertConcurrentRecords(t, db, writers*perWriter)
 			if err := recorder.Close(); err != nil {
@@ -67,9 +67,9 @@ func insertConcurrentRecords(recorder DataRecorder, firstID, count int) {
 		if id%2 != 0 {
 			tableName = "second"
 		}
-		recorder.InsertData(tableName, concurrentRecord{
+		MustRecord(recorder.InsertData(tableName, concurrentRecord{
 			ID: id, Location: fmt.Sprintf("location-%d", id%7),
-		})
+		}))
 		runtime.Gosched()
 	}
 }
@@ -116,17 +116,17 @@ func TestFlushRollsBackAndRetainsBatch(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	recorder := NewDataRecorderWithDB(db)
-	recorder.CreateTable("first", concurrentRecord{})
-	recorder.CreateTable("second", concurrentRecord{})
+	MustRecord(recorder.CreateTable("first", concurrentRecord{}))
+	MustRecord(recorder.CreateTable("second", concurrentRecord{}))
 	_, err = db.Exec(`CREATE TRIGGER reject_row BEFORE INSERT ON first
 		WHEN NEW.ID = 1 BEGIN SELECT RAISE(ABORT, 'test insert failure'); END`)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for id := range 2 {
-		recorder.InsertData("first", concurrentRecord{
+		MustRecord(recorder.InsertData("first", concurrentRecord{
 			ID: id, Location: fmt.Sprintf("location-%d", id),
-		})
+		}))
 	}
 	func() {
 		defer func() {
@@ -134,7 +134,7 @@ func TestFlushRollsBackAndRetainsBatch(t *testing.T) {
 				t.Error("Flush did not report the injected insert failure")
 			}
 		}()
-		recorder.Flush()
+		MustRecord(recorder.Flush())
 	}()
 	var count int
 	if err := db.QueryRow("SELECT COUNT(*) FROM first").Scan(&count); err != nil {
@@ -146,7 +146,7 @@ func TestFlushRollsBackAndRetainsBatch(t *testing.T) {
 	if _, err := db.Exec("DROP TRIGGER reject_row"); err != nil {
 		t.Fatal(err)
 	}
-	recorder.Flush()
+	MustRecord(recorder.Flush())
 	assertConcurrentRecords(t, db, 2)
 	if err := recorder.Close(); err != nil {
 		t.Fatal(err)

--- a/datarecording/datareader.go
+++ b/datarecording/datareader.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+
+	"github.com/sarchlab/akita/v5/internal/sqlitefile"
 )
 
 // QueryParams encapsulates all query parameters
@@ -58,7 +60,11 @@ type sqliteReader struct {
 // NewReader creates a new DataReader
 func NewReader(dbFilename string) (DataReader, error) {
 	// Open the database
-	db, err := sql.Open("sqlite", dbFilename)
+	dsn, err := sqlitefile.DSN(dbFilename)
+	if err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/datarecording/datareader.go
+++ b/datarecording/datareader.go
@@ -56,17 +56,21 @@ type sqliteReader struct {
 }
 
 // NewReader creates a new DataReader
-func NewReader(dbFilename string) DataReader {
+func NewReader(dbFilename string) (DataReader, error) {
 	// Open the database
 	db, err := sql.Open("sqlite", dbFilename)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	return &sqliteReader{
 		DB:      db,
 		typeMap: make(map[string]reflect.Type),
-	}
+	}, nil
 }
 
 // NewReaderWithDB creates a new DataReader with a given database
@@ -128,7 +132,11 @@ func (r *sqliteReader) Query(
 	}
 	defer rows.Close()
 
-	return r.scanRowsToSlice(ctx, rows, structType), totalCount, nil
+	result, err := r.scanRowsToSlice(ctx, rows, structType)
+	if err != nil {
+		return nil, 0, err
+	}
+	return result, totalCount, nil
 }
 
 func (r *sqliteReader) queryTotalCount(
@@ -157,12 +165,12 @@ func (r *sqliteReader) scanRowsToSlice(
 	ctx context.Context,
 	rows *sql.Rows,
 	structType reflect.Type,
-) []any {
+) ([]any, error) {
 	var results []any
 
 	columns, err := rows.Columns()
 	if err != nil {
-		return nil // Error getting columns
+		return nil, err
 	}
 
 	hasLocation := r.checkLocationTag(structType)
@@ -192,11 +200,13 @@ func (r *sqliteReader) scanRowsToSlice(
 
 		err := rows.Scan(scanTargets...)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 
 		if hasLocation {
-			r.restoreStrLocation(ctx, structVal, structType)
+			if err := r.restoreStrLocation(ctx, structVal, structType); err != nil {
+				return nil, err
+			}
 		}
 
 		results = append(results, structPtr.Interface())
@@ -204,10 +214,10 @@ func (r *sqliteReader) scanRowsToSlice(
 
 	err = rows.Err()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return results
+	return results, nil
 }
 
 func (r *sqliteReader) Close() error {
@@ -219,7 +229,7 @@ func (r *sqliteReader) restoreStrLocation(
 	ctx context.Context,
 	structVal reflect.Value,
 	structType reflect.Type,
-) {
+) error {
 	var strLocation string // Retrieves the real location
 
 	for i := 0; i < structType.NumField(); i++ {
@@ -232,11 +242,14 @@ func (r *sqliteReader) restoreStrLocation(
 
 			stmt := fmt.Sprintf("SELECT Locale FROM"+
 				" location WHERE ID = %s", index)
-			r.DB.QueryRowContext(ctx, stmt).Scan(&strLocation)
+			if err := r.DB.QueryRowContext(ctx, stmt).Scan(&strLocation); err != nil {
+				return err
+			}
 
 			fieldVal.SetString(strLocation)
 		}
 	}
+	return nil
 }
 
 // Helper function that checks whehter this struct has location tag

--- a/datarecording/datarecorder.go
+++ b/datarecording/datarecorder.go
@@ -13,7 +13,6 @@ import (
 	// Need to use SQLite connections.
 	_ "github.com/glebarez/go-sqlite"
 	"github.com/rs/xid"
-	"github.com/tebeka/atexit"
 )
 
 // DataRecorder is a backend that can record and store data.
@@ -21,39 +20,37 @@ import (
 // ListTables, and Flush calls. Stop producers before calling Close.
 type DataRecorder interface {
 	// CreateTable creates a new table with given filename
-	CreateTable(tableName string, sampleEntry any)
+	CreateTable(tableName string, sampleEntry any) error
 
 	// DataInsert writes a same-type task into table that already exists
-	InsertData(tableName string, entry any)
+	InsertData(tableName string, entry any) error
 
 	// ListTable returns a slice containing names of all tables
 	ListTables() []string
 
 	// Flush flushes all the buffered task into database
-	Flush()
+	Flush() error
 
 	// Close closes the recorder
 	Close() error
 }
 
 // NewDataRecorder creates a new DataRecorder.
-func NewDataRecorder(path string) DataRecorder {
+func NewDataRecorder(path string) (DataRecorder, error) {
 	w := &sqliteWriter{
 		dbName:    path,
 		batchSize: 100000,
 		tables:    make(map[string]*table),
 	}
 
-	w.Init()
-
-	atexit.Register(func() {
-		w.Flush()
-	})
-
-	return w
+	if err := w.Init(); err != nil {
+		return nil, err
+	}
+	return w, nil
 }
 
-// NewDataRecorderWithDB creates a new DataRecorder with a given database.
+// NewDataRecorderWithDB creates a recorder and takes responsibility for closing
+// the database. The caller must not share it with another simulation.
 func NewDataRecorderWithDB(db *sql.DB) DataRecorder {
 	w := &sqliteWriter{
 		DB:        db,
@@ -86,28 +83,39 @@ type sqliteWriter struct {
 	locationInfo map[string]int
 	batchSize    int
 	entryCount   int
+	closed       bool
+	closeErr     error
 }
 
 // Init establishes a connection to the database.
-func (t *sqliteWriter) Init() {
+func (t *sqliteWriter) Init() (err error) {
+	defer recoverIO(&err)
 	if t.dbName == "" {
 		t.dbName = "akita_data_recording_" + xid.New().String()
 	}
 
 	filename := t.dbName + ".sqlite3"
-	os.Remove(filename)
-
-	_, err := os.Stat(filename)
-	if err == nil {
-		panic(fmt.Errorf("file %s already exists", filename))
+	// Exclusive creation prevents a second simulation from deleting a live
+	// recorder's file. Output paths are owned by exactly one simulation.
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	if err = file.Close(); err != nil {
+		return err
 	}
 
 	db, err := sql.Open("sqlite", filename)
 	if err != nil {
-		panic(err)
+		panic(recorderIOError{err})
 	}
 
+	if err = db.Ping(); err != nil {
+		_ = db.Close()
+		return err
+	}
 	t.DB = db
+	return nil
 }
 
 func (t *sqliteWriter) isAllowedType(kind reflect.Kind) bool {
@@ -135,7 +143,7 @@ func (t *sqliteWriter) isAllowedType(kind reflect.Kind) bool {
 	}
 }
 
-func (t *sqliteWriter) checkStructFields(entry any) error {
+func (t *sqliteWriter) checkStructFields(entry any) {
 	types := reflect.TypeOf(entry)
 
 	for i := 0; i < types.NumField(); i++ {
@@ -149,11 +157,9 @@ func (t *sqliteWriter) checkStructFields(entry any) error {
 
 		fieldKind := field.Type.Kind()
 		if !t.isAllowedType(fieldKind) {
-			return errors.New("entry is invalid")
+			panic("entry is invalid")
 		}
 	}
-
-	return nil
 }
 
 func (t *sqliteWriter) mustHaveAtMostOneTag(field reflect.StructField) {
@@ -182,14 +188,15 @@ func (t *sqliteWriter) mustHaveAtMostOneTag(field reflect.StructField) {
 		"ignore, unique, index, or location")
 }
 
-func (t *sqliteWriter) CreateTable(tableName string, sampleEntry any) {
+func (t *sqliteWriter) CreateTable(tableName string, sampleEntry any) (err error) {
+	defer recoverIO(&err)
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
-	err := t.checkStructFields(sampleEntry)
-	if err != nil {
-		panic(err)
+	if t.closed {
+		return sql.ErrConnDone
 	}
+
+	t.checkStructFields(sampleEntry)
 
 	fieldNames := t.getFieldNames(sampleEntry)
 	fields := strings.Join(fieldNames, ", \n\t")
@@ -212,6 +219,7 @@ func (t *sqliteWriter) CreateTable(tableName string, sampleEntry any) {
 	t.tables[tableName] = tableInfo
 
 	t.prepareStatement(tableName, sampleEntry)
+	return nil
 }
 
 func (t *sqliteWriter) checkLocationTag(entry any) bool {
@@ -272,7 +280,7 @@ func (t *sqliteWriter) prepareStatement(table string, task any) {
 
 	stmt, err := t.PrepareContext(context.Background(), sqlStr)
 	if err != nil {
-		panic(err)
+		panic(recorderIOError{err})
 	}
 
 	t.tables[table].statement = stmt
@@ -332,9 +340,13 @@ func (t *sqliteWriter) createIndex(tableName, fieldName string, unique bool) {
 	t.mustExecute(indexSQL)
 }
 
-func (t *sqliteWriter) InsertData(tableName string, entry any) {
+func (t *sqliteWriter) InsertData(tableName string, entry any) (err error) {
+	defer recoverIO(&err)
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if t.closed {
+		return sql.ErrConnDone
+	}
 
 	table, exists := t.tables[tableName]
 	if !exists {
@@ -348,6 +360,7 @@ func (t *sqliteWriter) InsertData(tableName string, entry any) {
 	if t.entryCount >= t.batchSize {
 		t.flushLocked()
 	}
+	return nil
 }
 
 func (t *sqliteWriter) ListTables() []string {
@@ -362,11 +375,16 @@ func (t *sqliteWriter) ListTables() []string {
 	return tables
 }
 
-func (t *sqliteWriter) Flush() {
+func (t *sqliteWriter) Flush() (err error) {
+	defer recoverIO(&err)
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if t.closed {
+		return sql.ErrConnDone
+	}
 
 	t.flushLocked()
+	return nil
 }
 
 // flushLocked owns the buffers and location dictionary until the whole batch
@@ -378,7 +396,7 @@ func (t *sqliteWriter) flushLocked() {
 
 	tx, err := t.DB.BeginTx(context.Background(), nil)
 	if err != nil {
-		panic(err)
+		panic(recorderIOError{err})
 	}
 	defer tx.Rollback()
 
@@ -399,7 +417,7 @@ func (t *sqliteWriter) flushLocked() {
 	}
 
 	if err := tx.Commit(); err != nil {
-		panic(err)
+		panic(recorderIOError{err})
 	}
 
 	for _, table := range t.tables {
@@ -455,7 +473,7 @@ func (t *sqliteWriter) insertEntryForTable(
 
 	_, err := stmt.ExecContext(context.Background(), v...)
 	if err != nil {
-		panic(err)
+		panic(recorderIOError{err})
 	}
 }
 
@@ -494,7 +512,7 @@ func (t *sqliteWriter) mustExecute(query string) sql.Result {
 	res, err := t.ExecContext(context.Background(), query)
 	if err != nil {
 		fmt.Printf("Failed to execute: %s\n", query)
-		panic(err)
+		panic(recorderIOError{err})
 	}
 
 	return res
@@ -520,17 +538,19 @@ func (t *sqliteWriter) buildIndexes() {
 	}
 }
 
-func (t *sqliteWriter) Close() error {
+// Close releases the owned database even when the final batch or index build
+// fails. A failed Flush retains its batch for retry; Close is final and is not
+// a retry operation. Do not resubmit entries after an automatic flush failure.
+func (t *sqliteWriter) Close() (err error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
+	if t.closed {
+		return t.closeErr
+	}
+	t.closed = true
+	defer func() { err = errors.Join(err, t.DB.Close()); t.closeErr = err }()
+	defer recoverIO(&err)
 	t.flushLocked()
 	t.buildIndexes()
-
-	err := t.DB.Close()
-	if err != nil {
-		return fmt.Errorf("failed to close database connection: %w", err)
-	}
-
 	return nil
 }

--- a/datarecording/datarecorder.go
+++ b/datarecording/datarecorder.go
@@ -13,6 +13,7 @@ import (
 	// Need to use SQLite connections.
 	_ "github.com/glebarez/go-sqlite"
 	"github.com/rs/xid"
+	"github.com/sarchlab/akita/v5/internal/sqlitefile"
 )
 
 // DataRecorder is a backend that can record and store data.
@@ -101,17 +102,28 @@ func (t *sqliteWriter) Init() (err error) {
 	if err != nil {
 		return err
 	}
+	// No recorder has been published yet. Release our unused path if opening
+	// the database fails so a later attempt can claim it again.
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, os.Remove(filename))
+		}
+	}()
 	if err = file.Close(); err != nil {
 		return err
 	}
 
-	db, err := sql.Open("sqlite", filename)
+	dsn, err := sqlitefile.DSN(filename)
 	if err != nil {
-		panic(recorderIOError{err})
+		return err
+	}
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return err
 	}
 
 	if err = db.Ping(); err != nil {
-		_ = db.Close()
+		err = errors.Join(err, db.Close())
 		return err
 	}
 	t.DB = db

--- a/datarecording/errors.go
+++ b/datarecording/errors.go
@@ -1,0 +1,23 @@
+package datarecording
+
+// MustRecord adapts recorder errors to a managed model callback. Standalone
+// callers should handle the returned error directly. It never discards failures.
+func MustRecord(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// recorderIOError unwinds private SQL helpers to the recorder's public I/O boundary.
+// Programming errors retain their original panic semantics.
+type recorderIOError struct{ error }
+
+func recoverIO(err *error) {
+	if p := recover(); p != nil {
+		if failure, ok := p.(recorderIOError); ok {
+			*err = failure.error
+		} else {
+			panic(p)
+		}
+	}
+}

--- a/datarecording/errors_test.go
+++ b/datarecording/errors_test.go
@@ -1,0 +1,84 @@
+package datarecording
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriterOperationalFailuresReturnErrors(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "recording")
+	recorder, err := NewDataRecorder(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewDataRecorder(file); err == nil {
+		t.Fatal("second recorder replaced owned output")
+	}
+	w := recorder.(*sqliteWriter)
+	if err := w.CreateTable("records", struct{ ID int }{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.InsertData("records", struct{ ID int }{1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.DB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Flush(); err == nil {
+		t.Fatal("flush hid closed database")
+	}
+	if w.entryCount != 1 {
+		t.Fatal("failed flush lost retained batch")
+	}
+	if err := w.Close(); err == nil {
+		t.Fatal("final flush failure hidden by close")
+	}
+	if _, err := NewDataRecorder(filepath.Join(t.TempDir(), "missing", "recording")); err == nil {
+		t.Fatal("bad output path accepted")
+	}
+}
+func TestReaderScanAndCancellationReturnErrors(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec("CREATE TABLE records (ID TEXT); INSERT INTO records VALUES ('not-an-integer')"); err != nil {
+		t.Fatal(err)
+	}
+	reader := NewReaderWithDB(db)
+	reader.MapTable("records", struct{ ID int }{})
+	rows, count, err := reader.Query(context.Background(), "records", QueryParams{})
+	if err == nil || rows != nil || count != 0 {
+		t.Fatalf("scan failure became partial results: %v %d %v", rows, count, err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, _, err := reader.Query(ctx, "records", QueryParams{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation lost: %v", err)
+	}
+}
+
+func TestClosedRecorderRejectsWrites(t *testing.T) {
+	r, err := NewDataRecorder(filepath.Join(t.TempDir(), "result"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.CreateTable("records", struct{ ID int }{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, err := range []error{
+		r.InsertData("records", struct{ ID int }{1}),
+		r.CreateTable("more", struct{ ID int }{}), r.Flush(),
+	} {
+		if !errors.Is(err, sql.ErrConnDone) {
+			t.Fatalf("closed recorder accepted an operation: %v", err)
+		}
+	}
+}

--- a/datarecording/errors_test.go
+++ b/datarecording/errors_test.go
@@ -82,3 +82,35 @@ func TestClosedRecorderRejectsWrites(t *testing.T) {
 		}
 	}
 }
+
+func TestOutputPathsRemainLiteralSQLiteFilenames(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "result")
+	type record struct{ ID int }
+	for i, name := range []string{base, base + ".sqlite3?ignored#suffix"} {
+		r, err := NewDataRecorder(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := r.CreateTable("records", record{}); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.InsertData("records", record{ID: i}); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
+		}
+		reader, err := NewReader(name + ".sqlite3")
+		if err != nil {
+			t.Fatal(err)
+		}
+		reader.MapTable("records", record{})
+		rows, count, err := reader.Query(context.Background(), "records", QueryParams{})
+		if err != nil || count != 1 || len(rows) != 1 || rows[0].(*record).ID != i {
+			t.Fatalf("output path aliased another recording: rows=%v count=%d err=%v", rows, count, err)
+		}
+		if err := reader.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/datarecording/example_test.go
+++ b/datarecording/example_test.go
@@ -19,7 +19,10 @@ func Example() {
 	dbPath := "test"
 	os.Remove(dbPath + ".sqlite3")
 
-	recorder := datarecording.NewDataRecorder(dbPath)
+	recorder, err := datarecording.NewDataRecorder(dbPath)
+	if err != nil {
+		panic(err)
+	}
 
 	cleanup := func() {
 		os.Remove(dbPath + ".sqlite3")
@@ -27,15 +30,18 @@ func Example() {
 	defer cleanup()
 
 	task1 := Task{1, "task1", 30, "A"}
-	recorder.CreateTable("test_table", task1)
+	datarecording.MustRecord(recorder.CreateTable("test_table", task1))
 
 	task2 := Task{2, "task2", 15, "B"}
-	recorder.InsertData("test_table", task2)
-	recorder.Flush()
+	datarecording.MustRecord(recorder.InsertData("test_table", task2))
+	datarecording.MustRecord(recorder.Flush())
 
 	recorder.Close()
 
-	reader := datarecording.NewReader(dbPath + ".sqlite3")
+	reader, err := datarecording.NewReader(dbPath + ".sqlite3")
+	if err != nil {
+		panic(err)
+	}
 	reader.MapTable("test_table", Task{})
 
 	results, _, err := reader.Query(context.Background(), "test_table", datarecording.QueryParams{})

--- a/datarecording/faults_test.go
+++ b/datarecording/faults_test.go
@@ -1,0 +1,110 @@
+package datarecording
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+var faultDriverID atomic.Uint64
+var errInjectedIO = errors.New("injected recording I/O failure")
+
+type faultState struct {
+	phase  string
+	closed bool
+}
+type faultDriver struct{ state *faultState }
+
+func (d faultDriver) Open(string) (driver.Conn, error) { return &faultConn{state: d.state}, nil }
+
+type faultConn struct{ state *faultState }
+
+func (c *faultConn) Prepare(q string) (driver.Stmt, error) {
+	return &faultStmt{state: c.state, query: q}, nil
+}
+func (c *faultConn) Close() error {
+	c.state.closed = true
+	if c.state.phase == "close" {
+		return errInjectedIO
+	}
+	return nil
+}
+func (c *faultConn) Begin() (driver.Tx, error) {
+	if c.state.phase == "begin" {
+		return nil, errInjectedIO
+	}
+	return &faultTx{state: c.state}, nil
+}
+func (c *faultConn) ExecContext(_ context.Context, q string, _ []driver.NamedValue) (driver.Result, error) {
+	if c.state.phase == "index" && strings.HasPrefix(q, "CREATE INDEX") {
+		return nil, errInjectedIO
+	}
+	return driver.RowsAffected(1), nil
+}
+
+type faultStmt struct {
+	state *faultState
+	query string
+}
+
+func (*faultStmt) Close() error  { return nil }
+func (*faultStmt) NumInput() int { return -1 }
+func (s *faultStmt) Exec([]driver.Value) (driver.Result, error) {
+	if s.state.phase == "write" {
+		return nil, errInjectedIO
+	}
+	return driver.RowsAffected(1), nil
+}
+func (*faultStmt) Query([]driver.Value) (driver.Rows, error) {
+	return nil, errors.New("unexpected query")
+}
+
+type faultTx struct{ state *faultState }
+
+func (tx *faultTx) Commit() error {
+	if tx.state.phase == "commit" {
+		return errInjectedIO
+	}
+	return nil
+}
+func (*faultTx) Rollback() error { return nil }
+
+func TestRecorderContainsIOFailuresAndClosesResources(t *testing.T) {
+	for _, phase := range []string{"begin", "write", "commit", "index", "close"} {
+		t.Run(phase, func(t *testing.T) {
+			state := &faultState{}
+			name := fmt.Sprintf("akita-fault-%d", faultDriverID.Add(1))
+			sql.Register(name, faultDriver{state})
+			db, err := sql.Open(name, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			db.SetMaxOpenConns(1)
+			w := NewDataRecorderWithDB(db).(*sqliteWriter)
+			type row struct {
+				ID int `akita_data:"index"`
+			}
+			if err := w.CreateTable("records", row{}); err != nil {
+				t.Fatal(err)
+			}
+			if err := w.InsertData("records", row{1}); err != nil {
+				t.Fatal(err)
+			}
+			state.phase = phase
+			if err := w.Close(); !errors.Is(err, errInjectedIO) {
+				t.Fatalf("%s failure lost: %v", phase, err)
+			}
+			if !state.closed {
+				t.Fatalf("%s failure leaked connection", phase)
+			}
+			if (phase == "begin" || phase == "write" || phase == "commit") && w.entryCount != 1 {
+				t.Fatal("failed transaction discarded uncommitted batch")
+			}
+		})
+	}
+}

--- a/doc/tutorial/components/04_build_and_run.md
+++ b/doc/tutorial/components/04_build_and_run.md
@@ -10,7 +10,10 @@ component and runs the engine.
 ## Building the Component
 
 ```go
-s := simulation.MakeBuilder().Build()
+s, err := simulation.MakeBuilder().Build()
+if err != nil {
+    panic(err) // command-line boundary
+}
 
 spec := walkSpec{Freq: 1 * timing.GHz, WallDistance: 10}
 comp := modeling.NewBuilder[walkSpec, walkState, modeling.None]().
@@ -71,7 +74,9 @@ if err := s.GetEngine().Run(); err != nil {
     panic(err)
 }
 
-s.Terminate()
+if err := s.Terminate(); err != nil {
+    panic(err) // requested output did not complete
+}
 ```
 
 `TickLater` schedules the first tick at the next cycle. Without it the
@@ -119,3 +124,7 @@ This component talks to nobody. The next section, **Make Components Talk to
 Each Other**, introduces **ports** for sending and receiving messages,
 **multiple middlewares** that share one component's state, and the
 per-package **builder** convention used throughout Akita.
+
+For a host running multiple simulations, construct components in a `Build`
+callback or `Simulation.Setup`, and handle boundary errors without panicking
+in the host. See [the failure-isolation example](https://github.com/sarchlab/akita/tree/main/examples/failureisolation).

--- a/doc/tutorial/events/01_first_program.md
+++ b/doc/tutorial/events/01_first_program.md
@@ -36,23 +36,25 @@ implements a single method:
 ```go
 type EventPrinter struct{}
 
-func (e *EventPrinter) Handle(event timing.Event) error {
+func (e *EventPrinter) Handle(event timing.Event) {
     fmt.Printf("Event: %d\n", event.Time())
-    return nil
 }
 ```
 
 When the engine fires an event, it looks up the registered handler by name
-and calls `Handle(event)`. Anything the handler returns as an error stops
-the simulation.
+and calls `Handle(event)`. A handler panic fails its owning simulation;
+`Run` returns the captured failure. `Handle` has no error result.
 
 ### 2. Building the simulation
 
 ```go
-s := simulation.MakeBuilder().Build()
+s, err := simulation.MakeBuilder().Build()
+if err != nil {
+    panic(err) // command-line boundary
+}
 ```
 
-`simulation.MakeBuilder().Build()` returns a `*simulation.Simulation`. It
+`simulation.MakeBuilder().Build()` returns `(*simulation.Simulation, error)`. It
 owns an engine, a registrar, and optional tracing and monitoring
 infrastructure. For this example we only need the engine:
 
@@ -77,11 +79,11 @@ The type assertion is a safety check — most engines implement
 ### 4. Creating and scheduling the event
 
 ```go
-evt := timing.MakeEventBase(1, "printer")
+evt := timing.MakeEventBase(s.GetIDGenerator(), 1, "printer")
 engine.Schedule(evt)
 ```
 
-`MakeEventBase(time, handlerID)` creates a minimal event whose `Time()`
+`MakeEventBase(ids, time, handlerID)` creates a minimal event whose `Time()`
 returns `1` and whose `HandlerID()` returns `"printer"`. The engine will
 fire it at time = 1 picosecond and dispatch it to the handler registered
 under `"printer"`.
@@ -89,7 +91,7 @@ under `"printer"`.
 ### 5. Running
 
 ```go
-err := engine.Run()
+err = engine.Run()
 if err != nil {
     panic(err)
 }
@@ -102,7 +104,9 @@ event and returns.
 ### 6. Cleanup
 
 ```go
-s.Terminate()
+if err := s.Terminate(); err != nil {
+    panic(err) // requested output did not complete
+}
 ```
 
 `Terminate` flushes any tracing and data-recording buffers held by the
@@ -138,3 +142,7 @@ and the engine returned because no further events were scheduled.
 
 The next chapter shows handlers that schedule *more* events during the
 simulation — the basic pattern that components themselves use internally.
+
+For a host running multiple simulations, construct components in a `Build`
+callback or `Simulation.Setup`, and handle boundary errors without panicking
+in the host. See [the failure-isolation example](https://github.com/sarchlab/akita/tree/main/examples/failureisolation).

--- a/doc/tutorial/events/02_many_events.md
+++ b/doc/tutorial/events/02_many_events.md
@@ -55,7 +55,7 @@ type handler struct {
     count int
 }
 
-func (h *handler) Handle(e timing.Event) error {
+func (h *handler) Handle(e timing.Event) {
     h.count += 1
 
     evt := e.(splitEvent)
@@ -65,7 +65,6 @@ func (h *handler) Handle(e timing.Event) error {
     h.scheduleNextSplitEvent(evt.Time(), evt.id)
     h.scheduleNextSplitEvent(evt.Time(), h.count)
 
-    return nil
 }
 ```
 
@@ -105,7 +104,10 @@ when no more events are pending, the engine returns.
 ```go
 randGen = rand.New(rand.NewSource(0))
 
-s := simulation.MakeBuilder().Build()
+s, err := simulation.MakeBuilder().Build()
+if err != nil {
+    panic(err) // command-line boundary
+}
 engine = s.GetEngine()
 h := handler{count: 1}
 
@@ -121,7 +123,7 @@ firstEvt := splitEvent{
 }
 engine.Schedule(firstEvt)
 
-err := engine.Run()
+err = engine.Run()
 ```
 
 Same shape as the previous example: build, get engine, register handler,
@@ -165,3 +167,7 @@ introduces **event-driven components**, which wear the component shape you
 already know from the first section — Spec, State, ports — but wake on
 demand instead of every cycle. They are the bridge between raw events and
 the default ticking components.
+
+For a host running multiple simulations, construct components in a `Build`
+callback or `Simulation.Setup`, and handle boundary errors without panicking
+in the host. See [the failure-isolation example](https://github.com/sarchlab/akita/tree/main/examples/failureisolation).

--- a/doc/tutorial/hooks/07_builtin_tracers_and_filters.md
+++ b/doc/tutorial/hooks/07_builtin_tracers_and_filters.md
@@ -90,7 +90,10 @@ Unlike the time tracers it does take a `timing.TimeTeller` (the engine works),
 alongside a `datarecording.DataRecorder`:
 
 ```go
-recorder := datarecording.NewDataRecorder("trace")
+recorder, err := datarecording.NewDataRecorder("trace")
+if err != nil {
+    return err
+}
 dbTracer := tracing.NewDBTracer(engine, recorder)
 tracing.CollectTrace(component, dbTracer)
 

--- a/doc/tutorial/migration.md
+++ b/doc/tutorial/migration.md
@@ -138,18 +138,12 @@ Note the new `SendTaskID` and `RecvTaskID` fields for tracing integration.
 
 ### IDGenerator (V5)
 
-```go
-// v5/sim/idgenerator.go
-type IDGenerator interface {
-    Generate() uint64
-}
-
-// Two implementations: sequential (deterministic) and parallel (non-deterministic).
-sim.UseSequentialIDGenerator() // Call before any Generate()
-sim.UseParallelIDGenerator()   // For parallel simulations
-
-id := sim.GetIDGenerator().Generate() // returns uint64
-```
+Each engine owns a concurrent ID sequence and tracing associations. Use
+`sim.GetIDGenerator()` where `sim` is a `*simulation.Simulation`, or
+`timing.IDsFor(engine)` through an engine interface. Pass this owner into event
+and message construction. Process-global generator selection and resets have
+been removed. Custom generators implement `Generate`, `Track`, `Lookup`, and
+`Forget`; see `timing.IDGenerator`.
 
 ### Before / After
 
@@ -193,7 +187,7 @@ if req.ID == 0 { ... }
 - Replace `== ""` / `!= ""` checks with `== 0` / `!= 0`.
 - Replace `fmt.Sprintf`-based ID formatting with `strconv.FormatUint` or `%d`.
 - Update tracing task ID comparisons from string to uint64.
-- Checkpoint/restore: use `GetIDGeneratorNextID()` / `SetIDGeneratorNextID()` to snapshot generator state.
+- Checkpoint/restore: the simulation snapshots its owned generator. Restore into a fresh simulation; do not reset a process-global counter.
 
 ---
 

--- a/doc/tutorial/talking/02_builder_and_ports.md
+++ b/doc/tutorial/talking/02_builder_and_ports.md
@@ -129,7 +129,7 @@ values, so the literal has no `&`:
 ```go
 pingMsg := pingReq{
     MsgMeta: messaging.MsgMeta{
-        ID:  timing.GetIDGenerator().Generate(),
+        ID:  m.comp.IDGenerator().Generate(),
         Src: outPort(m.comp).AsRemote(),
         Dst: state.PingDst,
     },

--- a/examples/01_print_event/main.go
+++ b/examples/01_print_event/main.go
@@ -10,14 +10,17 @@ import (
 type EventPrinter struct {
 }
 
-func (e *EventPrinter) Handle(event timing.Event) error {
+func (e *EventPrinter) Handle(event timing.Event) {
 	fmt.Printf("Event: %d\n", event.Time())
 
-	return nil
+	return
 }
 
 func main() {
-	s := simulation.MakeBuilder().Build()
+	s, err := simulation.MakeBuilder().Build()
+	if err != nil {
+		panic(err)
+	}
 
 	handler := &EventPrinter{}
 	engine := s.GetEngine()
@@ -26,12 +29,14 @@ func main() {
 		registrar.RegisterHandler("printer", handler)
 	}
 
-	engine.Schedule(timing.MakeEventBase(1, "printer"))
+	engine.Schedule(timing.MakeEventBase(timing.IDsFor(engine), 1, "printer"))
 
-	err := engine.Run()
+	err = engine.Run()
 	if err != nil {
 		panic(err)
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/examples/02_cell_split/main.go
+++ b/examples/02_cell_split/main.go
@@ -35,7 +35,7 @@ type handler struct {
 	count int
 }
 
-func (h *handler) Handle(e timing.Event) error {
+func (h *handler) Handle(e timing.Event) {
 	h.count += 1
 
 	evt := e.(splitEvent)
@@ -45,7 +45,7 @@ func (h *handler) Handle(e timing.Event) error {
 	h.scheduleNextSplitEvent(evt.Time(), evt.id)
 	h.scheduleNextSplitEvent(evt.Time(), h.count) // h.count is the new cell
 
-	return nil
+	return
 }
 
 func (h *handler) scheduleNextSplitEvent(now timing.VTimeInPicoSec, id int) {
@@ -64,7 +64,10 @@ func (h *handler) scheduleNextSplitEvent(now timing.VTimeInPicoSec, id int) {
 func main() {
 	randGen = rand.New(rand.NewSource(0))
 
-	s := simulation.MakeBuilder().Build()
+	s, err := simulation.MakeBuilder().Build()
+	if err != nil {
+		panic(err)
+	}
 	engine = s.GetEngine()
 	h := handler{
 		count: 1,
@@ -83,12 +86,14 @@ func main() {
 
 	engine.Schedule(firstEvt)
 
-	err := engine.Run()
+	err = engine.Run()
 	if err != nil {
 		panic(err)
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 
 	fmt.Printf("Cell count at time %d ps: %d\n", endTime, h.count)
 }

--- a/examples/03_random_walk/main.go
+++ b/examples/03_random_walk/main.go
@@ -49,7 +49,10 @@ func (m *walkMW) Tick() bool {
 }
 
 func main() {
-	s := simulation.MakeBuilder().Build()
+	s, err := simulation.MakeBuilder().Build()
+	if err != nil {
+		panic(err)
+	}
 
 	spec := walkSpec{Freq: 1 * timing.GHz, WallDistance: 10}
 	comp := modeling.NewBuilder[walkSpec, walkState, modeling.None]().
@@ -68,5 +71,7 @@ func main() {
 		panic(err)
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/examples/checkpointdemo/main.go
+++ b/examples/checkpointdemo/main.go
@@ -63,7 +63,7 @@ func (m *workerMW) Tick() bool {
 		return false
 	}
 
-	id := timing.GetIDGenerator().Generate()
+	id := m.comp.IDGenerator().Generate()
 	m.comp.State.Processed++
 	m.comp.State.Checksum = m.comp.State.Checksum*1000003 + id
 	m.comp.State.Pending--
@@ -78,9 +78,14 @@ func main() {
 	ckpt := flag.String("ckpt", "/tmp/akita-checkpoint.tar.gz", "checkpoint path")
 	flag.Parse()
 
-	sim := simulation.MakeBuilder().WithoutMonitoring().Build()
+	sim, err := simulation.MakeBuilder().WithoutMonitoring().Build()
+	if err != nil {
+		panic(err)
+	}
 	defer func() {
-		sim.Terminate()
+		if err := sim.Terminate(); err != nil {
+			panic(err)
+		}
 		os.Remove("akita_sim_" + sim.ID() + ".sqlite3")
 	}()
 

--- a/examples/checkpointdemo/main.go
+++ b/examples/checkpointdemo/main.go
@@ -87,6 +87,7 @@ func main() {
 			panic(err)
 		}
 		os.Remove("akita_sim_" + sim.ID() + ".sqlite3")
+		os.Remove("akita_sim_" + sim.ID() + ".complete")
 	}()
 
 	engine := sim.GetEngine().(*timing.SerialEngine)

--- a/examples/failureisolation/main.go
+++ b/examples/failureisolation/main.go
@@ -1,0 +1,83 @@
+// Command failureisolation runs two simulations in one process. A model panic
+// fails one instance while its peer completes. Run with go run ./examples/failureisolation.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sarchlab/akita/v5/simulation"
+	"github.com/sarchlab/akita/v5/timing"
+)
+
+type counter struct {
+	engine timing.Engine
+	count  int
+	fail   bool
+}
+
+func (c *counter) Handle(evt timing.Event) {
+	c.count++
+	if c.fail {
+		panic("injected model failure")
+	}
+	if c.count < 3 {
+		c.engine.Schedule(timing.MakeEventBase(timing.IDsFor(c.engine), evt.Time()+1, "counter"))
+	}
+}
+func build(path string, fail bool) (*simulation.Simulation, *counter, error) {
+	c := &counter{fail: fail}
+	s, err := simulation.MakeBuilder().WithoutMonitoring().WithOutputFileName(path).
+		Build(func(s *simulation.Simulation) error {
+			c.engine = s.GetEngine()
+			c.engine.(timing.HandlerRegistrar).RegisterHandler("counter", c)
+			c.engine.Schedule(timing.MakeEventBase(s.GetIDGenerator(), 1, "counter"))
+			return nil
+		})
+	return s, c, err
+}
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+func run() error {
+	dir, err := os.MkdirTemp("", "akita-isolation-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+	bad, badCount, err := build(filepath.Join(dir, "failed"), true)
+	if err != nil {
+		return err
+	}
+	defer bad.Terminate()
+	good, goodCount, err := build(filepath.Join(dir, "healthy"), false)
+	if err != nil {
+		return err
+	}
+	defer good.Terminate()
+	done := make(chan error, 1)
+	go func() { done <- bad.Run() }()
+	goodErr := good.Run()
+	badErr := <-done
+	if goodErr != nil {
+		return goodErr
+	}
+	if badErr == nil || badCount.count != 1 || goodCount.count != 3 {
+		return fmt.Errorf("isolation contract not met")
+	}
+	if err := good.Terminate(); err != nil {
+		return err
+	}
+	if err := bad.Terminate(); err == nil {
+		return fmt.Errorf("failure lost during finalization")
+	}
+	return json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"failure_contained": true, "failed_state": bad.State(), "unaffected_state": good.State(),
+		"failed_events": badCount.count, "completed_events": goodCount.count,
+	})
+}

--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -73,7 +73,7 @@ func (m *agentMW) send() bool {
 		p := s.Pending[0]
 		port.Send(pingRsp{
 			MsgMeta: messaging.MsgMeta{
-				ID:    timing.GetIDGenerator().Generate(),
+				ID:    m.comp.IDGenerator().Generate(),
 				Src:   port.AsRemote(),
 				Dst:   p.Dst,
 				RspTo: p.ReqID,
@@ -87,7 +87,7 @@ func (m *agentMW) send() bool {
 	if s.PingsToSend > 0 && port.CanSend() {
 		port.Send(pingReq{
 			MsgMeta: messaging.MsgMeta{
-				ID:  timing.GetIDGenerator().Generate(),
+				ID:  m.comp.IDGenerator().Generate(),
 				Src: port.AsRemote(),
 				Dst: s.PingDst,
 			},

--- a/examples/ping/processor.go
+++ b/examples/ping/processor.go
@@ -68,7 +68,7 @@ func (p *pingProcessor) sendScheduledPings(
 
 		pingMsg := pingReq{
 			MsgMeta: messaging.MsgMeta{
-				ID:  timing.GetIDGenerator().Generate(),
+				ID:  comp.IDGenerator().Generate(),
 				Src: outPort(comp).AsRemote(),
 				Dst: sp.Dst,
 			},
@@ -109,7 +109,7 @@ func (p *pingProcessor) deliverPendingResponses(
 
 		rsp := pingRsp{
 			MsgMeta: messaging.MsgMeta{
-				ID:    timing.GetIDGenerator().Generate(),
+				ID:    comp.IDGenerator().Generate(),
 				Src:   outPort(comp).AsRemote(),
 				Dst:   pr.Dst,
 				RspTo: pr.OrigMsgID,

--- a/examples/reqtracing/main.go
+++ b/examples/reqtracing/main.go
@@ -74,7 +74,7 @@ func (m *clientMW) send() bool {
 
 	req := readReq{
 		MsgMeta: messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  m.comp.IDGenerator().Generate(),
 			Src: port.AsRemote(),
 			Dst: s.Dst,
 		},
@@ -180,7 +180,7 @@ func (m *serverMW) respond() bool {
 	txn := m.pending[0]
 	port.Send(readRsp{
 		MsgMeta: messaging.MsgMeta{
-			ID:    timing.GetIDGenerator().Generate(),
+			ID:    m.comp.IDGenerator().Generate(),
 			Src:   port.AsRemote(),
 			Dst:   txn.req.Src,
 			RspTo: txn.req.ID,

--- a/examples/tasktree/main.go
+++ b/examples/tasktree/main.go
@@ -31,14 +31,14 @@ type readRsp struct {
 	messaging.MsgMeta
 }
 
-func newReq(src, dst messaging.RemotePort) readReq {
+func newReq(ids timing.IDGenerator, src, dst messaging.RemotePort) readReq {
 	return readReq{MsgMeta: messaging.MsgMeta{
-		ID: timing.GetIDGenerator().Generate(), Src: src, Dst: dst}}
+		ID: ids.Generate(), Src: src, Dst: dst}}
 }
 
-func newRsp(src, dst messaging.RemotePort, rspTo uint64) readRsp {
+func newRsp(ids timing.IDGenerator, src, dst messaging.RemotePort, rspTo uint64) readRsp {
 	return readRsp{MsgMeta: messaging.MsgMeta{
-		ID: timing.GetIDGenerator().Generate(), Src: src, Dst: dst, RspTo: rspTo}}
+		ID: ids.Generate(), Src: src, Dst: dst, RspTo: rspTo}}
 }
 
 // --- Client ---
@@ -69,7 +69,7 @@ func (m *clientMW) send() bool {
 		return false
 	}
 
-	req := newReq(port.AsRemote(), s.Dst)
+	req := newReq(m.comp.IDGenerator(), port.AsRemote(), s.Dst)
 	tracing.TraceReqInitiate(m.comp, req, 0) // root task, no parent
 	port.Send(req)
 	m.inFlight[req.ID] = req
@@ -136,7 +136,7 @@ func (m *cacheMW) forwardDown() bool {
 	tracing.TraceReqReceive(m.comp, upReq) // req_in @ this cache
 
 	// Miss: send a request one level down, parented to the task above.
-	downReq := newReq(bottom.AsRemote(), m.comp.State.DownstreamDst)
+	downReq := newReq(m.comp.IDGenerator(), bottom.AsRemote(), m.comp.State.DownstreamDst)
 	tracing.TraceReqInitiate(m.comp, downReq, tracing.MsgIDAtReceiver(upReq, m.comp))
 	bottom.Send(downReq)
 
@@ -162,7 +162,7 @@ func (m *cacheMW) respondUp() bool {
 
 	tracing.TraceReqFinalize(m.comp, txn.downReq) // close the downstream task
 
-	upRsp := newRsp(top.AsRemote(), txn.upReq.Src, txn.upReq.ID)
+	upRsp := newRsp(m.comp.IDGenerator(), top.AsRemote(), txn.upReq.Src, txn.upReq.ID)
 	top.Send(upRsp)
 	tracing.TraceReqComplete(m.comp, txn.upReq) // close the handling task
 
@@ -191,7 +191,7 @@ func (m *memMW) Tick() bool {
 	req := msg.(readReq)
 
 	tracing.TraceReqReceive(m.comp, req) // req_in @ Memory — a leaf task
-	port.Send(newRsp(port.AsRemote(), req.Src, req.ID))
+	port.Send(newRsp(m.comp.IDGenerator(), port.AsRemote(), req.Src, req.ID))
 	tracing.TraceReqComplete(m.comp, req)
 	port.RetrieveIncoming()
 	return true

--- a/examples/tickingping/sendmw.go
+++ b/examples/tickingping/sendmw.go
@@ -3,7 +3,6 @@ package tickingping
 import (
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/modeling"
-	"github.com/sarchlab/akita/v5/timing"
 )
 
 // outPort is a helper that returns the "Out" port from the component.
@@ -39,7 +38,7 @@ func (m *sendMW) sendRsp() bool {
 
 	rsp := pingRsp{
 		MsgMeta: messaging.MsgMeta{
-			ID:    timing.GetIDGenerator().Generate(),
+			ID:    m.comp.IDGenerator().Generate(),
 			Src:   outPort(m.comp).AsRemote(),
 			Dst:   trans.ReqSrc,
 			RspTo: trans.ReqID,
@@ -67,7 +66,7 @@ func (m *sendMW) sendPing() bool {
 
 	pingMsg := pingReq{
 		MsgMeta: messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  m.comp.IDGenerator().Generate(),
 			Src: outPort(m.comp).AsRemote(),
 			Dst: state.PingDst,
 		},

--- a/internal/codec/registry.go
+++ b/internal/codec/registry.go
@@ -16,6 +16,7 @@
 package codec
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -116,6 +117,9 @@ func (r *Registry[T]) Tags() []string {
 func (r *Registry[T]) EncodeSlice(vs []T) (json.RawMessage, error) {
 	payloads := make([]typedPayload, len(vs))
 	for i, v := range vs {
+		if reflect.TypeOf(v) == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr && reflect.ValueOf(v).IsNil()) {
+			return nil, fmt.Errorf("codec: nil %s at index %d", r.label, i)
+		}
 		raw, err := json.Marshal(v)
 		if err != nil {
 			return nil, fmt.Errorf("codec: encode %s %T: %w", r.label, v, err)
@@ -152,6 +156,9 @@ func (r *Registry[T]) DecodeSlice(data json.RawMessage) ([]T, error) {
 
 func (r *Registry[T]) decodeOne(tp typedPayload) (T, error) {
 	var zero T
+	if bytes.Equal(bytes.TrimSpace(tp.Payload), []byte("null")) {
+		return zero, fmt.Errorf("codec: null %s payload", r.label)
+	}
 
 	r.mu.RLock()
 	t, ok := r.types[tp.Type]

--- a/internal/codec/registry_test.go
+++ b/internal/codec/registry_test.go
@@ -98,3 +98,20 @@ func TestRegistry_CheckRoundTrip(t *testing.T) {
 		t.Fatalf("expected CheckRoundTrip to fail for an unregistered type")
 	}
 }
+
+func TestRegistryRejectsNilAndNullValues(t *testing.T) {
+	r := NewRegistry[shape]("shape")
+	r.Register(&rect{})
+	for _, input := range []shape{nil, (*rect)(nil)} {
+		if _, err := r.EncodeSlice([]shape{input}); err == nil {
+			t.Fatal("encoded nil shape")
+		}
+	}
+	payload, err := json.Marshal([]typedPayload{{Type: Tag(&rect{}), Payload: json.RawMessage("null")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.DecodeSlice(payload); err == nil {
+		t.Fatal("null shape silently became a zero-valued shape")
+	}
+}

--- a/internal/sqlitefile/path.go
+++ b/internal/sqlitefile/path.go
@@ -1,0 +1,18 @@
+// Package sqlitefile encodes literal filesystem paths for SQLite connections.
+package sqlitefile
+
+import (
+	"net/url"
+	"path/filepath"
+)
+
+// DSN prevents SQLite from interpreting characters in a filename as connection
+// options and silently opening a different file. Callers may append URI options
+// to the returned string.
+func DSN(filename string) (string, error) {
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return "", err
+	}
+	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}).String(), nil
+}

--- a/mem/README.md
+++ b/mem/README.md
@@ -48,8 +48,11 @@ storage := mem.NewStorage(4 * mem.GB)
 storage.Write(0x1000, []byte{0xDE, 0xAD})
 
 // Read data
-data, err := storage.Read(0x1000, 2)
+data := storage.Read(0x1000, 2)
 ```
+
+Empty or invalid ranges panic before allocation or mutation. A managed
+simulation contains that panic and becomes terminally failed.
 
 A `Storage` can be registered with the simulation as shared state via
 `NewStorageResource(name, storage)`, making its contents reachable by name

--- a/mem/acceptancetests/checkpointresume/id_fixture_test.go
+++ b/mem/acceptancetests/checkpointresume/id_fixture_test.go
@@ -1,0 +1,4 @@
+package checkpointresume
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/acceptancetests/checkpointresume/id_fixture_test.go
+++ b/mem/acceptancetests/checkpointresume/id_fixture_test.go
@@ -1,4 +1,5 @@
 package checkpointresume
+
 import "github.com/sarchlab/akita/v5/timing"
 
 var testIDs = timing.NewIDGenerator()

--- a/mem/acceptancetests/checkpointresume/resume_test.go
+++ b/mem/acceptancetests/checkpointresume/resume_test.go
@@ -110,7 +110,7 @@ func (m *driverMW) sendNext() bool {
 		}
 		idx := st.WritesSent
 		req := memprotocol.WriteReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = port.AsRemote()
 		req.Dst = m.d.lowModule.AsRemote()
 		req.Address = addressForOp(idx)
@@ -136,7 +136,7 @@ func (m *driverMW) sendNext() bool {
 		}
 		idx := st.ReadsSent
 		req := memprotocol.ReadReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = port.AsRemote()
 		req.Dst = m.d.lowModule.AsRemote()
 		req.Address = addressForOp(idx)
@@ -184,7 +184,10 @@ func buildDriver(reg modeling.Registrar, lowModule messaging.Port) *driver {
 // and an ideal memory controller wired over a direct connection. The connection
 // is registered so its round-robin cursor is checkpointed too.
 func buildSim() (*simulation.Simulation, *driver) {
-	sim := simulation.MakeBuilder().WithoutMonitoring().Build()
+	sim, err := simulation.MakeBuilder().WithoutMonitoring().Build()
+	if err != nil {
+		panic(err)
+	}
 
 	dramSpec := idealmemcontroller.DefaultSpec()
 	dramSpec.Capacity = 1 * mem.MB

--- a/mem/acceptancetests/dram/test.go
+++ b/mem/acceptancetests/dram/test.go
@@ -34,7 +34,10 @@ func setupTest() (*simulation.Simulation, timing.Engine, *memaccessagent.MemAcce
 		simBuilder = simBuilder.WithVisTracingOnStart()
 	}
 
-	s := simBuilder.Build()
+	s, err := simBuilder.Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := s.GetEngine()
 
 	conn := directconnection.MakeBuilder().

--- a/mem/acceptancetests/dram/test.go
+++ b/mem/acceptancetests/dram/test.go
@@ -119,5 +119,7 @@ func main() {
 		panic("more requests to send")
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/mem/acceptancetests/idealmemcontroller/test.go
+++ b/mem/acceptancetests/idealmemcontroller/test.go
@@ -122,5 +122,7 @@ func main() {
 		panic("more requests to send")
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/mem/acceptancetests/idealmemcontroller/test.go
+++ b/mem/acceptancetests/idealmemcontroller/test.go
@@ -35,7 +35,10 @@ func setupTest() (*simulation.Simulation, timing.Engine, *memaccessagent.MemAcce
 		simBuilder = simBuilder.WithVisTracingOnStart()
 	}
 
-	s := simBuilder.Build()
+	s, err := simBuilder.Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := s.GetEngine()
 
 	conn := directconnection.MakeBuilder().

--- a/mem/acceptancetests/memaccessagent/middleware.go
+++ b/mem/acceptancetests/memaccessagent/middleware.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -166,7 +165,7 @@ func (m *agentMiddleware) doRead() bool {
 	}
 
 	readReq := memprotocol.ReadReq{}
-	readReq.ID = timing.GetIDGenerator().Generate()
+	readReq.ID = m.agent.IDGenerator().Generate()
 	readReq.Src = m.memPort().AsRemote()
 	readReq.Dst = m.agent.LowModule.AsRemote()
 	readReq.Address = address
@@ -249,7 +248,7 @@ func (m *agentMiddleware) doWrite() bool {
 
 	writeData := uint32ToBytes(data)
 	writeReq := memprotocol.WriteReq{}
-	writeReq.ID = timing.GetIDGenerator().Generate()
+	writeReq.ID = m.agent.IDGenerator().Generate()
 	writeReq.Src = m.memPort().AsRemote()
 	writeReq.Dst = m.agent.LowModule.AsRemote()
 	writeReq.Address = address

--- a/mem/acceptancetests/pagemigration/migrationcontroller.go
+++ b/mem/acceptancetests/pagemigration/migrationcontroller.go
@@ -255,7 +255,7 @@ func (m *migMW) beginMigration() {
 
 	// Open a parent task spanning the whole migration so the control phases nest
 	// under it in the trace.
-	state.MigTaskID = timing.GetIDGenerator().Generate()
+	state.MigTaskID = m.ctrl.IDGenerator().Generate()
 	tracing.StartTask(m.ctrl, tracing.TaskStart{
 		ID:       state.MigTaskID,
 		Kind:     "migration",
@@ -277,7 +277,7 @@ func (m *migMW) startPhaseTask(phase migPhase) {
 	}
 
 	name := phaseName(phase)
-	state.PhaseTaskID = timing.GetIDGenerator().Generate()
+	state.PhaseTaskID = m.ctrl.IDGenerator().Generate()
 	tracing.StartTask(m.ctrl, tracing.TaskStart{
 		ID:       state.PhaseTaskID,
 		ParentID: state.MigTaskID,
@@ -330,7 +330,7 @@ func (m *migMW) runControlPhase(
 		}
 
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = m.ctrl.IDGenerator().Generate()
 		req.Src = m.ctrlPort().AsRemote()
 		req.Dst = targets[state.SendCursor]
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -404,7 +404,7 @@ func (m *migMW) tickCopying() bool {
 		SrcSide:    "inside",
 		DstSide:    "outside",
 	}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = m.ctrl.IDGenerator().Generate()
 	req.Src = m.moverPort().AsRemote()
 	req.Dst = m.ctrl.moverDst
 	req.TrafficClass = "datamoverprotocol.DataMoveRequest"

--- a/mem/acceptancetests/pagemigration/test.go
+++ b/mem/acceptancetests/pagemigration/test.go
@@ -122,7 +122,10 @@ func setupTest(seed int64) (
 		simBuilder = simBuilder.WithVisTracingOnStart()
 	}
 
-	s := simBuilder.Build()
+	s, err := simBuilder.Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := s.GetEngine()
 
 	shared := buildSharedHierarchy(s)

--- a/mem/acceptancetests/pagemigration/test.go
+++ b/mem/acceptancetests/pagemigration/test.go
@@ -583,5 +583,7 @@ func main() {
 			"Completed %d page migrations.\n", migCtrl.State.NumMigrations)
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/mem/acceptancetests/sharedl2vm/test.go
+++ b/mem/acceptancetests/sharedl2vm/test.go
@@ -503,5 +503,7 @@ func main() {
 		"All %d agents completed %d reads and %d writes each.\n",
 		numAgents, *numAccessFlag, *numAccessFlag)
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/mem/acceptancetests/sharedl2vm/test.go
+++ b/mem/acceptancetests/sharedl2vm/test.go
@@ -90,7 +90,10 @@ func setupTest(seed int64) (*simulation.Simulation, timing.Engine, []agentChain)
 		simBuilder = simBuilder.WithVisTracingOnStart()
 	}
 
-	s := simBuilder.Build()
+	s, err := simBuilder.Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := s.GetEngine()
 
 	shared := buildSharedHierarchy(s)

--- a/mem/acceptancetests/virtualmem/test.go
+++ b/mem/acceptancetests/virtualmem/test.go
@@ -44,10 +44,19 @@ func setupTest() (*simulation.Simulation, timing.Engine, *memaccessagent.MemAcce
 		simBuilder = simBuilder.WithVisTracingOnStart()
 	}
 
-	s := simBuilder.Build()
+	s, err := simBuilder.Build()
+	if err != nil {
+		panic(err)
+	}
 
 	engine := s.GetEngine()
 
+	agent = buildTestComponents(s)
+	return s, engine, agent
+}
+
+func buildTestComponents(s *simulation.Simulation) *memaccessagent.MemAccessAgent {
+	var agent *memaccessagent.MemAccessAgent
 	l1Cache, l2Cache, memCtrl := buildMemoryHierarchy(s)
 	ioMMU, tlb, l2TLB := buildTranslationHierarchy(s)
 
@@ -95,7 +104,7 @@ func setupTest() (*simulation.Simulation, timing.Engine, *memaccessagent.MemAcce
 		at, tlb, l2TLB, ioMMU,
 		l1Cache, l2Cache, memCtrl)
 
-	return s, engine, agent
+	return agent
 }
 
 // buildROB builds a reorder buffer that forwards every access to bottomUnit

--- a/mem/acceptancetests/virtualmem/test.go
+++ b/mem/acceptancetests/virtualmem/test.go
@@ -343,5 +343,7 @@ func main() {
 		panic("more requests to send")
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/mem/acceptancetests/virtualmemcheckpoint/driver_test.go
+++ b/mem/acceptancetests/virtualmemcheckpoint/driver_test.go
@@ -128,7 +128,7 @@ func (m *driverMW) sendNext() bool {
 		}
 		idx := st.WritesSent
 		req := memprotocol.WriteReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = port.AsRemote()
 		req.Dst = m.d.lowModule.AsRemote()
 		req.Address = addressForOp(idx)
@@ -154,7 +154,7 @@ func (m *driverMW) sendNext() bool {
 		}
 		idx := st.ReadsSent
 		req := memprotocol.ReadReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = port.AsRemote()
 		req.Dst = m.d.lowModule.AsRemote()
 		req.Address = addressForOp(idx)

--- a/mem/acceptancetests/virtualmemcheckpoint/id_fixture_test.go
+++ b/mem/acceptancetests/virtualmemcheckpoint/id_fixture_test.go
@@ -1,4 +1,5 @@
 package virtualmemcheckpoint
+
 import "github.com/sarchlab/akita/v5/timing"
 
 var testIDs = timing.NewIDGenerator()

--- a/mem/acceptancetests/virtualmemcheckpoint/id_fixture_test.go
+++ b/mem/acceptancetests/virtualmemcheckpoint/id_fixture_test.go
@@ -1,0 +1,4 @@
+package virtualmemcheckpoint
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/acceptancetests/virtualmemcheckpoint/resume_test.go
+++ b/mem/acceptancetests/virtualmemcheckpoint/resume_test.go
@@ -32,7 +32,10 @@ func cleanup(sim *simulation.Simulation) {
 // table. Every component, port, connection, and the page table is registered,
 // so all of it is part of the checkpoint inventory.
 func buildSim() (*simulation.Simulation, *driver) {
-	sim := simulation.MakeBuilder().WithoutMonitoring().Build()
+	sim, err := simulation.MakeBuilder().WithoutMonitoring().Build()
+	if err != nil {
+		panic(err)
+	}
 
 	l1Cache, l2Cache, memCtrl := buildMemoryHierarchy(sim)
 	ioMMU, itlb, l2TLB := buildTranslationHierarchy(sim)

--- a/mem/acceptancetests/writearoundcache/test.go
+++ b/mem/acceptancetests/writearoundcache/test.go
@@ -158,5 +158,7 @@ func main() {
 		panic("more requests to send")
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/mem/acceptancetests/writearoundcache/test.go
+++ b/mem/acceptancetests/writearoundcache/test.go
@@ -35,7 +35,10 @@ func buildEnvironment() (*simulation.Simulation, timing.Engine, *memaccessagent.
 		simBuilder = simBuilder.WithVisTracingOnStart()
 	}
 
-	s := simBuilder.Build()
+	s, err := simBuilder.Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := s.GetEngine()
 
 	conn := directconnection.MakeBuilder().

--- a/mem/acceptancetests/writebackcache/test.go
+++ b/mem/acceptancetests/writebackcache/test.go
@@ -36,7 +36,10 @@ func buildEnvironment() (*simulation.Simulation, timing.Engine, *memaccessagent.
 		simBuilder = simBuilder.WithVisTracingOnStart()
 	}
 
-	s := simBuilder.Build()
+	s, err := simBuilder.Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := s.GetEngine()
 
 	conn := directconnection.MakeBuilder().

--- a/mem/acceptancetests/writebackcache/test.go
+++ b/mem/acceptancetests/writebackcache/test.go
@@ -155,5 +155,7 @@ func main() {
 		panic("more requests to send")
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/mem/acceptancetests/writeevictcache/test.go
+++ b/mem/acceptancetests/writeevictcache/test.go
@@ -158,5 +158,7 @@ func main() {
 		panic("more requests to send")
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/mem/acceptancetests/writeevictcache/test.go
+++ b/mem/acceptancetests/writeevictcache/test.go
@@ -35,7 +35,10 @@ func buildEnvironment() (*simulation.Simulation, timing.Engine, *memaccessagent.
 		simBuilder = simBuilder.WithVisTracingOnStart()
 	}
 
-	s := simBuilder.Build()
+	s, err := simBuilder.Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := s.GetEngine()
 
 	conn := directconnection.MakeBuilder().

--- a/mem/acceptancetests/writethroughcache/test.go
+++ b/mem/acceptancetests/writethroughcache/test.go
@@ -158,5 +158,7 @@ func main() {
 		panic("more requests to send")
 	}
 
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 }

--- a/mem/acceptancetests/writethroughcache/test.go
+++ b/mem/acceptancetests/writethroughcache/test.go
@@ -35,7 +35,10 @@ func buildEnvironment() (*simulation.Simulation, timing.Engine, *memaccessagent.
 		simBuilder = simBuilder.WithVisTracingOnStart()
 	}
 
-	s := simBuilder.Build()
+	s, err := simBuilder.Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := s.GetEngine()
 
 	conn := directconnection.MakeBuilder().

--- a/mem/cache/writeback/bankstage.go
+++ b/mem/cache/writeback/bankstage.go
@@ -4,7 +4,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/cache"
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -121,7 +120,7 @@ func (s *bankStage) acceptIntoPipeline(next *State, spec Spec, transIdx int) {
 	// transaction that visits the bank more than once (e.g. evict then fill)
 	// opens one subtask per visit, each closed in finishBank.
 	if trans.hasReqMeta() {
-		pid := timing.GetIDGenerator().Generate()
+		pid := s.cache.comp.IDGenerator().Generate()
 		trans.BankPID = pid
 		tracing.StartTask(s.cache.comp, tracing.TaskStart{
 			ID:       pid,
@@ -202,11 +201,8 @@ func (s *bankStage) finalizeReadHit(transIdx int, trans *transactionState) bool 
 	_, offset := getCacheLineID(addr, spec.Log2BlockSize)
 	nextBlock := &next.DirectoryState.Sets[trans.BlockSetID].Blocks[trans.BlockWayID]
 
-	data, err := s.cache.storage.Read(
+	data := s.cache.storage.Read(
 		nextBlock.CacheAddress+offset, trans.ReadAccessByteSize)
-	if err != nil {
-		panic(err)
-	}
 
 	trans.Removed = true
 
@@ -215,7 +211,7 @@ func (s *bankStage) finalizeReadHit(transIdx int, trans *transactionState) bool 
 	nextBlock.ReadCount--
 
 	dataReady := memprotocol.DataReadyRsp{}
-	dataReady.ID = timing.GetIDGenerator().Generate()
+	dataReady.ID = s.cache.comp.IDGenerator().Generate()
 	dataReady.Src = s.cache.topPort().AsRemote()
 	dataReady.Dst = trans.ReadMeta.Src
 	dataReady.RspTo = trans.ReadMeta.ID
@@ -254,7 +250,7 @@ func (s *bankStage) finalizeWriteHit(transIdx int, trans *transactionState) bool
 	next.BankInflightTransCounts[s.bankID]--
 
 	done := memprotocol.WriteDoneRsp{}
-	done.ID = timing.GetIDGenerator().Generate()
+	done.ID = s.cache.comp.IDGenerator().Generate()
 	done.Src = s.cache.topPort().AsRemote()
 	done.Dst = trans.WriteMeta.Src
 	done.RspTo = trans.WriteMeta.ID
@@ -274,11 +270,8 @@ func (s *bankStage) writeData(
 	offset uint64,
 	log2BlockSize uint64,
 ) []bool {
-	data, err := s.cache.storage.Read(
+	data := s.cache.storage.Read(
 		block.CacheAddress, 1<<log2BlockSize)
-	if err != nil {
-		panic(err)
-	}
 
 	dirtyMask := block.DirtyMask
 	if dirtyMask == nil {
@@ -293,10 +286,7 @@ func (s *bankStage) writeData(
 		}
 	}
 
-	err = s.cache.storage.Write(block.CacheAddress, data)
-	if err != nil {
-		panic(err)
-	}
+	s.cache.storage.Write(block.CacheAddress, data)
 
 	return dirtyMask
 }
@@ -316,10 +306,8 @@ func (s *bankStage) finalizeBankWriteFetched(
 
 	mshrBuf.PushTyped(transIdx)
 
-	err := s.cache.storage.Write(nextBlock.CacheAddress, trans.MSHRData)
-	if err != nil {
-		panic(err)
-	}
+	s.cache.storage.Write(nextBlock.CacheAddress, trans.MSHRData)
+
 	nextBlock.IsLocked = false
 	nextBlock.IsValid = true
 
@@ -342,11 +330,8 @@ func (s *bankStage) finalizeBankEviction(
 		return false
 	}
 
-	data, err := s.cache.storage.Read(
+	data := s.cache.storage.Read(
 		trans.VictimCacheAddress, 1<<spec.Log2BlockSize)
-	if err != nil {
-		panic(err)
-	}
 
 	trans.EvictingData = data
 

--- a/mem/cache/writeback/bankstage_test.go
+++ b/mem/cache/writeback/bankstage_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Bank Stage", func() {
 			storage.Write(0x40, []byte{1, 2, 3, 4, 5, 6, 7, 8})
 
 			read := memprotocol.ReadReq{}
-			read.ID = timing.GetIDGenerator().Generate()
+			read.ID = testIDs.Generate()
 			read.Src = messaging.RemotePort("Agent")
 			read.Address = 0x104
 			read.AccessByteSize = 4
@@ -164,7 +164,7 @@ var _ = Describe("Bank Stage", func() {
 			block.IsLocked = true
 
 			write := memprotocol.WriteReq{}
-			write.ID = timing.GetIDGenerator().Generate()
+			write.ID = testIDs.Generate()
 			write.Src = messaging.RemotePort("Agent")
 			write.Address = 0x104
 			write.Data = []byte{5, 6, 7, 8}
@@ -200,7 +200,7 @@ var _ = Describe("Bank Stage", func() {
 			ret := bs.Tick()
 
 			Expect(ret).To(BeTrue())
-			data, _ := storage.Read(0x44, 4)
+			data := storage.Read(0x44, 4)
 			Expect(data).To(Equal([]byte{5, 6, 7, 8}))
 			next := &m.comp.State
 			block := &next.DirectoryState.Sets[0].Blocks[0]
@@ -252,7 +252,7 @@ var _ = Describe("Bank Stage", func() {
 
 			Expect(ret).To(BeTrue())
 			next := &m.comp.State
-			writtenData, _ := storage.Read(0x40, 64)
+			writtenData := storage.Read(0x40, 64)
 			Expect(writtenData).To(Equal(next.Transactions[0].MSHRData))
 			block := &next.DirectoryState.Sets[0].Blocks[0]
 			Expect(block.IsLocked).To(BeFalse())

--- a/mem/cache/writeback/control_behavior_test.go
+++ b/mem/cache/writeback/control_behavior_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Write-Back Cache control behavior", func() {
 
 	makeRead := func(addr uint64) memprotocol.ReadReq {
 		req := memprotocol.ReadReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.Address = addr
@@ -80,7 +80,7 @@ var _ = Describe("Write-Back Cache control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Ctrl")
 		req.Dst = ctrlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -97,7 +97,7 @@ var _ = Describe("Write-Back Cache control behavior", func() {
 			data[i] = byte(i + 1)
 		}
 		rsp := memprotocol.DataReadyRsp{Data: data}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = messaging.RemotePort("LowerCache")
 		rsp.Dst = botPort.AsRemote()
 		rsp.RspTo = read.ID
@@ -130,7 +130,7 @@ var _ = Describe("Write-Back Cache control behavior", func() {
 		for i := range data {
 			data[i] = fill
 		}
-		Expect(storage.Write(block.CacheAddress, data)).To(Succeed())
+		storage.Write(block.CacheAddress, data)
 
 		return setID
 	}
@@ -447,7 +447,7 @@ var _ = Describe("Write-Back Cache control behavior", func() {
 				if w, ok := out.(memprotocol.WriteReq); ok {
 					botWrites = append(botWrites, w)
 					done := memprotocol.WriteDoneRsp{}
-					done.ID = timing.GetIDGenerator().Generate()
+					done.ID = testIDs.Generate()
 					done.Src = messaging.RemotePort("LowerCache")
 					done.Dst = botPort.AsRemote()
 					done.RspTo = w.ID

--- a/mem/cache/writeback/ctrlmiddleware.go
+++ b/mem/cache/writeback/ctrlmiddleware.go
@@ -362,7 +362,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/cache/writeback/directorystage.go
+++ b/mem/cache/writeback/directorystage.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/vm"
 
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -653,7 +652,7 @@ func (ds *directoryStage) needEviction(victim *cache.BlockState) bool {
 func (ds *directoryStage) startDirPipeline(transIdx int) {
 	trans := &ds.cache.comp.State.Transactions[transIdx]
 
-	pid := timing.GetIDGenerator().Generate()
+	pid := ds.cache.comp.IDGenerator().Generate()
 	trans.DirPipelinePID = pid
 
 	tracing.StartTask(ds.cache.comp, tracing.TaskStart{

--- a/mem/cache/writeback/directorystage_test.go
+++ b/mem/cache/writeback/directorystage_test.go
@@ -79,7 +79,7 @@ var _ = Describe("DirectoryStage", func() {
 	Context("read", func() {
 		BeforeEach(func() {
 			read := memprotocol.ReadReq{}
-			read.ID = timing.GetIDGenerator().Generate()
+			read.ID = testIDs.Generate()
 			read.Address = 0x100
 			read.PID = 1
 			read.AccessByteSize = 64
@@ -177,7 +177,7 @@ var _ = Describe("DirectoryStage", func() {
 	Context("write", func() {
 		BeforeEach(func() {
 			write := memprotocol.WriteReq{}
-			write.ID = timing.GetIDGenerator().Generate()
+			write.ID = testIDs.Generate()
 			write.Address = 0x100
 			write.PID = 1
 			write.TrafficBytes = 12

--- a/mem/cache/writeback/flusher.go
+++ b/mem/cache/writeback/flusher.go
@@ -4,7 +4,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
 	"github.com/sarchlab/akita/v5/mem/vm"
 
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 
 	// blockRef is a set+way pair referencing a block in the directory.
@@ -230,7 +229,7 @@ func (f *flusher) finalizeFlushing() bool {
 	}
 
 	rsp := memcontrolprotocol.Rsp{Command: memcontrolprotocol.CmdFlush, Success: true}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = f.pipeline.comp.IDGenerator().Generate()
 	rsp.Src = f.ctrlPort().AsRemote()
 	rsp.Dst = next.ProcessingFlush.MsgMeta.Src
 	rsp.RspTo = next.ProcessingFlush.MsgMeta.ID

--- a/mem/cache/writeback/flusher_test.go
+++ b/mem/cache/writeback/flusher_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Flusher", func() {
 			m.comp.State.CacheState = int(cacheStatePaused)
 
 			req := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdFlush}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.TrafficClass = "memcontrolprotocol.Req"
 			controlPort.Deliver(req)
 
@@ -126,7 +126,7 @@ var _ = Describe("Flusher", func() {
 			next.HasProcessingFlush = true
 			next.ProcessingFlush = flushReqState{
 				MsgMeta: messaging.MsgMeta{
-					ID: timing.GetIDGenerator().Generate(),
+					ID: testIDs.Generate(),
 				},
 			}
 
@@ -141,7 +141,7 @@ var _ = Describe("Flusher", func() {
 			next.HasProcessingFlush = true
 			next.ProcessingFlush = flushReqState{
 				MsgMeta: messaging.MsgMeta{
-					ID: timing.GetIDGenerator().Generate(),
+					ID: testIDs.Generate(),
 				},
 			}
 
@@ -162,7 +162,7 @@ var _ = Describe("Flusher", func() {
 			next := &m.comp.State
 			next.CacheState = int(cacheStateFlushing)
 			next.HasProcessingFlush = true
-			flushID := timing.GetIDGenerator().Generate()
+			flushID := testIDs.Generate()
 			next.ProcessingFlush = flushReqState{
 				MsgMeta: messaging.MsgMeta{
 					ID:  flushID,
@@ -191,7 +191,7 @@ var _ = Describe("Flusher", func() {
 			m.comp.State.CacheState = int(cacheStatePaused)
 
 			req := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdFlush}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.TrafficClass = "memcontrolprotocol.Req"
 
 			controlPort.Deliver(req)

--- a/mem/cache/writeback/id_fixture_test.go
+++ b/mem/cache/writeback/id_fixture_test.go
@@ -1,0 +1,4 @@
+package writeback
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/cache/writeback/id_mock_test.go
+++ b/mem/cache/writeback/id_mock_test.go
@@ -1,0 +1,4 @@
+package writeback
+import "github.com/sarchlab/akita/v5/timing"
+func (m *MockEngine) IDGenerator() timing.IDGenerator { return mockIDs }
+var mockIDs = timing.NewIDGenerator()

--- a/mem/cache/writeback/milestone_test.go
+++ b/mem/cache/writeback/milestone_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Write-Back Cache milestones", func() {
 			})
 
 			read := memprotocol.ReadReq{}
-			read.ID = timing.GetIDGenerator().Generate()
+			read.ID = testIDs.Generate()
 			read.Src = agentPort.AsRemote()
 			read.Dst = topPort.AsRemote()
 			read.Address = 0x10004
@@ -215,7 +215,7 @@ var _ = Describe("Write-Back Cache milestones", func() {
 			})
 
 			read := memprotocol.ReadReq{}
-			read.ID = timing.GetIDGenerator().Generate()
+			read.ID = testIDs.Generate()
 			read.Src = agentPort.AsRemote()
 			read.Dst = topPort.AsRemote()
 			read.Address = 0x10004

--- a/mem/cache/writeback/mshrstage.go
+++ b/mem/cache/writeback/mshrstage.go
@@ -2,7 +2,6 @@ package writeback
 
 import (
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -102,7 +101,7 @@ func (s *mshrStage) respondRead(
 	_, offset := getCacheLineID(trans.ReadAddress, log2BlockSize)
 	respondData := data[offset : offset+trans.ReadAccessByteSize]
 	dataReady := memprotocol.DataReadyRsp{}
-	dataReady.ID = timing.GetIDGenerator().Generate()
+	dataReady.ID = s.cache.comp.IDGenerator().Generate()
 	dataReady.Src = s.cache.topPort().AsRemote()
 	dataReady.Dst = trans.ReadMeta.Src
 	dataReady.RspTo = trans.ReadMeta.ID
@@ -126,7 +125,7 @@ func (s *mshrStage) respondRead(
 
 func (s *mshrStage) respondWrite(trans *transactionState) {
 	writeDoneRsp := memprotocol.WriteDoneRsp{}
-	writeDoneRsp.ID = timing.GetIDGenerator().Generate()
+	writeDoneRsp.ID = s.cache.comp.IDGenerator().Generate()
 	writeDoneRsp.Src = s.cache.topPort().AsRemote()
 	writeDoneRsp.Dst = trans.WriteMeta.Src
 	writeDoneRsp.RspTo = trans.WriteMeta.ID

--- a/mem/cache/writeback/mshrstage_test.go
+++ b/mem/cache/writeback/mshrstage_test.go
@@ -86,7 +86,7 @@ var _ = Describe("MSHR Stage", func() {
 
 	It("should stall if topSender is busy", func() {
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Address = 0x104
 		read.AccessByteSize = 4
 		read.TrafficBytes = 12
@@ -131,7 +131,7 @@ var _ = Describe("MSHR Stage", func() {
 
 	It("should send data ready to top", func() {
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = messaging.RemotePort("Agent")
 		read.Address = 0x104
 		read.AccessByteSize = 4

--- a/mem/cache/writeback/reset_leak_test.go
+++ b/mem/cache/writeback/reset_leak_test.go
@@ -63,7 +63,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	// fetch ReadReq out the Bottom port. We never answer it, so req_in, the
 	// fetch req_out, and the directory-pipeline subtask stay open.
 	read := memprotocol.ReadReq{}
-	read.ID = timing.GetIDGenerator().Generate()
+	read.ID = testIDs.Generate()
 	read.Src = messaging.RemotePort("Agent")
 	read.Dst = topPort.AsRemote()
 	read.Address = 0x10000
@@ -95,7 +95,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	// Reset while the fetch is in flight.
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = ctrlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/cache/writeback/topparser.go
+++ b/mem/cache/writeback/topparser.go
@@ -2,7 +2,6 @@ package writeback
 
 import (
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -27,7 +26,7 @@ func (p *topParser) Tick() bool {
 	}
 
 	trans := transactionState{
-		ID: timing.GetIDGenerator().Generate(),
+		ID: p.cache.comp.IDGenerator().Generate(),
 	}
 
 	switch msg := msg.(type) {

--- a/mem/cache/writeback/topparser_test.go
+++ b/mem/cache/writeback/topparser_test.go
@@ -82,7 +82,7 @@ var _ = Describe("TopParser", func() {
 
 	It("should parse read from top", func() {
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Address = 0x100
 		read.AccessByteSize = 64
 		read.TrafficBytes = 12
@@ -102,7 +102,7 @@ var _ = Describe("TopParser", func() {
 
 	It("should parse write from top", func() {
 		write := memprotocol.WriteReq{}
-		write.ID = timing.GetIDGenerator().Generate()
+		write.ID = testIDs.Generate()
 		write.Address = 0x100
 		write.TrafficBytes = 12
 		write.TrafficClass = "memprotocol.WriteReq"

--- a/mem/cache/writeback/writebackcache_test.go
+++ b/mem/cache/writeback/writebackcache_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		})
 
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = agentPort.AsRemote()
 		read.Dst = cacheComp.GetPortByName("Top").AsRemote()
 		read.Address = 0x10004
@@ -162,7 +162,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		})
 
 		write := memprotocol.WriteReq{}
-		write.ID = timing.GetIDGenerator().Generate()
+		write.ID = testIDs.Generate()
 		write.Src = agentPort.AsRemote()
 		write.Dst = cacheComp.GetPortByName("Top").AsRemote()
 		write.Address = 0x10004
@@ -179,7 +179,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		// Re-read state after engine run
 		postState := m.comp.State
 		postBlock := &postState.DirectoryState.Sets[setID].Blocks[0]
-		retData, _ := m.storage.Read(postBlock.CacheAddress+0x4, 4)
+		retData := m.storage.Read(postBlock.CacheAddress+0x4, 4)
 		Expect(retData).To(Equal(write.Data))
 		Expect(postBlock.IsValid).To(BeTrue())
 		Expect(postBlock.IsDirty).To(BeTrue())
@@ -198,7 +198,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		})
 
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = agentPort.AsRemote()
 		read.Dst = cacheComp.GetPortByName("Top").AsRemote()
 		read.Address = 0x10004
@@ -228,7 +228,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		})
 
 		read1 := memprotocol.ReadReq{}
-		read1.ID = timing.GetIDGenerator().Generate()
+		read1.ID = testIDs.Generate()
 		read1.Src = agentPort.AsRemote()
 		read1.Dst = cacheComp.GetPortByName("Top").AsRemote()
 		read1.Address = 0x10004
@@ -238,7 +238,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		cacheComp.GetPortByName("Top").Deliver(read1)
 
 		read2 := memprotocol.ReadReq{}
-		read2.ID = timing.GetIDGenerator().Generate()
+		read2.ID = testIDs.Generate()
 		read2.Src = agentPort.AsRemote()
 		read2.Dst = cacheComp.GetPortByName("Top").AsRemote()
 		read2.Address = 0x10008
@@ -272,7 +272,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 			1, 2, 3, 4, 5, 6, 7, 8,
 		}
 		write := memprotocol.WriteReq{}
-		write.ID = timing.GetIDGenerator().Generate()
+		write.ID = testIDs.Generate()
 		write.Src = agentPort.AsRemote()
 		write.Dst = cacheComp.GetPortByName("Top").AsRemote()
 		write.Address = 0x10000
@@ -282,7 +282,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		cacheComp.GetPortByName("Top").Deliver(write)
 
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = agentPort.AsRemote()
 		read.Dst = cacheComp.GetPortByName("Top").AsRemote()
 		read.Address = 0x10004
@@ -329,7 +329,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		m.comp.State = state
 
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = agentPort.AsRemote()
 		read.Dst = cacheComp.GetPortByName("Top").AsRemote()
 		read.Address = 0x10004
@@ -348,7 +348,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 
 	It("should flush", func() {
 		write1 := memprotocol.WriteReq{}
-		write1.ID = timing.GetIDGenerator().Generate()
+		write1.ID = testIDs.Generate()
 		write1.Src = agentPort.AsRemote()
 		write1.Dst = cacheComp.GetPortByName("Top").AsRemote()
 		write1.Address = 0x100000
@@ -358,7 +358,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		cacheComp.GetPortByName("Top").Deliver(write1)
 
 		write2 := memprotocol.WriteReq{}
-		write2.ID = timing.GetIDGenerator().Generate()
+		write2.ID = testIDs.Generate()
 		write2.Src = agentPort.AsRemote()
 		write2.Dst = cacheComp.GetPortByName("Top").AsRemote()
 		write2.Address = 0x100000
@@ -373,7 +373,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 
 		// Flush is a conditional verb: pause first so it is legal.
 		pause := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdPause}
-		pause.ID = timing.GetIDGenerator().Generate()
+		pause.ID = testIDs.Generate()
 		pause.Src = controlAgentPort.AsRemote()
 		pause.Dst = cacheComp.GetPortByName("Control").AsRemote()
 		pause.TrafficClass = "memcontrolprotocol.Req"
@@ -387,7 +387,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		Expect(pauseRsp.(memcontrolprotocol.Rsp).Success).To(BeTrue())
 
 		flush := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdFlush}
-		flush.ID = timing.GetIDGenerator().Generate()
+		flush.ID = testIDs.Generate()
 		flush.Src = controlAgentPort.AsRemote()
 		flush.Dst = cacheComp.GetPortByName("Control").AsRemote()
 		flush.TrafficClass = "memcontrolprotocol.Req"
@@ -401,8 +401,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		Expect(rsp.(memcontrolprotocol.Rsp).Success).To(BeTrue())
 
 		// The dirty block's data reached DRAM.
-		flushed, err := dramStorage.Read(0x100000, 4)
-		Expect(err).ToNot(HaveOccurred())
+		flushed := dramStorage.Read(0x100000, 4)
 		Expect(flushed).To(Equal([]byte{1, 2, 3, 4}))
 	})
 })

--- a/mem/cache/writeback/writebufferstage.go
+++ b/mem/cache/writeback/writebufferstage.go
@@ -5,7 +5,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/mem/vm"
 
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -139,7 +138,7 @@ func (wb *writeBufferStage) fetchFromBottom(
 	spec := wb.cache.comp.Spec()
 	lowModulePort := wb.cache.findPort(trans.FetchAddress)
 	read := memprotocol.ReadReq{}
-	read.ID = timing.GetIDGenerator().Generate()
+	read.ID = wb.cache.comp.IDGenerator().Generate()
 	read.Src = wb.cache.bottomPort().AsRemote()
 	read.Dst = lowModulePort
 	read.PID = trans.FetchPID
@@ -244,7 +243,7 @@ func (wb *writeBufferStage) write() bool {
 
 	lowModulePort := wb.cache.findPort(trans.EvictingAddr)
 	write := memprotocol.WriteReq{}
-	write.ID = timing.GetIDGenerator().Generate()
+	write.ID = wb.cache.comp.IDGenerator().Generate()
 	write.Src = wb.cache.bottomPort().AsRemote()
 	write.Dst = lowModulePort
 	write.PID = trans.EvictingPID

--- a/mem/cache/writeback/writebufferstage_test.go
+++ b/mem/cache/writeback/writebufferstage_test.go
@@ -85,7 +85,7 @@ var _ = Describe("WriteBufferStage", func() {
 	Context("processing new writeBufferFetch transactions", func() {
 		It("should fetch from bottom", func() {
 			read := memprotocol.ReadReq{}
-			read.ID = timing.GetIDGenerator().Generate()
+			read.ID = testIDs.Generate()
 			read.TrafficClass = "memprotocol.ReadReq"
 			trans := transactionState{
 				Action:       writeBufferFetch,
@@ -119,7 +119,7 @@ var _ = Describe("WriteBufferStage", func() {
 			next.InflightFetchIndices = []int{10, 11, 12, 13}
 
 			read := memprotocol.ReadReq{}
-			read.ID = timing.GetIDGenerator().Generate()
+			read.ID = testIDs.Generate()
 			read.TrafficClass = "memprotocol.ReadReq"
 			trans := transactionState{
 				Action:       writeBufferFetch,
@@ -142,7 +142,7 @@ var _ = Describe("WriteBufferStage", func() {
 	Context("writing evictions", func() {
 		It("should send eviction to bottom", func() {
 			read := memprotocol.ReadReq{}
-			read.ID = timing.GetIDGenerator().Generate()
+			read.ID = testIDs.Generate()
 			read.TrafficClass = "memprotocol.ReadReq"
 			trans := transactionState{
 				EvictingAddr: 0x200,
@@ -188,7 +188,7 @@ var _ = Describe("WriteBufferStage", func() {
 			evictWrite.TrafficClass = "memprotocol.WriteReq"
 
 			read := memprotocol.ReadReq{}
-			read.ID = timing.GetIDGenerator().Generate()
+			read.ID = testIDs.Generate()
 			read.TrafficClass = "memprotocol.ReadReq"
 			trans := transactionState{
 				HasEvictionWriteReq:  true,

--- a/mem/cache/writethroughcache/bankstage.go
+++ b/mem/cache/writethroughcache/bankstage.go
@@ -1,7 +1,6 @@
 package writethroughcache
 
 import (
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -61,7 +60,7 @@ func (s *bankStage) extractFromBuf() bool {
 	// pipeline, so its bank read/write gets its own child bar under the req_in,
 	// mirroring the directory pipeline subtask. The bank latency then shows as
 	// real work rather than an unexplained gap before completion.
-	pid := timing.GetIDGenerator().Generate()
+	pid := s.cache.comp.IDGenerator().Generate()
 	trans.BankTaskID = pid
 	tracing.StartTask(s.cache.comp, tracing.TaskStart{
 		ID:       pid,
@@ -105,11 +104,8 @@ func (s *bankStage) finalizeReadHitTrans(
 	nextBlock := &next.DirectoryState.Sets[trans.BlockSetID].Blocks[trans.BlockWayID]
 	blockSize := uint64(1 << s.cache.comp.Spec().Log2BlockSize)
 
-	data, err := s.cache.storage.Read(
+	data := s.cache.storage.Read(
 		nextBlock.CacheAddress, blockSize)
-	if err != nil {
-		panic(err)
-	}
 
 	nextBlock.ReadCount--
 
@@ -132,10 +128,7 @@ func (s *bankStage) finalizeWriteTrans(
 	nextBlock := &next.DirectoryState.Sets[trans.BlockSetID].Blocks[trans.BlockWayID]
 	blockSize := 1 << s.cache.comp.Spec().Log2BlockSize
 
-	data, err := s.cache.storage.Read(nextBlock.CacheAddress, uint64(blockSize))
-	if err != nil {
-		panic(err)
-	}
+	data := s.cache.storage.Read(nextBlock.CacheAddress, uint64(blockSize))
 
 	offset := trans.WriteAddress - nextBlock.Tag
 
@@ -145,10 +138,7 @@ func (s *bankStage) finalizeWriteTrans(
 		}
 	}
 
-	err = s.cache.storage.Write(nextBlock.CacheAddress, data)
-	if err != nil {
-		panic(err)
-	}
+	s.cache.storage.Write(nextBlock.CacheAddress, data)
 
 	nextBlock.DirtyMask = trans.WriteDirtyMask
 	nextBlock.IsLocked = false
@@ -172,10 +162,7 @@ func (s *bankStage) finalizeWriteFetchedTrans(
 	next := &s.cache.comp.State
 	nextBlock := &next.DirectoryState.Sets[trans.BlockSetID].Blocks[trans.BlockWayID]
 
-	err := s.cache.storage.Write(nextBlock.CacheAddress, trans.Data)
-	if err != nil {
-		panic(err)
-	}
+	s.cache.storage.Write(nextBlock.CacheAddress, trans.Data)
 
 	nextBlock.DirtyMask = trans.WriteFetchedDirtyMask
 	nextBlock.IsLocked = false

--- a/mem/cache/writethroughcache/bankstage_test.go
+++ b/mem/cache/writethroughcache/bankstage_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Bankstage", func() {
 			storage: storage,
 		}
 		c.comp = modeling.NewBuilder[Spec, State, Resources]().
-			WithEngine(nil).
+			WithEngine(timing.NewSerialEngine()).
 			WithFreq(1 * timing.GHz).
 			WithSpec(Spec{
 				BankLatency:      10,
@@ -115,7 +115,7 @@ var _ = Describe("Bankstage", func() {
 			})
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -168,7 +168,7 @@ var _ = Describe("Bankstage", func() {
 			next.DirectoryState.Sets[blockSetID].Blocks[blockWayID].IsValid = true
 
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 64 + 12,
 				TrafficClass: "req",
 			}
@@ -219,7 +219,7 @@ var _ = Describe("Bankstage", func() {
 
 			Expect(madeProgress).To(BeTrue())
 			Expect(next.DirectoryState.Sets[blockSetID].Blocks[blockWayID].IsLocked).To(BeFalse())
-			data, _ := storage.Read(0x400, 64)
+			data := storage.Read(0x400, 64)
 			Expect(data).To(Equal([]byte{
 				0, 0, 0, 0, 0, 0, 0, 0,
 				1, 2, 3, 4, 5, 6, 7, 8,
@@ -283,7 +283,7 @@ var _ = Describe("Bankstage", func() {
 			Expect(madeProgress).To(BeTrue())
 			Expect(next.DirectoryState.Sets[blockSetID].Blocks[blockWayID].IsLocked).To(BeFalse())
 			trans := &next.Transactions[0]
-			data, _ := storage.Read(0x400, 64)
+			data := storage.Read(0x400, 64)
 			Expect(data).To(Equal(trans.Data))
 		})
 
@@ -297,7 +297,7 @@ var _ = Describe("Bankstage", func() {
 				// the coalesced write that depends on the fetcher's
 				// merged fill landing in storage.
 				coalescedWriteMeta = messaging.MsgMeta{
-					ID:           timing.GetIDGenerator().Generate(),
+					ID:           testIDs.Generate(),
 					TrafficBytes: 4 + 12,
 					TrafficClass: "req",
 				}

--- a/mem/cache/writethroughcache/bottomparser_test.go
+++ b/mem/cache/writethroughcache/bottomparser_test.go
@@ -78,13 +78,13 @@ var _ = Describe("Bottom Parser", func() {
 			next := &c.comp.State
 
 			writeToBottomMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
 
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -103,7 +103,7 @@ var _ = Describe("Bottom Parser", func() {
 			)
 
 			done := memprotocol.WriteDoneRsp{}
-			done.ID = timing.GetIDGenerator().Generate()
+			done.ID = testIDs.Generate()
 			done.RspTo = writeToBottomMeta.ID
 			done.TrafficBytes = 4
 			done.TrafficClass = "rsp"
@@ -123,12 +123,12 @@ var _ = Describe("Bottom Parser", func() {
 			next := &c.comp.State
 
 			writeToBottomMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 4 + 12,
 				TrafficClass: "req",
 			}
@@ -153,7 +153,7 @@ var _ = Describe("Bottom Parser", func() {
 			)
 
 			done := memprotocol.WriteDoneRsp{}
-			done.ID = timing.GetIDGenerator().Generate()
+			done.ID = testIDs.Generate()
 			done.RspTo = writeToBottomMeta.ID
 			done.TrafficBytes = 4
 			done.TrafficClass = "rsp"
@@ -182,7 +182,7 @@ var _ = Describe("Bottom Parser", func() {
 			next := &c.comp.State
 
 			readToBottomMeta = messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -198,7 +198,7 @@ var _ = Describe("Bottom Parser", func() {
 				1, 2, 3, 4, 5, 6, 7, 8,
 			}
 			dataReady = memprotocol.DataReadyRsp{}
-			dataReady.ID = timing.GetIDGenerator().Generate()
+			dataReady.ID = testIDs.Generate()
 			dataReady.RspTo = readToBottomMeta.ID
 			dataReady.Data = drData
 			dataReady.TrafficBytes = len(drData) + 4
@@ -212,7 +212,7 @@ var _ = Describe("Bottom Parser", func() {
 			next.DirectoryState.Sets[blockSetID].Blocks[blockWayID].IsValid = true
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -287,7 +287,7 @@ var _ = Describe("Bottom Parser", func() {
 
 			// Add another read transaction (index 1) that is in the MSHR
 			read2Meta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -303,7 +303,7 @@ var _ = Describe("Bottom Parser", func() {
 
 			// Add a write transaction (index 2)
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 16 + 12,
 				TrafficClass: "req",
 			}

--- a/mem/cache/writethroughcache/cache_test.go
+++ b/mem/cache/writethroughcache/cache_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Cache", func() {
 	It("should do read miss", func() {
 		dramStorage.Write(0x100, []byte{1, 2, 3, 4})
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = cuPort.AsRemote()
 		read.Dst = c.GetPortByName("Top").AsRemote()
 		read.Address = 0x100
@@ -114,7 +114,7 @@ var _ = Describe("Cache", func() {
 	It("should do read miss coalesce", func() {
 		dramStorage.Write(0x100, []byte{1, 2, 3, 4, 5, 6, 7, 8})
 		read1 := memprotocol.ReadReq{}
-		read1.ID = timing.GetIDGenerator().Generate()
+		read1.ID = testIDs.Generate()
 		read1.Src = cuPort.AsRemote()
 		read1.Dst = c.GetPortByName("Top").AsRemote()
 		read1.Address = 0x100
@@ -124,7 +124,7 @@ var _ = Describe("Cache", func() {
 		c.GetPortByName("Top").Deliver(read1)
 
 		read2 := memprotocol.ReadReq{}
-		read2.ID = timing.GetIDGenerator().Generate()
+		read2.ID = testIDs.Generate()
 		read2.Src = cuPort.AsRemote()
 		read2.Dst = c.GetPortByName("Top").AsRemote()
 		read2.Address = 0x104
@@ -155,7 +155,7 @@ var _ = Describe("Cache", func() {
 	It("should do read hit", func() {
 		dramStorage.Write(0x100, []byte{1, 2, 3, 4, 5, 6, 7, 8})
 		read1 := memprotocol.ReadReq{}
-		read1.ID = timing.GetIDGenerator().Generate()
+		read1.ID = testIDs.Generate()
 		read1.Src = cuPort.AsRemote()
 		read1.Dst = c.GetPortByName("Top").AsRemote()
 		read1.Address = 0x100
@@ -171,7 +171,7 @@ var _ = Describe("Cache", func() {
 		Expect(rsps[0].(memprotocol.DataReadyRsp).Data).To(Equal([]byte{1, 2, 3, 4}))
 
 		read2 := memprotocol.ReadReq{}
-		read2.ID = timing.GetIDGenerator().Generate()
+		read2.ID = testIDs.Generate()
 		read2.Src = cuPort.AsRemote()
 		read2.Dst = c.GetPortByName("Top").AsRemote()
 		read2.Address = 0x104
@@ -191,7 +191,7 @@ var _ = Describe("Cache", func() {
 
 	It("should write partial line", func() {
 		write := memprotocol.WriteReq{}
-		write.ID = timing.GetIDGenerator().Generate()
+		write.ID = testIDs.Generate()
 		write.Src = cuPort.AsRemote()
 		write.Dst = c.GetPortByName("Top").AsRemote()
 		write.Address = 0x100
@@ -206,13 +206,13 @@ var _ = Describe("Cache", func() {
 		Expect(rsps).To(HaveLen(1))
 		Expect(rsps[0].Meta().RspTo).To(Equal(write.ID))
 
-		data, _ := dramStorage.Read(0x100, 4)
+		data := dramStorage.Read(0x100, 4)
 		Expect(data).To(Equal([]byte{1, 2, 3, 4}))
 	})
 
 	It("should write full line", func() {
 		write := memprotocol.WriteReq{}
-		write.ID = timing.GetIDGenerator().Generate()
+		write.ID = testIDs.Generate()
 		write.Src = cuPort.AsRemote()
 		write.Dst = c.GetPortByName("Top").AsRemote()
 		write.Address = 0x100
@@ -235,7 +235,7 @@ var _ = Describe("Cache", func() {
 		Expect(rsps).To(HaveLen(1))
 		Expect(rsps[0].Meta().RspTo).To(Equal(write.ID))
 
-		data, _ := dramStorage.Read(0x100, 4)
+		data := dramStorage.Read(0x100, 4)
 		Expect(data).To(Equal([]byte{1, 2, 3, 4}))
 	})
 

--- a/mem/cache/writethroughcache/control_behavior_test.go
+++ b/mem/cache/writethroughcache/control_behavior_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Writethrough cache control behavior", func() {
 
 	makeRead := func(addr uint64) memprotocol.ReadReq {
 		req := memprotocol.ReadReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.Address = addr
@@ -94,7 +94,7 @@ var _ = Describe("Writethrough cache control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Ctrl")
 		req.Dst = ctrlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -107,7 +107,7 @@ var _ = Describe("Writethrough cache control behavior", func() {
 	// the fetcher's slice [offset:offset+AccessByteSize] is always in range.
 	makeFill := func(bottomRead memprotocol.ReadReq) memprotocol.DataReadyRsp {
 		rsp := memprotocol.DataReadyRsp{Data: make([]byte, blockSize)}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = messaging.RemotePort("LowerCache")
 		rsp.Dst = bottomPort.AsRemote()
 		rsp.RspTo = bottomRead.ID

--- a/mem/cache/writethroughcache/ctrlmiddleware.go
+++ b/mem/cache/writethroughcache/ctrlmiddleware.go
@@ -331,7 +331,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/cache/writethroughcache/directory.go
+++ b/mem/cache/writethroughcache/directory.go
@@ -5,7 +5,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 
 	"github.com/sarchlab/akita/v5/queueing"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -41,7 +40,7 @@ func (d *directory) acceptIntoPipeline() (madeProgress bool) {
 
 		transIdx := dirBuf.Pop()
 		trans := &next.Transactions[transIdx]
-		pid := timing.GetIDGenerator().Generate()
+		pid := d.cache.comp.IDGenerator().Generate()
 		trans.DirPipelineTaskID = pid
 		tracing.StartTask(d.cache.comp, tracing.TaskStart{
 			ID:       pid,
@@ -290,7 +289,7 @@ func (d *directory) writeBottom(trans *transactionState) bool {
 	cacheLineID := addr / blockSize * blockSize
 
 	writeToBottom := memprotocol.WriteReq{}
-	writeToBottom.ID = timing.GetIDGenerator().Generate()
+	writeToBottom.ID = d.cache.comp.IDGenerator().Generate()
 	writeToBottom.Src = d.cache.bottomPort().AsRemote()
 	// Route by cache-line ID so the write-through write and the
 	// corresponding read-fill always target the same lower-memory port,
@@ -338,7 +337,7 @@ func (d *directory) fetchFromBottom(
 		PID:            pid,
 		AccessByteSize: blockSize,
 	}
-	readToBottom.ID = timing.GetIDGenerator().Generate()
+	readToBottom.ID = d.cache.comp.IDGenerator().Generate()
 	readToBottom.Src = d.cache.bottomPort().AsRemote()
 	readToBottom.Dst = bottomModule
 	readToBottom.TrafficBytes, readToBottom.TrafficClass = 12, "req"

--- a/mem/cache/writethroughcache/directory_test.go
+++ b/mem/cache/writethroughcache/directory_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Directory", func() {
 	// next CanSend returns false, simulating a busy port.
 	fillBottomOutgoing := func() {
 		dummy := memprotocol.ReadReq{}
-		dummy.ID = timing.GetIDGenerator().Generate()
+		dummy.ID = testIDs.Generate()
 		dummy.Src = bottomPort.AsRemote()
 		dummy.Dst = messaging.RemotePort("DRAM")
 		dummy.TrafficClass = "req"
@@ -98,7 +98,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -133,7 +133,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -175,7 +175,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -209,7 +209,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -242,7 +242,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -289,7 +289,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -318,7 +318,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -347,7 +347,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -381,7 +381,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -410,7 +410,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			readMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -441,7 +441,7 @@ var _ = Describe("Directory", func() {
 			// the MSHR — required so the coalesced write can record it
 			// as MSHRFillFetcherIdx.
 			fetcherReadMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 12,
 				TrafficClass: "req",
 			}
@@ -457,7 +457,7 @@ var _ = Describe("Directory", func() {
 			)
 
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 4 + 12,
 				TrafficClass: "req",
 			}
@@ -501,7 +501,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 4 + 12,
 				TrafficClass: "req",
 			}
@@ -543,7 +543,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 4 + 12,
 				TrafficClass: "req",
 			}
@@ -575,7 +575,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 4 + 12,
 				TrafficClass: "req",
 			}
@@ -607,7 +607,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 4 + 12,
 				TrafficClass: "req",
 			}
@@ -640,7 +640,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 4 + 12,
 				TrafficClass: "req",
 			}
@@ -675,7 +675,7 @@ var _ = Describe("Directory", func() {
 			next := &c.comp.State
 
 			writeMeta := messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				TrafficBytes: 64 + 12,
 				TrafficClass: "req",
 			}

--- a/mem/cache/writethroughcache/id_external_fixture_test.go
+++ b/mem/cache/writethroughcache/id_external_fixture_test.go
@@ -1,0 +1,4 @@
+package writethroughcache_test
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/cache/writethroughcache/id_fixture_test.go
+++ b/mem/cache/writethroughcache/id_fixture_test.go
@@ -1,0 +1,4 @@
+package writethroughcache
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/cache/writethroughcache/intake.go
+++ b/mem/cache/writethroughcache/intake.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -82,7 +81,7 @@ func (s *intake) createTransaction(msg messaging.Msg) int {
 	switch m := msg.(type) {
 	case memprotocol.ReadReq:
 		t = transactionState{
-			ID:                 timing.GetIDGenerator().Generate(),
+			ID:                 s.cache.comp.IDGenerator().Generate(),
 			HasRead:            true,
 			ReadMeta:           m.MsgMeta,
 			ReadAddress:        m.Address,
@@ -91,7 +90,7 @@ func (s *intake) createTransaction(msg messaging.Msg) int {
 		}
 	case memprotocol.WriteReq:
 		t = transactionState{
-			ID:             timing.GetIDGenerator().Generate(),
+			ID:             s.cache.comp.IDGenerator().Generate(),
 			HasWrite:       true,
 			WriteMeta:      m.MsgMeta,
 			WriteAddress:   m.Address,

--- a/mem/cache/writethroughcache/milestone_test.go
+++ b/mem/cache/writethroughcache/milestone_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Cache milestones", func() {
 
 		dramStorage.Write(0x100, []byte{1, 2, 3, 4})
 		read := memprotocol.ReadReq{Address: 0x100, AccessByteSize: 4}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = cuPort.AsRemote()
 		read.Dst = c.GetPortByName("Top").AsRemote()
 		read.TrafficBytes = 12
@@ -211,7 +211,7 @@ var _ = Describe("Cache milestones", func() {
 
 		dramStorage.Write(0x100, []byte{1, 2, 3, 4})
 		read := memprotocol.ReadReq{Address: 0x100, AccessByteSize: 4}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = cuPort.AsRemote()
 		read.Dst = c.GetPortByName("Top").AsRemote()
 		read.TrafficBytes = 12
@@ -261,7 +261,7 @@ var _ = Describe("Cache milestones", func() {
 			fullLine[i] = byte(i)
 		}
 		warm := memprotocol.WriteReq{Address: 0x100, Data: fullLine}
-		warm.ID = timing.GetIDGenerator().Generate()
+		warm.ID = testIDs.Generate()
 		warm.Src = cuPort.AsRemote()
 		warm.Dst = c.GetPortByName("Top").AsRemote()
 		warm.TrafficBytes = 64 + 12
@@ -279,7 +279,7 @@ var _ = Describe("Cache milestones", func() {
 		// Now a partial write to the same line: this is a write-through write
 		// hit and must carry the write-hit tag.
 		hit := memprotocol.WriteReq{Address: 0x100, Data: []byte{9, 9, 9, 9}}
-		hit.ID = timing.GetIDGenerator().Generate()
+		hit.ID = testIDs.Generate()
 		hit.Src = cuPort.AsRemote()
 		hit.Dst = c.GetPortByName("Top").AsRemote()
 		hit.TrafficBytes = 4 + 12
@@ -333,7 +333,7 @@ var _ = Describe("Cache milestones", func() {
 			fullLine[i] = byte(i)
 		}
 		miss := memprotocol.WriteReq{Address: 0x100, Data: fullLine}
-		miss.ID = timing.GetIDGenerator().Generate()
+		miss.ID = testIDs.Generate()
 		miss.Src = cuPort.AsRemote()
 		miss.Dst = c.GetPortByName("Top").AsRemote()
 		miss.TrafficBytes = 64 + 12
@@ -371,7 +371,7 @@ var _ = Describe("Cache milestones", func() {
 		// open a bank subtask.
 		fullLine := make([]byte, 64)
 		w := memprotocol.WriteReq{Address: 0x100, Data: fullLine}
-		w.ID = timing.GetIDGenerator().Generate()
+		w.ID = testIDs.Generate()
 		w.Src = cuPort.AsRemote()
 		w.Dst = c.GetPortByName("Top").AsRemote()
 		w.TrafficBytes = 64 + 12

--- a/mem/cache/writethroughcache/reset_leak_test.go
+++ b/mem/cache/writethroughcache/reset_leak_test.go
@@ -70,7 +70,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	// bottom fetch (req_out) that is never answered, leaving the transaction in
 	// flight with both its req_in and req_out tracing tasks open.
 	read := memprotocol.ReadReq{Address: 0, AccessByteSize: 4}
-	read.ID = timing.GetIDGenerator().Generate()
+	read.ID = testIDs.Generate()
 	read.Src = messaging.RemotePort("Agent")
 	read.Dst = topPort.AsRemote()
 	read.TrafficBytes = 12
@@ -116,7 +116,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	// Reset while the transaction is in flight.
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = ctrlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/cache/writethroughcache/respondstage.go
+++ b/mem/cache/writethroughcache/respondstage.go
@@ -2,7 +2,6 @@ package writethroughcache
 
 import (
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -34,7 +33,7 @@ func (s *respondStage) Tick() bool {
 
 func (s *respondStage) respondReadTrans(trans *transactionState) bool {
 	dr := memprotocol.DataReadyRsp{}
-	dr.ID = timing.GetIDGenerator().Generate()
+	dr.ID = s.cache.comp.IDGenerator().Generate()
 	dr.Src = s.cache.topPort().AsRemote()
 	dr.Dst = trans.ReadMeta.Src
 	dr.RspTo = trans.ReadMeta.ID
@@ -64,7 +63,7 @@ func (s *respondStage) respondReadTrans(trans *transactionState) bool {
 
 func (s *respondStage) respondWriteTrans(trans *transactionState) bool {
 	done := memprotocol.WriteDoneRsp{}
-	done.ID = timing.GetIDGenerator().Generate()
+	done.ID = s.cache.comp.IDGenerator().Generate()
 	done.Src = s.cache.topPort().AsRemote()
 	done.Dst = trans.WriteMeta.Src
 	done.RspTo = trans.WriteMeta.ID

--- a/mem/cache/writethroughcache/respondstage_test.go
+++ b/mem/cache/writethroughcache/respondstage_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Respond Stage", func() {
 			next := &mw.comp.State
 
 			readMeta = messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				Src:          "SomeSrc",
 				TrafficBytes: 12,
 				TrafficClass: "req",
@@ -107,7 +107,7 @@ var _ = Describe("Respond Stage", func() {
 			next := &mw.comp.State
 
 			writeMeta = messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           testIDs.Generate(),
 				Src:          "SomeSrc",
 				TrafficBytes: 12,
 				TrafficClass: "req",

--- a/mem/datamover/control_behavior_test.go
+++ b/mem/datamover/control_behavior_test.go
@@ -74,7 +74,7 @@ var _ = Describe("DataMover control behavior", func() {
 	// (one read on Outside, one write on Inside).
 	makeMove := func() datamoverprotocol.DataMoveRequest {
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.SrcAddress = 0
@@ -88,7 +88,7 @@ var _ = Describe("DataMover control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Cmd")
 		req.Dst = ctrlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -97,7 +97,7 @@ var _ = Describe("DataMover control behavior", func() {
 
 	answerRead := func(port messaging.Port, read memprotocol.ReadReq) {
 		rsp := memprotocol.DataReadyRsp{Data: make([]byte, int(read.AccessByteSize))}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = read.Dst
 		rsp.Dst = port.AsRemote()
 		rsp.RspTo = read.ID
@@ -107,7 +107,7 @@ var _ = Describe("DataMover control behavior", func() {
 
 	answerWrite := func(port messaging.Port, write memprotocol.WriteReq) {
 		rsp := memprotocol.WriteDoneRsp{}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = write.Dst
 		rsp.Dst = port.AsRemote()
 		rsp.RspTo = write.ID

--- a/mem/datamover/ctrlmiddleware.go
+++ b/mem/datamover/ctrlmiddleware.go
@@ -196,7 +196,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/datamover/ctrlparsemw.go
+++ b/mem/datamover/ctrlparsemw.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
 
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 
 	// ctrlParseMW handles control port parsing and transaction completion.
@@ -137,7 +136,7 @@ func (m *ctrlParseMW) finishTransaction() bool {
 
 	rsp := datamoverprotocol.DataMoveResponse{
 		MsgMeta: messaging.MsgMeta{
-			ID:    timing.GetIDGenerator().Generate(),
+			ID:    m.comp.IDGenerator().Generate(),
 			Src:   trans.ReqDst,
 			Dst:   trans.ReqSrc,
 			RspTo: trans.ReqID,

--- a/mem/datamover/datamoving_test.go
+++ b/mem/datamover/datamoving_test.go
@@ -107,7 +107,7 @@ var _ = Describe("DataMover", func() {
 		outsideStorage.Write(0, data)
 
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = srcPort.AsRemote()
 		req.Dst = dataMover.GetPortByName("Top").AsRemote()
 		req.SrcAddress = 0
@@ -138,7 +138,7 @@ var _ = Describe("DataMover", func() {
 		outsideStorage.Write(4096, data)
 
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = srcPort.AsRemote()
 		req.Dst = dataMover.GetPortByName("Top").AsRemote()
 		req.SrcAddress = 4096
@@ -165,7 +165,7 @@ var _ = Describe("DataMover", func() {
 		insideStorage.Write(0, data)
 
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = srcPort.AsRemote()
 		req.Dst = dataMover.GetPortByName("Top").AsRemote()
 		req.SrcAddress = 0
@@ -192,7 +192,7 @@ var _ = Describe("DataMover", func() {
 		insideStorage.Write(0, data)
 
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = srcPort.AsRemote()
 		req.Dst = dataMover.GetPortByName("Top").AsRemote()
 		req.SrcAddress = 0
@@ -219,7 +219,7 @@ var _ = Describe("DataMover", func() {
 		outsideStorage.Write(0, data)
 
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = srcPort.AsRemote()
 		req.Dst = dataMover.GetPortByName("Top").AsRemote()
 		req.SrcAddress = 0
@@ -241,7 +241,7 @@ var _ = Describe("DataMover", func() {
 
 	It("should handle zero-size transfers", func() {
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = srcPort.AsRemote()
 		req.Dst = dataMover.GetPortByName("Top").AsRemote()
 		req.SrcAddress = 0
@@ -264,7 +264,7 @@ var _ = Describe("DataMover", func() {
 		insideStorage.Write(0, data)
 
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = srcPort.AsRemote()
 		req.Dst = dataMover.GetPortByName("Top").AsRemote()
 		req.SrcAddress = 0

--- a/mem/datamover/datatransfermw.go
+++ b/mem/datamover/datatransfermw.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
 
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 
 	// dataTransferMW handles data read/write operations between source and
@@ -131,7 +130,7 @@ func (m *dataTransferMW) readFromSrc() bool {
 	srcP := m.srcPort()
 
 	req := memprotocol.ReadReq{}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = m.comp.IDGenerator().Generate()
 	req.Address = addr
 	req.Src = srcP.AsRemote()
 	req.Dst = m.findSrcPort(addr)
@@ -231,7 +230,7 @@ func (m *dataTransferMW) writeToDst() bool {
 	dstP := m.dstPort()
 
 	req := memprotocol.WriteReq{}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = m.comp.IDGenerator().Generate()
 	req.Address = trans.NextWriteAddr
 	req.Data = data
 	req.Src = dstP.AsRemote()

--- a/mem/datamover/id_fixture_test.go
+++ b/mem/datamover/id_fixture_test.go
@@ -1,0 +1,4 @@
+package datamover
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/datamover/milestone_test.go
+++ b/mem/datamover/milestone_test.go
@@ -176,7 +176,7 @@ var _ = Describe("DataMover milestones", func() {
 		outsideStorage.Write(0, data)
 
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = srcPort.AsRemote()
 		req.Dst = topPort.AsRemote()
 		req.SrcAddress = 0
@@ -227,7 +227,7 @@ var _ = Describe("DataMover milestones", func() {
 		outsideStorage.Write(0, data)
 
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = srcPort.AsRemote()
 		req.Dst = topPort.AsRemote()
 		req.SrcAddress = 0
@@ -280,7 +280,7 @@ var _ = Describe("DataMover milestones", func() {
 
 		makeMove := func() datamoverprotocol.DataMoveRequest {
 			req := datamoverprotocol.DataMoveRequest{}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Src = srcPort.AsRemote()
 			req.Dst = topPort.AsRemote()
 			req.SrcAddress = 0

--- a/mem/datamover/reset_leak_test.go
+++ b/mem/datamover/reset_leak_test.go
@@ -64,7 +64,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	makeMove := func() datamoverprotocol.DataMoveRequest {
 		req := datamoverprotocol.DataMoveRequest{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.SrcAddress = 0
@@ -78,7 +78,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Cmd")
 		req.Dst = ctrlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/dram/banktickmw.go
+++ b/mem/dram/banktickmw.go
@@ -48,7 +48,7 @@ func (m *bankTickMW) Tick() bool {
 		next.RefreshBlockedIssue = true
 	}
 
-	progress = m.ctrl.fillCommandQueue(&spec, next) || progress
+	progress = m.ctrl.fillCommandQueue(m.comp.IDGenerator(), &spec, next) || progress
 
 	// Keep ticking while reads/writes are still in flight, even on cycles when
 	// no timing gap counted down — otherwise a pending completion with no other

--- a/mem/dram/control_behavior_test.go
+++ b/mem/dram/control_behavior_test.go
@@ -49,7 +49,7 @@ var _ = Describe("DRAM control behavior", func() {
 
 	makeRead := func(addr uint64) memprotocol.ReadReq {
 		req := memprotocol.ReadReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.Address = addr
@@ -61,7 +61,7 @@ var _ = Describe("DRAM control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Ctrl")
 		req.Dst = ctrlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/dram/ctrlmiddleware.go
+++ b/mem/dram/ctrlmiddleware.go
@@ -220,7 +220,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/dram/id_external_fixture_test.go
+++ b/mem/dram/id_external_fixture_test.go
@@ -1,0 +1,4 @@
+package dram_test
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/dram/id_fixture_test.go
+++ b/mem/dram/id_fixture_test.go
@@ -1,0 +1,4 @@
+package dram
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/dram/memcontroller_test.go
+++ b/mem/dram/memcontroller_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Transaction Splitting", func() {
 		trans.ReadMsg.Address = 0x100
 		trans.ReadMsg.AccessByteSize = 128
 
-		splitTransaction(spec, trans)
+		splitTransaction(testIDs, spec, trans)
 		// 128 bytes at 64-byte units = 2 sub-transactions
 		Expect(trans.SubTransactions).To(HaveLen(2))
 		Expect(trans.SubTransactions[0].Address).To(Equal(uint64(0x100)))
@@ -47,7 +47,7 @@ var _ = Describe("Transaction Splitting", func() {
 		trans.ReadMsg.Address = 0x110 // Not aligned
 		trans.ReadMsg.AccessByteSize = 4
 
-		splitTransaction(spec, trans)
+		splitTransaction(testIDs, spec, trans)
 		Expect(trans.SubTransactions).To(HaveLen(1))
 		Expect(trans.SubTransactions[0].Address).To(Equal(uint64(0x100)))
 	})
@@ -219,7 +219,7 @@ var _ = Describe("DRAM Integration", func() {
 
 		writeData := []byte{1, 2, 3, 4}
 		write := memprotocol.WriteReq{}
-		write.ID = timing.GetIDGenerator().Generate()
+		write.ID = testIDs.Generate()
 		write.Address = 0x40
 		write.Data = writeData
 		write.Src = srcPort.AsRemote()
@@ -228,7 +228,7 @@ var _ = Describe("DRAM Integration", func() {
 		write.TrafficClass = "memprotocol.WriteReq"
 
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Address = 0x40
 		read.AccessByteSize = 4
 		read.Src = srcPort.AsRemote()
@@ -494,7 +494,7 @@ var _ = Describe("Open Page Policy", func() {
 		spec.PagePolicy = PagePolicyOpen
 
 		ref := subTransRef{TxID: 0, SubIndex: 0}
-		cmd := createOpenPageCommand(spec, state, ref)
+		cmd := createOpenPageCommand(testIDs, spec, state, ref)
 
 		Expect(cmd).NotTo(BeNil())
 		Expect(cmd.Kind).To(Equal(int(cmdKindRead)))
@@ -504,7 +504,7 @@ var _ = Describe("Open Page Policy", func() {
 		spec.PagePolicy = PagePolicyOpen
 
 		ref := subTransRef{TxID: 1, SubIndex: 0}
-		cmd := createOpenPageCommand(spec, state, ref)
+		cmd := createOpenPageCommand(testIDs, spec, state, ref)
 
 		Expect(cmd).NotTo(BeNil())
 		Expect(cmd.Kind).To(Equal(int(cmdKindWrite)))
@@ -514,7 +514,7 @@ var _ = Describe("Open Page Policy", func() {
 		spec.PagePolicy = PagePolicyClose
 
 		ref := subTransRef{TxID: 0, SubIndex: 0}
-		cmd := createClosePageCommand(spec, state, ref)
+		cmd := createClosePageCommand(testIDs, spec, state, ref)
 
 		Expect(cmd).NotTo(BeNil())
 		Expect(cmd.Kind).To(Equal(int(cmdKindReadPrecharge)))
@@ -524,7 +524,7 @@ var _ = Describe("Open Page Policy", func() {
 		spec.PagePolicy = PagePolicyClose
 
 		ref := subTransRef{TxID: 1, SubIndex: 0}
-		cmd := createClosePageCommand(spec, state, ref)
+		cmd := createClosePageCommand(testIDs, spec, state, ref)
 
 		Expect(cmd).NotTo(BeNil())
 		Expect(cmd.Kind).To(Equal(int(cmdKindWritePrecharge)))
@@ -620,7 +620,7 @@ var _ = Describe("Open Page Policy", func() {
 			{TxID: 0, SubIndex: 0},
 		}
 
-		progress := tickSubTransQueue(spec, state)
+		progress := tickSubTransQueue(testIDs, spec, state)
 		Expect(progress).To(BeTrue())
 
 		// The command in the queue should be CmdKindRead (not ReadPrecharge)
@@ -635,7 +635,7 @@ var _ = Describe("Open Page Policy", func() {
 			{TxID: 0, SubIndex: 0},
 		}
 
-		progress := tickSubTransQueue(spec, state)
+		progress := tickSubTransQueue(testIDs, spec, state)
 		Expect(progress).To(BeTrue())
 
 		// The command in the queue should be CmdKindReadPrecharge
@@ -650,7 +650,7 @@ var _ = Describe("Open Page Policy", func() {
 			{TxID: 1, SubIndex: 0},
 		}
 
-		progress := tickSubTransQueue(spec, state)
+		progress := tickSubTransQueue(testIDs, spec, state)
 		Expect(progress).To(BeTrue())
 
 		Expect(state.CommandQueues.Entries).To(HaveLen(1))
@@ -664,7 +664,7 @@ var _ = Describe("Open Page Policy", func() {
 			{TxID: 1, SubIndex: 0},
 		}
 
-		progress := tickSubTransQueue(spec, state)
+		progress := tickSubTransQueue(testIDs, spec, state)
 		Expect(progress).To(BeTrue())
 
 		Expect(state.CommandQueues.Entries).To(HaveLen(1))
@@ -858,7 +858,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 				queueEntry{
 					QueueIndex: 0,
 					Command: commandState{
-						ID:       timing.GetIDGenerator().Generate(),
+						ID:       testIDs.Generate(),
 						Kind:     int(cmdKindWritePrecharge),
 						Location: location{Rank: 0, BankGroup: 0, Bank: uint64(i), Row: uint64(i)},
 					},
@@ -893,7 +893,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 			{
 				QueueIndex: 0,
 				Command: commandState{
-					ID:       timing.GetIDGenerator().Generate(),
+					ID:       testIDs.Generate(),
 					Kind:     int(cmdKindWritePrecharge),
 					Location: location{Rank: 0, BankGroup: 0, Bank: 0, Row: 1},
 				},
@@ -902,7 +902,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 			{
 				QueueIndex: 0,
 				Command: commandState{
-					ID:       timing.GetIDGenerator().Generate(),
+					ID:       testIDs.Generate(),
 					Kind:     int(cmdKindWritePrecharge),
 					Location: location{Rank: 0, BankGroup: 0, Bank: 1, Row: 2},
 				},
@@ -920,7 +920,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 		// Fill write queue to capacity (4)
 		for i := range 4 {
 			cmd := &commandState{
-				ID:       timing.GetIDGenerator().Generate(),
+				ID:       testIDs.Generate(),
 				Kind:     int(cmdKindWritePrecharge),
 				Location: location{Rank: 0, BankGroup: 0, Bank: uint64(i)},
 			}
@@ -930,7 +930,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 
 		// One more write should be rejected
 		extraWrite := &commandState{
-			ID:       timing.GetIDGenerator().Generate(),
+			ID:       testIDs.Generate(),
 			Kind:     int(cmdKindWritePrecharge),
 			Location: location{Rank: 0, BankGroup: 0, Bank: 0},
 		}
@@ -938,7 +938,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 
 		// But a read should still be accepted
 		readCmd := &commandState{
-			ID:       timing.GetIDGenerator().Generate(),
+			ID:       testIDs.Generate(),
 			Kind:     int(cmdKindReadPrecharge),
 			Location: location{Rank: 0, BankGroup: 0, Bank: 0},
 		}
@@ -949,7 +949,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 		// Fill read queue to capacity (4)
 		for i := range 4 {
 			cmd := &commandState{
-				ID:       timing.GetIDGenerator().Generate(),
+				ID:       testIDs.Generate(),
 				Kind:     int(cmdKindReadPrecharge),
 				Location: location{Rank: 0, BankGroup: 0, Bank: uint64(i)},
 			}
@@ -959,7 +959,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 
 		// One more read should be rejected
 		extraRead := &commandState{
-			ID:       timing.GetIDGenerator().Generate(),
+			ID:       testIDs.Generate(),
 			Kind:     int(cmdKindReadPrecharge),
 			Location: location{Rank: 0, BankGroup: 0, Bank: 0},
 		}
@@ -967,7 +967,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 
 		// But a write should still be accepted
 		writeCmd := &commandState{
-			ID:       timing.GetIDGenerator().Generate(),
+			ID:       testIDs.Generate(),
 			Kind:     int(cmdKindWritePrecharge),
 			Location: location{Rank: 0, BankGroup: 0, Bank: 0},
 		}
@@ -982,7 +982,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 		// Fill unified queue to capacity
 		for range 4 {
 			cmd := &commandState{
-				ID:       timing.GetIDGenerator().Generate(),
+				ID:       testIDs.Generate(),
 				Kind:     int(cmdKindReadPrecharge),
 				Location: location{Rank: 0, BankGroup: 0, Bank: 0},
 			}
@@ -992,14 +992,14 @@ var _ = Describe("Read/Write Queue Separation", func() {
 
 		// Both reads and writes should be rejected
 		readCmd := &commandState{
-			ID:       timing.GetIDGenerator().Generate(),
+			ID:       testIDs.Generate(),
 			Kind:     int(cmdKindReadPrecharge),
 			Location: location{Rank: 0, BankGroup: 0, Bank: 0},
 		}
 		Expect(canAcceptCommand(state, readCmd, spec)).To(BeFalse())
 
 		writeCmd := &commandState{
-			ID:       timing.GetIDGenerator().Generate(),
+			ID:       testIDs.Generate(),
 			Kind:     int(cmdKindWritePrecharge),
 			Location: location{Rank: 0, BankGroup: 0, Bank: 0},
 		}
@@ -1025,7 +1025,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 
 	It("should tag queue entries with IsWrite flag", func() {
 		writeCmd := &commandState{
-			ID:       timing.GetIDGenerator().Generate(),
+			ID:       testIDs.Generate(),
 			Kind:     int(cmdKindWritePrecharge),
 			Location: location{Rank: 0},
 		}
@@ -1033,7 +1033,7 @@ var _ = Describe("Read/Write Queue Separation", func() {
 		Expect(state.CommandQueues.Entries[0].IsWrite).To(BeTrue())
 
 		readCmd := &commandState{
-			ID:       timing.GetIDGenerator().Generate(),
+			ID:       testIDs.Generate(),
 			Kind:     int(cmdKindReadPrecharge),
 			Location: location{Rank: 0},
 		}

--- a/mem/dram/milestone_test.go
+++ b/mem/dram/milestone_test.go
@@ -88,7 +88,7 @@ var _ = Describe("DRAM admission milestones", func() {
 
 	makeRead := func(addr uint64) memprotocol.ReadReq {
 		req := memprotocol.ReadReq{Address: addr, AccessByteSize: 4}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.TrafficBytes = 12
@@ -150,7 +150,7 @@ var _ = Describe("DRAM refresh-stall attribution", func() {
 		tracing.CollectIncomingBufferTrace(topPort)
 
 		read := memprotocol.ReadReq{Address: 0x40, AccessByteSize: 4}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = messaging.RemotePort("Agent")
 		read.Dst = topPort.AsRemote()
 		read.TrafficBytes = 12

--- a/mem/dram/p0_regression_test.go
+++ b/mem/dram/p0_regression_test.go
@@ -55,7 +55,7 @@ func newP0Harness(spec Spec, tracers ...tracing.Tracer) *p0Harness {
 
 func (h *p0Harness) read(addr uint64) memprotocol.ReadReq {
 	r := memprotocol.ReadReq{}
-	r.ID = timing.GetIDGenerator().Generate()
+	r.ID = testIDs.Generate()
 	r.Address = addr
 	r.AccessByteSize = 64
 	r.Src = h.src.AsRemote()
@@ -67,7 +67,7 @@ func (h *p0Harness) read(addr uint64) memprotocol.ReadReq {
 
 func (h *p0Harness) write(addr uint64, data []byte) memprotocol.WriteReq {
 	w := memprotocol.WriteReq{}
-	w.ID = timing.GetIDGenerator().Generate()
+	w.ID = testIDs.Generate()
 	w.Address = addr
 	w.Data = data
 	w.Src = h.src.AsRemote()

--- a/mem/dram/parsetopmw.go
+++ b/mem/dram/parsetopmw.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sarchlab/akita/v5/modeling"
 
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -39,7 +38,7 @@ func (m *parseTopMW) parseTop(spec *Spec, next *State) bool {
 		return false
 	}
 
-	ts := transactionState{ID: timing.GetIDGenerator().Generate()}
+	ts := transactionState{ID: m.comp.IDGenerator().Generate()}
 
 	switch msg := msgI.(type) {
 	case memprotocol.ReadReq:
@@ -54,7 +53,7 @@ func (m *parseTopMW) parseTop(spec *Spec, next *State) bool {
 
 	// Split into sub-transactions
 	transIdx := len(next.Transactions)
-	splitTransaction(spec, &ts)
+	splitTransaction(m.comp.IDGenerator(), spec, &ts)
 
 	if !canPushSubTrans(next, len(ts.SubTransactions),
 		spec.TransactionQueueSize) {

--- a/mem/dram/plugins.go
+++ b/mem/dram/plugins.go
@@ -29,7 +29,7 @@ type scheduler interface {
 // open- vs close-page variant. The location is resolved by the addrMapper.
 type rowPolicy interface {
 	Name() string
-	CommandFor(spec *Spec, st *State, ref subTransRef, loc location) *commandState
+	CommandFor(ids timing.IDGenerator, spec *Spec, st *State, ref subTransRef, loc location) *commandState
 }
 
 // addrMapper maps a physical address to a DRAM location. The location keeps a
@@ -65,9 +65,10 @@ type openPageRowPolicy struct{}
 func (openPageRowPolicy) Name() string { return rowPolicyOpen }
 
 func (openPageRowPolicy) CommandFor(
+	ids timing.IDGenerator,
 	_ *Spec, st *State, ref subTransRef, loc location,
 ) *commandState {
-	return buildColumnCommand(st, ref, loc, cmdKindRead, cmdKindWrite)
+	return buildColumnCommand(ids, st, ref, loc, cmdKindRead, cmdKindWrite)
 }
 
 // closePageRowPolicy issues ReadPrecharge/WritePrecharge (auto-precharge),
@@ -77,16 +78,18 @@ type closePageRowPolicy struct{}
 func (closePageRowPolicy) Name() string { return rowPolicyClose }
 
 func (closePageRowPolicy) CommandFor(
+	ids timing.IDGenerator,
 	_ *Spec, st *State, ref subTransRef, loc location,
 ) *commandState {
 	return buildColumnCommand(
-		st, ref, loc, cmdKindReadPrecharge, cmdKindWritePrecharge)
+		ids, st, ref, loc, cmdKindReadPrecharge, cmdKindWritePrecharge)
 }
 
 // buildColumnCommand constructs a column command for a sub-transaction at the
 // given location, choosing the read or write variant from the parent
 // transaction's direction.
 func buildColumnCommand(
+	ids timing.IDGenerator,
 	st *State, ref subTransRef, loc location,
 	readKind, writeKind commandKind,
 ) *commandState {
@@ -94,7 +97,7 @@ func buildColumnCommand(
 	sub := &trans.SubTransactions[ref.SubIndex]
 
 	cmd := &commandState{
-		ID:          timing.GetIDGenerator().Generate(),
+		ID:          ids.Generate(),
 		Address:     sub.Address,
 		SubTransRef: ref,
 		Location:    loc,
@@ -165,7 +168,7 @@ type controller struct {
 // sub-transaction queue into a command queue: it maps the address and turns the
 // sub-transaction into a column command via the configured strategies. Returns
 // true if a sub-transaction was enqueued.
-func (c *controller) fillCommandQueue(spec *Spec, state *State) bool {
+func (c *controller) fillCommandQueue(ids timing.IDGenerator, spec *Spec, state *State) bool {
 	for i, ref := range state.SubTransQueue.Entries {
 		sub := subTransByRef(state, ref)
 		if sub == nil {
@@ -173,7 +176,7 @@ func (c *controller) fillCommandQueue(spec *Spec, state *State) bool {
 		}
 
 		loc := c.addrMapper.Map(spec, sub.Address)
-		cmd := c.rowPolicy.CommandFor(spec, state, ref, loc)
+		cmd := c.rowPolicy.CommandFor(ids, spec, state, ref, loc)
 
 		if canAcceptCommand(state, cmd, spec) {
 			acceptCommand(state, cmd)

--- a/mem/dram/queue_ops.go
+++ b/mem/dram/queue_ops.go
@@ -7,6 +7,7 @@ import (
 // splitTransaction breaks a transaction into sub-transactions based on
 // the access unit size (from Spec.Log2AccessUnitSize).
 func splitTransaction(
+	ids timing.IDGenerator,
 	spec *Spec,
 	trans *transactionState,
 ) {
@@ -31,7 +32,7 @@ func splitTransaction(
 
 	for a := alignedAddr; a < alignedEnd; a += unitSize {
 		st := subTransState{
-			ID:        timing.GetIDGenerator().Generate(),
+			ID:        ids.Generate(),
 			Address:   a,
 			Completed: false,
 		}
@@ -64,34 +65,36 @@ func pushSubTrans(state *State, transIdx int) {
 // made. Production drives this through the component's configured controller
 // (see controller.fillCommandQueue); this package-level shim builds the default
 // controller so tests can exercise the path directly.
-func tickSubTransQueue(spec *Spec, state *State) bool {
-	return newDefaultController(spec).fillCommandQueue(spec, state)
+func tickSubTransQueue(ids timing.IDGenerator, spec *Spec, state *State) bool {
+	return newDefaultController(spec).fillCommandQueue(ids, spec, state)
 }
 
 // createClosePageCommand creates a command for a sub-transaction using
 // close-page policy (auto-precharge). Thin wrapper over the row policy, kept
 // for direct testing.
 func createClosePageCommand(
+	ids timing.IDGenerator,
 	spec *Spec,
 	state *State,
 	ref subTransRef,
 ) *commandState {
 	st := subTransByRef(state, ref)
 	return closePageRowPolicy{}.CommandFor(
-		spec, state, ref, mapAddress(spec, st.Address))
+		ids, spec, state, ref, mapAddress(spec, st.Address))
 }
 
 // createOpenPageCommand creates a command for a sub-transaction using
 // open-page policy (plain Read/Write, leaving the row buffer open). Thin
 // wrapper over the row policy, kept for direct testing.
 func createOpenPageCommand(
+	ids timing.IDGenerator,
 	spec *Spec,
 	state *State,
 	ref subTransRef,
 ) *commandState {
 	st := subTransByRef(state, ref)
 	return openPageRowPolicy{}.CommandFor(
-		spec, state, ref, mapAddress(spec, st.Address))
+		ids, spec, state, ref, mapAddress(spec, st.Address))
 }
 
 // getQueueIndex returns the command queue index for a command (by rank).

--- a/mem/dram/reset_leak_test.go
+++ b/mem/dram/reset_leak_test.go
@@ -52,7 +52,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	// out. Ticking just enough to admit the transaction — but far fewer than the
 	// DRAM access latency — leaves it in flight.
 	read := memprotocol.ReadReq{Address: 0, AccessByteSize: 4}
-	read.ID = timing.GetIDGenerator().Generate()
+	read.ID = testIDs.Generate()
 	read.Src = messaging.RemotePort("Agent")
 	read.Dst = topPort.AsRemote()
 	read.TrafficBytes = 12
@@ -83,7 +83,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	// Reset while the transaction is in flight.
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = ctrlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/dram/respondmw.go
+++ b/mem/dram/respondmw.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sarchlab/akita/v5/modeling"
 
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -74,14 +73,11 @@ func (m *respondMW) finalizeWriteTrans(
 	t *transactionState,
 	i int,
 ) bool {
-	err := m.comp.Resources().Storage.Write(
+	m.comp.Resources().Storage.Write(
 		transactionGlobalAddress(t), t.WriteMsg.Data)
-	if err != nil {
-		panic(err)
-	}
 
 	writeDone := memprotocol.WriteDoneRsp{}
-	writeDone.ID = timing.GetIDGenerator().Generate()
+	writeDone.ID = m.comp.IDGenerator().Generate()
 	writeDone.Src = m.topPort().AsRemote()
 	writeDone.Dst = t.WriteMsg.Src
 	writeDone.RspTo = t.WriteMsg.ID
@@ -105,14 +101,11 @@ func (m *respondMW) finalizeReadTrans(
 	t *transactionState,
 	i int,
 ) bool {
-	data, err := m.comp.Resources().Storage.Read(
+	data := m.comp.Resources().Storage.Read(
 		transactionGlobalAddress(t), t.ReadMsg.AccessByteSize)
-	if err != nil {
-		panic(err)
-	}
 
 	dataReady := memprotocol.DataReadyRsp{}
-	dataReady.ID = timing.GetIDGenerator().Generate()
+	dataReady.ID = m.comp.IDGenerator().Generate()
 	dataReady.Src = m.topPort().AsRemote()
 	dataReady.Dst = t.ReadMsg.Src
 	dataReady.Data = data

--- a/mem/dram/stats_test.go
+++ b/mem/dram/stats_test.go
@@ -105,7 +105,7 @@ var _ = Describe("DRAM Statistics", func() {
 
 		// Send a write request
 		write := memprotocol.WriteReq{}
-		write.ID = timing.GetIDGenerator().Generate()
+		write.ID = testIDs.Generate()
 		write.Address = 0x40
 		write.Data = []byte{1, 2, 3, 4}
 		write.Src = srcPort.AsRemote()
@@ -116,7 +116,7 @@ var _ = Describe("DRAM Statistics", func() {
 
 		// Send a read request
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Address = 0x40
 		read.AccessByteSize = 4
 		read.Src = srcPort.AsRemote()

--- a/mem/idealmemcontroller/checkpoint_test.go
+++ b/mem/idealmemcontroller/checkpoint_test.go
@@ -19,7 +19,10 @@ func TestCheckpointRoundTrip(t *testing.T) {
 	const buildID = "test-build"
 	const payload = "persisted bytes"
 
-	sim := simulation.MakeBuilder().WithoutMonitoring().Build()
+	sim, err := simulation.MakeBuilder().WithoutMonitoring().Build()
+	if err != nil {
+		panic(err)
+	}
 	defer func() {
 		sim.Terminate()
 		os.Remove("akita_sim_" + sim.ID() + ".sqlite3")
@@ -33,9 +36,7 @@ func TestCheckpointRoundTrip(t *testing.T) {
 		Build("DRAM")
 
 	storage := dram.Resources().Storage
-	if err := storage.Write(0x40, []byte(payload)); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	storage.Write(0x40, []byte(payload))
 	dram.State.CurrentCmdID = 7
 
 	if err := sim.SaveCheckpoint(path, buildID); err != nil {
@@ -43,19 +44,15 @@ func TestCheckpointRoundTrip(t *testing.T) {
 	}
 
 	// Mutate the resource and the component state away from the checkpoint.
-	if err := storage.Write(0x40, make([]byte, len(payload))); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	storage.Write(0x40, make([]byte, len(payload)))
 	dram.State.CurrentCmdID = 99
 
 	if err := sim.LoadCheckpoint(path, buildID); err != nil {
 		t.Fatalf("LoadCheckpoint: %v", err)
 	}
 
-	got, err := storage.Read(0x40, uint64(len(payload)))
-	if err != nil {
-		t.Fatalf("Read: %v", err)
-	}
+	got := storage.Read(0x40, uint64(len(payload)))
+
 	if string(got) != payload {
 		t.Fatalf("storage = %q, want %q", got, payload)
 	}

--- a/mem/idealmemcontroller/control_behavior_test.go
+++ b/mem/idealmemcontroller/control_behavior_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Ideal Memory Controller control behavior", func() {
 
 	makeRead := func(addr uint64) memprotocol.ReadReq {
 		req := memprotocol.ReadReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.Address = addr
@@ -62,7 +62,7 @@ var _ = Describe("Ideal Memory Controller control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Ctrl")
 		req.Dst = ctrlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/idealmemcontroller/ctrlmiddleware.go
+++ b/mem/idealmemcontroller/ctrlmiddleware.go
@@ -177,7 +177,7 @@ func makeRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/idealmemcontroller/id_fixture_test.go
+++ b/mem/idealmemcontroller/id_fixture_test.go
@@ -1,0 +1,4 @@
+package idealmemcontroller
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/idealmemcontroller/id_mock_test.go
+++ b/mem/idealmemcontroller/id_mock_test.go
@@ -1,0 +1,4 @@
+package idealmemcontroller
+import "github.com/sarchlab/akita/v5/timing"
+func (m *MockEngine) IDGenerator() timing.IDGenerator { return mockIDs }
+var mockIDs = timing.NewIDGenerator()

--- a/mem/idealmemcontroller/idealmemcontroller_test.go
+++ b/mem/idealmemcontroller/idealmemcontroller_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Ideal Memory Controller", func() {
 
 	makeReadReq := func() memprotocol.ReadReq {
 		req := memprotocol.ReadReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.Address = 0
@@ -92,7 +92,7 @@ var _ = Describe("Ideal Memory Controller", func() {
 
 	It("should accept write request and add to inflight transactions", func() {
 		writeReq := memprotocol.WriteReq{}
-		writeReq.ID = timing.GetIDGenerator().Generate()
+		writeReq.ID = testIDs.Generate()
 		writeReq.Src = messaging.RemotePort("Agent")
 		writeReq.Dst = topPort.AsRemote()
 		writeReq.Address = 0
@@ -137,7 +137,7 @@ var _ = Describe("Ideal Memory Controller", func() {
 
 	It("should send write response after latency ticks", func() {
 		writeReq := memprotocol.WriteReq{}
-		writeReq.ID = timing.GetIDGenerator().Generate()
+		writeReq.ID = testIDs.Generate()
 		writeReq.Src = messaging.RemotePort("Agent")
 		writeReq.Dst = topPort.AsRemote()
 		writeReq.Address = 0
@@ -164,8 +164,7 @@ var _ = Describe("Ideal Memory Controller", func() {
 		Expect(rsp).To(BeAssignableToTypeOf(memprotocol.WriteDoneRsp{}))
 
 		// Verify data was written to storage
-		data, err := storage.Read(0, 4)
-		Expect(err).ToNot(HaveOccurred())
+		data := storage.Read(0, 4)
 		Expect(data).To(Equal([]byte{0, 1, 2, 3}))
 	})
 
@@ -212,11 +211,10 @@ var _ = Describe("Ideal Memory Controller", func() {
 
 	It("should write with dirty mask", func() {
 		// Pre-write data
-		err := storage.Write(0, []byte{10, 20, 30, 40})
-		Expect(err).ToNot(HaveOccurred())
+		storage.Write(0, []byte{10, 20, 30, 40})
 
 		writeReq := memprotocol.WriteReq{}
-		writeReq.ID = timing.GetIDGenerator().Generate()
+		writeReq.ID = testIDs.Generate()
 		writeReq.Src = messaging.RemotePort("Agent")
 		writeReq.Dst = topPort.AsRemote()
 		writeReq.Address = 0
@@ -238,8 +236,7 @@ var _ = Describe("Ideal Memory Controller", func() {
 		memController.Tick()
 
 		// Check that only dirty bytes were written
-		data, err := storage.Read(0, 4)
-		Expect(err).ToNot(HaveOccurred())
+		data := storage.Read(0, 4)
 		Expect(data).To(Equal([]byte{10, 20, 2, 40}))
 	})
 

--- a/mem/idealmemcontroller/memmiddleware.go
+++ b/mem/idealmemcontroller/memmiddleware.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sarchlab/akita/v5/modeling"
 
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -131,13 +130,10 @@ func (m *memMiddleware) sendResponse(tx *inflightTransaction) bool {
 }
 
 func (m *memMiddleware) sendReadResponse(tx *inflightTransaction) bool {
-	data, err := m.comp.Resources().Storage.Read(tx.Address, tx.AccessByteSize)
-	if err != nil {
-		log.Panic(err)
-	}
+	data := m.comp.Resources().Storage.Read(tx.Address, tx.AccessByteSize)
 
 	rsp := memprotocol.DataReadyRsp{}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = m.comp.IDGenerator().Generate()
 	rsp.Src = m.topPort().AsRemote()
 	rsp.Dst = tx.Src
 	rsp.RspTo = tx.ReqID
@@ -158,7 +154,7 @@ func (m *memMiddleware) sendReadResponse(tx *inflightTransaction) bool {
 
 func (m *memMiddleware) sendWriteResponse(tx *inflightTransaction) bool {
 	rsp := memprotocol.WriteDoneRsp{}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = m.comp.IDGenerator().Generate()
 	rsp.Src = m.topPort().AsRemote()
 	rsp.Dst = tx.Src
 	rsp.RspTo = tx.ReqID
@@ -174,15 +170,9 @@ func (m *memMiddleware) sendWriteResponse(tx *inflightTransaction) bool {
 	addr := tx.Address
 
 	if tx.DirtyMask == nil {
-		err := m.comp.Resources().Storage.Write(addr, tx.Data)
-		if err != nil {
-			log.Panic(err)
-		}
+		m.comp.Resources().Storage.Write(addr, tx.Data)
 	} else {
-		data, err := m.comp.Resources().Storage.Read(addr, uint64(len(tx.Data)))
-		if err != nil {
-			panic(err)
-		}
+		data := m.comp.Resources().Storage.Read(addr, uint64(len(tx.Data)))
 
 		for i := 0; i < len(tx.Data); i++ {
 			if tx.DirtyMask[i] {
@@ -190,10 +180,7 @@ func (m *memMiddleware) sendWriteResponse(tx *inflightTransaction) bool {
 			}
 		}
 
-		err = m.comp.Resources().Storage.Write(addr, data)
-		if err != nil {
-			panic(err)
-		}
+		m.comp.Resources().Storage.Write(addr, data)
 	}
 
 	m.traceReqComplete(tx.RecvTaskID, tx.ReqID)

--- a/mem/idealmemcontroller/reset_leak_test.go
+++ b/mem/idealmemcontroller/reset_leak_test.go
@@ -55,7 +55,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	// Admit a read: takeNewReqs opens the req_in task and parks the access in
 	// InflightTransactions; the access never completes within the ticks below.
 	read := memprotocol.ReadReq{Address: 0, AccessByteSize: 4}
-	read.ID = timing.GetIDGenerator().Generate()
+	read.ID = testIDs.Generate()
 	read.Src = messaging.RemotePort("Agent")
 	read.Dst = topPort.AsRemote()
 	read.TrafficClass = "memprotocol.ReadReq"
@@ -73,7 +73,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	// Reset while the access is in flight.
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = ctrlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/memcontrolprotocol/checkpoint_test.go
+++ b/mem/memcontrolprotocol/checkpoint_test.go
@@ -133,7 +133,7 @@ func (h *cacheOverDRAM) write(t *testing.T, addr uint64, data []byte) {
 	t.Helper()
 
 	req := memprotocol.WriteReq{Address: addr, Data: data}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = h.agent
 	req.Dst = h.top.AsRemote()
 	req.TrafficClass = "memprotocol.WriteReq"
@@ -156,7 +156,7 @@ func (h *cacheOverDRAM) read(t *testing.T, addr uint64, size uint64) []byte {
 	t.Helper()
 
 	req := memprotocol.ReadReq{Address: addr, AccessByteSize: size}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = h.agent
 	req.Dst = h.top.AsRemote()
 	req.TrafficClass = "memprotocol.ReadReq"
@@ -179,7 +179,7 @@ func (h *cacheOverDRAM) control(t *testing.T, cmd memcontrolprotocol.Command) me
 	t.Helper()
 
 	req := memcontrolprotocol.Req{Command: cmd}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = h.agent
 	req.Dst = h.ctrl.AsRemote()
 	req.TrafficClass = "memcontrolprotocol.Req"
@@ -222,10 +222,8 @@ func TestCheckpoint_DrainFlushReset_PersistsAndServesCorrectData(t *testing.T) {
 	// Guarantee 1: after Drain+Flush the backing memory is a complete,
 	// correct snapshot of everything written.
 	for addr, data := range want {
-		got, err := h.dramStorage.Read(addr, uint64(len(data)))
-		if err != nil {
-			t.Fatalf("backing read %#x: %v", addr, err)
-		}
+		got := h.dramStorage.Read(addr, uint64(len(data)))
+
 		if !bytes.Equal(got, data) {
 			t.Errorf("after Flush, backing memory[%#x] = %v, want %v",
 				addr, got, data)
@@ -305,7 +303,7 @@ func TestReset_DropsOrphanedBottomResponse(t *testing.T) {
 	// A read miss makes the cache issue a fetch out the Bottom port. Tick only
 	// the cache (no ferry) and capture that fetch so it stays "outstanding".
 	read := memprotocol.ReadReq{Address: 0, AccessByteSize: 4}
-	read.ID = timing.GetIDGenerator().Generate()
+	read.ID = testIDs.Generate()
 	read.Src = h.agent
 	read.Dst = h.top.AsRemote()
 	read.TrafficClass = "memprotocol.ReadReq"
@@ -325,7 +323,7 @@ func TestReset_DropsOrphanedBottomResponse(t *testing.T) {
 
 	// Reset while the fetch is outstanding (this clears the inflight indices).
 	rst := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	rst.ID = timing.GetIDGenerator().Generate()
+	rst.ID = testIDs.Generate()
 	rst.Src = h.agent
 	rst.Dst = h.ctrl.AsRemote()
 	rst.TrafficClass = "memcontrolprotocol.Req"
@@ -346,7 +344,7 @@ func TestReset_DropsOrphanedBottomResponse(t *testing.T) {
 
 	// The lower memory's now-orphaned response arrives after the reset.
 	rsp := memprotocol.DataReadyRsp{Data: make([]byte, cpBlockSize)}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = testIDs.Generate()
 	rsp.Src = h.dramTop.AsRemote()
 	rsp.Dst = h.bottom.AsRemote()
 	rsp.RspTo = fetch.ID

--- a/mem/memcontrolprotocol/contract.go
+++ b/mem/memcontrolprotocol/contract.go
@@ -326,7 +326,7 @@ func newControlReq(
 	cmd Command,
 ) Req {
 	req := Req{Command: cmd}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = timing.IDsFor(ctrl.Component()).Generate()
 	req.Src = messaging.RemotePort("ContractAgent")
 	req.Dst = ctrl.AsRemote()
 	req.TrafficClass = "Req"

--- a/mem/memcontrolprotocol/contract_test.go
+++ b/mem/memcontrolprotocol/contract_test.go
@@ -1,12 +1,12 @@
 package memcontrolprotocol_test
 
 import (
+	"github.com/sarchlab/akita/v5/timing"
 	"testing"
 
 	"github.com/sarchlab/akita/v5/hooking"
 	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 )
 
 // fakeComp is a minimal component that satisfies the contract harness's
@@ -156,7 +156,7 @@ func (c *fakeComp) makeRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = testIDs.Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo
@@ -271,3 +271,5 @@ func TestState_String(t *testing.T) {
 		}
 	}
 }
+
+func (c *fakeComp) IDGenerator() timing.IDGenerator { return testIDs }

--- a/mem/memcontrolprotocol/id_external_fixture_test.go
+++ b/mem/memcontrolprotocol/id_external_fixture_test.go
@@ -1,0 +1,4 @@
+package memcontrolprotocol_test
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/memcontrolprotocol/property_test.go
+++ b/mem/memcontrolprotocol/property_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 )
 
 // This file is the Layer-4 property/fuzz test. It drives the write-back
@@ -186,7 +185,7 @@ func (f *fuzzer) issueWrite() {
 		byte(f.rng.Intn(256)), byte(f.rng.Intn(256)),
 	}
 	req := memprotocol.WriteReq{Address: addr, Data: data}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = f.h.agent
 	req.Dst = f.h.top.AsRemote()
 	req.TrafficClass = "memprotocol.WriteReq"
@@ -203,7 +202,7 @@ func (f *fuzzer) issueRead() {
 		return
 	}
 	req := memprotocol.ReadReq{Address: addr, AccessByteSize: 4}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = f.h.agent
 	req.Dst = f.h.top.AsRemote()
 	req.TrafficClass = "memprotocol.ReadReq"
@@ -215,7 +214,7 @@ func (f *fuzzer) issueRead() {
 
 func (f *fuzzer) issueControl(cmd memcontrolprotocol.Command) {
 	req := memcontrolprotocol.Req{Command: cmd}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = f.h.agent
 	req.Dst = f.h.ctrl.AsRemote()
 	req.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/memcontrolprotocol/sequence_test.go
+++ b/mem/memcontrolprotocol/sequence_test.go
@@ -37,7 +37,7 @@ func driveCtrl(
 	t.Helper()
 
 	req := memcontrolprotocol.Req{Command: cmd, Addresses: addrs, PID: pid}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = messaging.RemotePort("Cmd")
 	req.Dst = ctrl.AsRemote()
 	req.TrafficClass = "memcontrolprotocol.Req"
@@ -153,7 +153,7 @@ func resolveTranslation(
 	rsp := vmprotocol.TranslationRsp{Page: vm.Page{
 		PID: pid, VAddr: vAddr, PAddr: vAddr + 0x10000, Valid: true,
 	}}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = testIDs.Generate()
 	rsp.Src = remote
 	rsp.Dst = bottom.AsRemote()
 	rsp.RspTo = botReq.ID
@@ -265,7 +265,7 @@ func makeTransReq(
 	pid vm.PID,
 ) vmprotocol.TranslationReq {
 	req := vmprotocol.TranslationReq{}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = messaging.RemotePort("Agent")
 	req.Dst = top.AsRemote()
 	req.PID = pid
@@ -286,7 +286,7 @@ func driveFlushAll(
 	t.Helper()
 
 	flush := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdFlush}
-	flush.ID = timing.GetIDGenerator().Generate()
+	flush.ID = testIDs.Generate()
 	flush.Src = messaging.RemotePort("Cmd")
 	flush.Dst = ctrl.AsRemote()
 	flush.TrafficClass = "memcontrolprotocol.Req"
@@ -328,7 +328,7 @@ func answerWriteBacks(bottom messaging.Port, writtenBack map[byte]bool) {
 			writtenBack[w.Data[0]] = true
 		}
 		done := memprotocol.WriteDoneRsp{}
-		done.ID = timing.GetIDGenerator().Generate()
+		done.ID = testIDs.Generate()
 		done.Src = messaging.RemotePort("LowerCache")
 		done.Dst = bottom.AsRemote()
 		done.RspTo = w.ID
@@ -413,9 +413,7 @@ func installDirtyBlock(
 	for i := range data {
 		data[i] = fill
 	}
-	if err := storage.Write(block.CacheAddress, data); err != nil {
-		t.Fatalf("seed storage: %v", err)
-	}
+	storage.Write(block.CacheAddress, data)
 
 	return setID
 }

--- a/mem/rob/id_fixture_test.go
+++ b/mem/rob/id_fixture_test.go
@@ -1,0 +1,4 @@
+package rob
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/rob/middleware.go
+++ b/mem/rob/middleware.go
@@ -267,7 +267,7 @@ func (m *middleware) buildShadowReq(
 			AccessByteSize: r.AccessByteSize,
 			PID:            r.PID,
 		}
-		shadow.ID = timing.GetIDGenerator().Generate()
+		shadow.ID = m.comp.IDGenerator().Generate()
 		shadow.Src = src
 		shadow.Dst = dst
 		shadow.TrafficBytes = r.TrafficBytes
@@ -280,7 +280,7 @@ func (m *middleware) buildShadowReq(
 			DirtyMask: r.DirtyMask,
 			PID:       r.PID,
 		}
-		shadow.ID = timing.GetIDGenerator().Generate()
+		shadow.ID = m.comp.IDGenerator().Generate()
 		shadow.Src = src
 		shadow.Dst = dst
 		shadow.TrafficBytes = r.TrafficBytes
@@ -296,7 +296,7 @@ func (m *middleware) buildTopRsp(
 ) messaging.Msg {
 	if trans.IsRead {
 		rsp := memprotocol.DataReadyRsp{Data: trans.RspData}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = m.comp.IDGenerator().Generate()
 		rsp.Src = src
 		rsp.Dst = trans.ReqFromTopSrc
 		rsp.RspTo = trans.ReqFromTopID
@@ -306,7 +306,7 @@ func (m *middleware) buildTopRsp(
 	}
 
 	rsp := memprotocol.WriteDoneRsp{}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = m.comp.IDGenerator().Generate()
 	rsp.Src = src
 	rsp.Dst = trans.ReqFromTopSrc
 	rsp.RspTo = trans.ReqFromTopID
@@ -523,7 +523,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/rob/milestone_test.go
+++ b/mem/rob/milestone_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Reorder Buffer milestones", func() {
 
 	makeRead := func(addr uint64) memprotocol.ReadReq {
 		req := memprotocol.ReadReq{Address: addr, AccessByteSize: 4}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = topRemote
 		req.Dst = topPort.AsRemote()
 		req.TrafficClass = "memprotocol.ReadReq"
@@ -127,7 +127,7 @@ var _ = Describe("Reorder Buffer milestones", func() {
 
 	makeWrite := func(addr uint64, data []byte) memprotocol.WriteReq {
 		req := memprotocol.WriteReq{Address: addr, Data: data}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = topRemote
 		req.Dst = topPort.AsRemote()
 		req.TrafficClass = "memprotocol.WriteReq"
@@ -161,7 +161,7 @@ var _ = Describe("Reorder Buffer milestones", func() {
 	It("records admission milestones on the buffer task and processing "+
 		"milestones on req_in, plus a read tag, for a read", func() {
 		rsp := memprotocol.DataReadyRsp{Data: []byte{1, 2, 3, 4}}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = bottomUnitRemote
 		rsp.Dst = bottomPort.AsRemote()
 		rsp.TrafficClass = "memprotocol.DataReadyRsp"
@@ -204,7 +204,7 @@ var _ = Describe("Reorder Buffer milestones", func() {
 
 	It("distinguishes a write with a subtask milestone and a write tag", func() {
 		rsp := memprotocol.WriteDoneRsp{}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = bottomUnitRemote
 		rsp.Dst = bottomPort.AsRemote()
 		rsp.TrafficClass = "memprotocol.WriteDoneRsp"
@@ -225,7 +225,7 @@ var _ = Describe("Reorder Buffer milestones", func() {
 	It("emits the dependency milestone before the response-sent milestone "+
 		"so the in-order-commit reason wins a same-tick tie", func() {
 		rsp := memprotocol.DataReadyRsp{Data: []byte{0xAB}}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = bottomUnitRemote
 		rsp.Dst = bottomPort.AsRemote()
 		rsp.TrafficClass = "memprotocol.DataReadyRsp"

--- a/mem/rob/reset_leak_test.go
+++ b/mem/rob/reset_leak_test.go
@@ -47,7 +47,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	// Admit a read: topDown opens the top req_in and the shadow req_out, then
 	// waits on the bottom response (which never comes — the request is in flight).
 	read := memprotocol.ReadReq{Address: 0, AccessByteSize: 4}
-	read.ID = timing.GetIDGenerator().Generate()
+	read.ID = testIDs.Generate()
 	read.Src = messaging.RemotePort("Agent")
 	read.Dst = topPort.AsRemote()
 	read.TrafficClass = "memprotocol.ReadReq"
@@ -65,7 +65,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	// Reset while the transaction is in flight.
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = ctrlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/rob/rob_test.go
+++ b/mem/rob/rob_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Reorder Buffer", func() {
 			Address:        addr,
 			AccessByteSize: 4,
 		}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = topRemote
 		req.Dst = topPort.AsRemote()
 		req.TrafficBytes = 12
@@ -90,7 +90,7 @@ var _ = Describe("Reorder Buffer", func() {
 			Address: addr,
 			Data:    data,
 		}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = topRemote
 		req.Dst = topPort.AsRemote()
 		req.TrafficBytes = len(data) + 12
@@ -173,7 +173,7 @@ var _ = Describe("Reorder Buffer", func() {
 			// Fill the bottom outgoing buffer so Send fails.
 			for i := 0; i < bottomBufSize; i++ {
 				filler := memprotocol.ReadReq{Address: uint64(i)}
-				filler.ID = timing.GetIDGenerator().Generate()
+				filler.ID = testIDs.Generate()
 				filler.Src = bottomPort.AsRemote()
 				filler.Dst = bottomUnitRemote
 				filler.TrafficClass = "memprotocol.ReadReq"
@@ -190,7 +190,7 @@ var _ = Describe("Reorder Buffer", func() {
 
 		It("panics on unsupported top-port traffic", func() {
 			req := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdFlush}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Src = topRemote
 			req.Dst = topPort.AsRemote()
 			req.TrafficClass = "memcontrolprotocol.Req"
@@ -210,7 +210,7 @@ var _ = Describe("Reorder Buffer", func() {
 			shadowID := rob.State.Transactions[0].ReqToBottomID
 
 			rsp := memprotocol.WriteDoneRsp{}
-			rsp.ID = timing.GetIDGenerator().Generate()
+			rsp.ID = testIDs.Generate()
 			rsp.Src = bottomUnitRemote
 			rsp.Dst = bottomPort.AsRemote()
 			rsp.RspTo = shadowID
@@ -227,7 +227,7 @@ var _ = Describe("Reorder Buffer", func() {
 
 		It("ignores a response that does not match any transaction", func() {
 			rsp := memprotocol.WriteDoneRsp{}
-			rsp.ID = timing.GetIDGenerator().Generate()
+			rsp.ID = testIDs.Generate()
 			rsp.Src = bottomUnitRemote
 			rsp.Dst = bottomPort.AsRemote()
 			rsp.RspTo = 999999
@@ -241,7 +241,7 @@ var _ = Describe("Reorder Buffer", func() {
 
 		It("drops unsupported bottom-port traffic", func() {
 			req := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdFlush}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Src = bottomUnitRemote
 			req.Dst = bottomPort.AsRemote()
 			req.TrafficClass = "memcontrolprotocol.Req"
@@ -266,7 +266,7 @@ var _ = Describe("Reorder Buffer", func() {
 			shadowID := rob.State.Transactions[0].ReqToBottomID
 
 			rsp := memprotocol.DataReadyRsp{Data: []byte{0xDE, 0xAD}}
-			rsp.ID = timing.GetIDGenerator().Generate()
+			rsp.ID = testIDs.Generate()
 			rsp.Src = bottomUnitRemote
 			rsp.Dst = bottomPort.AsRemote()
 			rsp.RspTo = shadowID
@@ -306,7 +306,7 @@ var _ = Describe("Reorder Buffer", func() {
 			// Deliver the second response first; the head must still wait
 			// since its response has not arrived yet.
 			rsp2 := memprotocol.DataReadyRsp{Data: []byte{0x22}}
-			rsp2.ID = timing.GetIDGenerator().Generate()
+			rsp2.ID = testIDs.Generate()
 			rsp2.Src = bottomUnitRemote
 			rsp2.Dst = bottomPort.AsRemote()
 			rsp2.RspTo = shadow2
@@ -324,7 +324,7 @@ var _ = Describe("Reorder Buffer", func() {
 			// Now deliver the response for the head; both should drain in
 			// order on subsequent ticks.
 			rsp1 := memprotocol.DataReadyRsp{Data: []byte{0x11}}
-			rsp1.ID = timing.GetIDGenerator().Generate()
+			rsp1.ID = testIDs.Generate()
 			rsp1.Src = bottomUnitRemote
 			rsp1.Dst = bottomPort.AsRemote()
 			rsp1.RspTo = shadow1
@@ -354,7 +354,7 @@ var _ = Describe("Reorder Buffer", func() {
 
 			shadowID := rob.State.Transactions[0].ReqToBottomID
 			rsp := memprotocol.DataReadyRsp{Data: []byte{0x1}}
-			rsp.ID = timing.GetIDGenerator().Generate()
+			rsp.ID = testIDs.Generate()
 			rsp.Src = bottomUnitRemote
 			rsp.Dst = bottomPort.AsRemote()
 			rsp.RspTo = shadowID
@@ -366,7 +366,7 @@ var _ = Describe("Reorder Buffer", func() {
 			// Fill the top outgoing buffer so the next bottomUp Send fails.
 			for i := 0; i < topBufSize; i++ {
 				filler := memprotocol.DataReadyRsp{Data: []byte{byte(i)}}
-				filler.ID = timing.GetIDGenerator().Generate()
+				filler.ID = testIDs.Generate()
 				filler.Src = topPort.AsRemote()
 				filler.Dst = topRemote
 				filler.TrafficClass = "memprotocol.DataReadyRsp"
@@ -393,7 +393,7 @@ var _ = Describe("Reorder Buffer", func() {
 			req := memcontrolprotocol.Req{
 				Command: memcontrolprotocol.CmdReset,
 			}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Src = messaging.RemotePort("Cmd")
 			req.Dst = ctrlPort.AsRemote()
 			req.TrafficClass = "memcontrolprotocol.Req"
@@ -429,7 +429,7 @@ var _ = Describe("Reorder Buffer", func() {
 			// Stale traffic that should be cleared on resume.
 			topPort.Deliver(makeRead(0))
 			stray := memprotocol.DataReadyRsp{Data: []byte{0xFF}}
-			stray.ID = timing.GetIDGenerator().Generate()
+			stray.ID = testIDs.Generate()
 			stray.Src = bottomUnitRemote
 			stray.Dst = bottomPort.AsRemote()
 			stray.RspTo = 0xDEAD
@@ -437,7 +437,7 @@ var _ = Describe("Reorder Buffer", func() {
 			bottomPort.Deliver(stray)
 
 			req := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdEnable}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Src = messaging.RemotePort("Cmd")
 			req.Dst = ctrlPort.AsRemote()
 			req.TrafficClass = "memcontrolprotocol.Req"
@@ -456,7 +456,7 @@ var _ = Describe("Reorder Buffer", func() {
 
 		makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 			req := memcontrolprotocol.Req{Command: cmd}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Src = messaging.RemotePort("Cmd")
 			req.Dst = ctrlPort.AsRemote()
 			req.TrafficClass = "memcontrolprotocol.Req"
@@ -494,7 +494,7 @@ var _ = Describe("Reorder Buffer", func() {
 			// Now let the in-flight reads complete.
 			for _, id := range shadowIDs {
 				rsp := memprotocol.DataReadyRsp{Data: []byte{0x1}}
-				rsp.ID = timing.GetIDGenerator().Generate()
+				rsp.ID = testIDs.Generate()
 				rsp.Src = bottomUnitRemote
 				rsp.Dst = bottomPort.AsRemote()
 				rsp.RspTo = id

--- a/mem/simplebankedmemory/bank_selection_test.go
+++ b/mem/simplebankedmemory/bank_selection_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Bank selection data correctness with global storage", func() {
 
 		for i, a := range addrs {
 			w := memprotocol.WriteReq{}
-			w.ID = timing.GetIDGenerator().Generate()
+			w.ID = testIDs.Generate()
 			w.Src = agent.port.AsRemote()
 			w.Dst = tp.AsRemote()
 			w.Address = a
@@ -159,7 +159,7 @@ var _ = Describe("Bank selection data correctness with global storage", func() {
 
 		for i, a := range addrs {
 			r := memprotocol.ReadReq{}
-			r.ID = timing.GetIDGenerator().Generate()
+			r.ID = testIDs.Generate()
 			r.Src = agent.port.AsRemote()
 			r.Dst = tp.AsRemote()
 			r.Address = a

--- a/mem/simplebankedmemory/control_behavior_test.go
+++ b/mem/simplebankedmemory/control_behavior_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Simple Banked Memory control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Ctrl")
 		req.Dst = ctrlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/simplebankedmemory/ctrlmiddleware.go
+++ b/mem/simplebankedmemory/ctrlmiddleware.go
@@ -195,7 +195,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/simplebankedmemory/dispatchmw.go
+++ b/mem/simplebankedmemory/dispatchmw.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sarchlab/akita/v5/modeling"
 
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -76,7 +75,7 @@ func (m *dispatchMW) dispatchFromTopPort() bool {
 		// ID rides on the item through the pipeline and is closed at finalize.
 		tracing.TraceReqReceive(m.comp, msg)
 
-		pipelineTaskID := timing.GetIDGenerator().Generate()
+		pipelineTaskID := m.comp.IDGenerator().Generate()
 		tracing.StartTask(m.comp, tracing.TaskStart{
 			ID:       pipelineTaskID,
 			ParentID: tracing.MsgIDAtReceiver(msg, m.comp),

--- a/mem/simplebankedmemory/id_fixture_test.go
+++ b/mem/simplebankedmemory/id_fixture_test.go
@@ -1,0 +1,4 @@
+package simplebankedmemory
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/simplebankedmemory/milestone_test.go
+++ b/mem/simplebankedmemory/milestone_test.go
@@ -121,7 +121,7 @@ var _ = Describe("SimpleBankedMemory admission milestones", func() {
 
 	makeRead := func(addr uint64) memprotocol.ReadReq {
 		req := memprotocol.ReadReq{Address: addr, AccessByteSize: 4}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.TrafficBytes = 12
@@ -210,10 +210,10 @@ var _ = Describe("SimpleBankedMemory pipeline-traversal milestones", func() {
 	It("attributes the bank-pipeline traversal as work on the read "+
 		"req_in", func() {
 		data := []byte{1, 2, 3, 4}
-		Expect(storage.Write(0x40, data)).To(Succeed())
+		storage.Write(0x40, data)
 
 		read := memprotocol.ReadReq{Address: 0x40, AccessByteSize: 4}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = agent.port.AsRemote()
 		read.Dst = topPort.AsRemote()
 		read.TrafficBytes = 12
@@ -253,7 +253,7 @@ var _ = Describe("SimpleBankedMemory pipeline-traversal milestones", func() {
 			Address: 0x80,
 			Data:    []byte{9, 8, 7, 6},
 		}
-		write.ID = timing.GetIDGenerator().Generate()
+		write.ID = testIDs.Generate()
 		write.Src = agent.port.AsRemote()
 		write.Dst = topPort.AsRemote()
 		write.TrafficBytes = len(write.Data) + 12

--- a/mem/simplebankedmemory/reset_leak_test.go
+++ b/mem/simplebankedmemory/reset_leak_test.go
@@ -62,7 +62,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	// Reset while the read is in flight.
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = ctrlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/simplebankedmemory/simplebankedmemory_test.go
+++ b/mem/simplebankedmemory/simplebankedmemory_test.go
@@ -135,8 +135,8 @@ func (a *testAgent) NotifyPortFree(messaging.Port) {
 	// No-op.
 }
 
-func (a *testAgent) Handle(timing.Event) error {
-	return nil
+func (a *testAgent) Handle(timing.Event) {
+	return
 }
 
 func (a *testAgent) send(msg messaging.Msg) {
@@ -189,8 +189,8 @@ func (a *bandwidthAgent) NotifyRecv(port messaging.Port) {
 
 func (a *bandwidthAgent) NotifyPortFree(messaging.Port) {}
 
-func (a *bandwidthAgent) Handle(timing.Event) error {
-	return nil
+func (a *bandwidthAgent) Handle(timing.Event) {
+	return
 }
 
 const (
@@ -229,7 +229,7 @@ func setupExampleSystem() (*Comp, *bandwidthAgent, *loopbackConnection, timing.F
 func makeReadReq(src, dst messaging.RemotePort, index int) memprotocol.ReadReq {
 	addr := uint64(index * readSize)
 	r := memprotocol.ReadReq{}
-	r.ID = timing.GetIDGenerator().Generate()
+	r.ID = testIDs.Generate()
 	r.Src = src
 	r.Dst = dst
 	r.Address = addr
@@ -297,12 +297,11 @@ var _ = Describe("SimpleBankedMemory", func() {
 
 	It("should return read data after configured latency", func() {
 		data := []byte{1, 2, 3, 4}
-		err := storage.Write(0x0, data)
-		Expect(err).NotTo(HaveOccurred())
+		storage.Write(0x0, data)
 
 		topPort := memComp.GetPortByName("Top")
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = agent.port.AsRemote()
 		read.Dst = topPort.AsRemote()
 		read.Address = 0x0
@@ -325,15 +324,14 @@ var _ = Describe("SimpleBankedMemory", func() {
 		addr := uint64(0x100)
 
 		initial := []byte{0xAA, 0xBB, 0xCC, 0xDD}
-		err := storage.Write(addr, initial)
-		Expect(err).NotTo(HaveOccurred())
+		storage.Write(addr, initial)
 
 		newData := []byte{0x10, 0x20, 0x30, 0x40}
 
 		topPort := memComp.GetPortByName("Top")
 
 		write := memprotocol.WriteReq{}
-		write.ID = timing.GetIDGenerator().Generate()
+		write.ID = testIDs.Generate()
 		write.Src = agent.port.AsRemote()
 		write.Dst = topPort.AsRemote()
 		write.Address = addr
@@ -342,7 +340,7 @@ var _ = Describe("SimpleBankedMemory", func() {
 		write.TrafficClass = "memprotocol.WriteReq"
 
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = agent.port.AsRemote()
 		read.Dst = topPort.AsRemote()
 		read.Address = addr
@@ -366,8 +364,7 @@ var _ = Describe("SimpleBankedMemory", func() {
 		Expect(ok).To(BeTrue())
 		Expect(readRsp.Data).To(Equal(newData))
 
-		committed, err := storage.Read(addr, uint64(len(newData)))
-		Expect(err).NotTo(HaveOccurred())
+		committed := storage.Read(addr, uint64(len(newData)))
 		Expect(committed).To(Equal(newData))
 	})
 
@@ -396,7 +393,7 @@ var _ = Describe("SimpleBankedMemory", func() {
 		// Write 4 bytes at a non-zero global address.
 		writeData := []byte{1, 2, 3, 4}
 		write := memprotocol.WriteReq{}
-		write.ID = timing.GetIDGenerator().Generate()
+		write.ID = testIDs.Generate()
 		write.Src = agent.port.AsRemote()
 		write.Dst = topPort.AsRemote()
 		write.Address = 0x200
@@ -406,7 +403,7 @@ var _ = Describe("SimpleBankedMemory", func() {
 
 		// Read the same global address back.
 		read := memprotocol.ReadReq{}
-		read.ID = timing.GetIDGenerator().Generate()
+		read.ID = testIDs.Generate()
 		read.Src = agent.port.AsRemote()
 		read.Dst = topPort.AsRemote()
 		read.Address = 0x200

--- a/mem/simplebankedmemory/tickfinalizemw.go
+++ b/mem/simplebankedmemory/tickfinalizemw.go
@@ -1,14 +1,11 @@
 package simplebankedmemory
 
 import (
-	"log"
-
 	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
 
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -67,11 +64,8 @@ func (m *tickFinalizeMW) finalizeRead(
 	readReq := &item.ReadMsg
 
 	if !item.Committed {
-		data, err := m.comp.Resources().Storage.Read(
+		data := m.comp.Resources().Storage.Read(
 			readReq.Address, readReq.AccessByteSize)
-		if err != nil {
-			log.Panic(err)
-		}
 
 		item.ReadData = data
 		item.Committed = true
@@ -92,7 +86,7 @@ func (m *tickFinalizeMW) finalizeRead(
 	m.finishPipeline(&item.ReadMsg, item.PipelineTaskID)
 
 	rsp := memprotocol.DataReadyRsp{}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = m.comp.IDGenerator().Generate()
 	rsp.Src = m.topPort().AsRemote()
 	rsp.Dst = readReq.Src
 	rsp.RspTo = readReq.ID
@@ -119,14 +113,9 @@ func (m *tickFinalizeMW) finalizeWrite(
 		addr := writeReq.Address
 
 		if writeReq.DirtyMask == nil {
-			if err := m.comp.Resources().Storage.Write(addr, writeReq.Data); err != nil {
-				log.Panic(err)
-			}
+			m.comp.Resources().Storage.Write(addr, writeReq.Data)
 		} else {
-			data, err := m.comp.Resources().Storage.Read(addr, uint64(len(writeReq.Data)))
-			if err != nil {
-				log.Panic(err)
-			}
+			data := m.comp.Resources().Storage.Read(addr, uint64(len(writeReq.Data)))
 
 			for i := range writeReq.Data {
 				if writeReq.DirtyMask[i] {
@@ -134,9 +123,7 @@ func (m *tickFinalizeMW) finalizeWrite(
 				}
 			}
 
-			if err := m.comp.Resources().Storage.Write(addr, data); err != nil {
-				log.Panic(err)
-			}
+			m.comp.Resources().Storage.Write(addr, data)
 		}
 
 		item.Committed = true
@@ -152,7 +139,7 @@ func (m *tickFinalizeMW) finalizeWrite(
 	m.finishPipeline(&item.WriteMsg, item.PipelineTaskID)
 
 	rsp := memprotocol.WriteDoneRsp{}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = m.comp.IDGenerator().Generate()
 	rsp.Src = m.topPort().AsRemote()
 	rsp.Dst = writeReq.Src
 	rsp.RspTo = writeReq.ID

--- a/mem/storage.go
+++ b/mem/storage.go
@@ -1,7 +1,6 @@
 package mem
 
 import (
-	"errors"
 	"sync"
 )
 
@@ -99,25 +98,21 @@ func (s *Storage) parseAddress(addr uint64) (baseAddr, inUnitAddr uint64) {
 	return
 }
 
-func (s *Storage) validateRange(address, length uint64) error {
+func (s *Storage) validateRange(address, length uint64) {
 	if length == 0 {
-		return errors.New("storage access length must be greater than zero")
+		panic("storage access length must be greater than zero")
 	}
 	// Subtraction avoids overflowing address + length.
 	if address > s.capacity || length > s.capacity-address {
-		return errors.New("accessing physical address beyond the storage capacity")
+		panic("accessing physical address beyond the storage capacity")
 	}
-
-	return nil
 }
 
-// Read returns length bytes starting at address. It returns an error for an
+// Read returns length bytes starting at address. It panics for an
 // empty range or a range extending beyond capacity, before allocating data or
 // storage units. A nonempty range may end exactly at capacity.
-func (s *Storage) Read(address uint64, length uint64) ([]byte, error) {
-	if err := s.validateRange(address, length); err != nil {
-		return nil, err
-	}
+func (s *Storage) Read(address uint64, length uint64) []byte {
+	s.validateRange(address, length)
 
 	currAddr := address
 	lenLeft := length
@@ -137,24 +132,24 @@ func (s *Storage) Read(address uint64, length uint64) ([]byte, error) {
 			lenToRead = lenLeftInUnit
 		}
 
+		unit.RLock()
 		copy(res[dataOffset:dataOffset+lenToRead],
 			unit.data[inUnitAddr:inUnitAddr+lenToRead])
+		unit.RUnlock()
 
 		lenLeft -= lenToRead
 		dataOffset += lenToRead
 		currAddr += lenToRead
 	}
 
-	return res, nil
+	return res
 }
 
-// Write stores data starting at address. It returns an error for empty data or
+// Write stores data starting at address. It panics for empty data or
 // a range extending beyond capacity, without allocating storage units or
 // changing stored bytes. A nonempty range may end exactly at capacity.
-func (s *Storage) Write(address uint64, data []byte) error {
-	if err := s.validateRange(address, uint64(len(data))); err != nil {
-		return err
-	}
+func (s *Storage) Write(address uint64, data []byte) {
+	s.validateRange(address, uint64(len(data)))
 
 	currAddr := address
 	dataOffset := uint64(0)
@@ -173,12 +168,12 @@ func (s *Storage) Write(address uint64, data []byte) error {
 			lenToWrite = lenLeftInUnit
 		}
 
+		unit.Lock()
 		copy(unit.data[inUnitAddr:inUnitAddr+lenToWrite],
 			data[dataOffset:dataOffset+lenToWrite])
+		unit.Unlock()
 
 		dataOffset += lenToWrite
 		currAddr += lenToWrite
 	}
-
-	return nil
 }

--- a/mem/storage_checkpoint.go
+++ b/mem/storage_checkpoint.go
@@ -70,11 +70,17 @@ func (s *Storage) LoadCheckpoint(r io.Reader) error {
 		return err
 	}
 
-	data := make(map[uint64]*storageUnit, numUnits)
+	if s.unitSize == 0 || (numUnits > 0 && (s.capacity == 0 || numUnits > 1+(s.capacity-1)/s.unitSize)) {
+		return fmt.Errorf("mem: invalid storage unit count")
+	}
+	data := make(map[uint64]*storageUnit)
 	for i := uint64(0); i < numUnits; i++ {
 		addr, err := readUint64(r)
 		if err != nil {
 			return err
+		}
+		if addr >= s.capacity || addr%s.unitSize != 0 || data[addr] != nil {
+			return fmt.Errorf("mem: invalid or duplicate storage unit address %d", addr)
 		}
 		unit := newStorageUnit(s.unitSize)
 		if _, err := io.ReadFull(r, unit.data); err != nil {

--- a/mem/storage_checkpoint_test.go
+++ b/mem/storage_checkpoint_test.go
@@ -10,13 +10,9 @@ import (
 
 func TestStorageCheckpointRoundTrip(t *testing.T) {
 	src := mem.NewStorage(1 * mem.MB)
-	if err := src.Write(0, []byte{1, 2, 3, 4}); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	src.Write(0, []byte{1, 2, 3, 4})
 	// A second write in a different allocation unit (default unit size 4 KB).
-	if err := src.Write(64*mem.KB, []byte{9, 9, 9}); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	src.Write(64*mem.KB, []byte{9, 9, 9})
 
 	var buf bytes.Buffer
 	if err := src.SaveCheckpoint(&buf); err != nil {
@@ -28,16 +24,16 @@ func TestStorageCheckpointRoundTrip(t *testing.T) {
 		t.Fatalf("LoadCheckpoint: %v", err)
 	}
 
-	got, _ := dst.Read(0, 4)
+	got := dst.Read(0, 4)
 	if !bytes.Equal(got, []byte{1, 2, 3, 4}) {
 		t.Fatalf("Read(0,4) = %v, want [1 2 3 4]", got)
 	}
-	got, _ = dst.Read(64*mem.KB, 3)
+	got = dst.Read(64*mem.KB, 3)
 	if !bytes.Equal(got, []byte{9, 9, 9}) {
 		t.Fatalf("Read(64KB,3) = %v, want [9 9 9]", got)
 	}
 	// An untouched region restores as zeros.
-	got, _ = dst.Read(4, 4)
+	got = dst.Read(4, 4)
 	if !bytes.Equal(got, []byte{0, 0, 0, 0}) {
 		t.Fatalf("untouched Read = %v, want zeros", got)
 	}

--- a/mem/storage_range_test.go
+++ b/mem/storage_range_test.go
@@ -46,25 +46,17 @@ func testInvalidStorageRange(t *testing.T, capacity, address, length uint64, ope
 	s := NewStorageWithUnitSize(capacity, 4)
 	original := []byte{1, 2, 3, 4}
 	if capacity >= 4 {
-		if err := s.Write(0, original); err != nil {
-			t.Fatal(err)
-		}
+		s.Write(0, original)
 	}
 	unitsBefore := len(s.data)
 
-	var err error
-	if operation == "read" {
-		var data []byte
-		data, err = s.Read(address, length)
-		if err != nil && data != nil {
-			t.Errorf("rejected read returned data: %v", data)
+	mustPanic(t, func() {
+		if operation == "read" {
+			s.Read(address, length)
+		} else {
+			s.Write(address, make([]byte, length))
 		}
-	} else {
-		err = s.Write(address, make([]byte, length))
-	}
-	if err == nil {
-		t.Error("invalid range succeeded")
-	}
+	})
 	if len(s.data) != unitsBefore {
 		t.Errorf("invalid range allocated units: %d -> %d", unitsBefore, len(s.data))
 	}
@@ -75,10 +67,7 @@ func testInvalidStorageRange(t *testing.T, capacity, address, length uint64, ope
 
 func TestStorageRejectsHugeReadBeforeAllocation(t *testing.T) {
 	s := NewStorageWithUnitSize(10, 4)
-	data, err := s.Read(1, math.MaxUint64)
-	if err == nil || data != nil {
-		t.Fatalf("huge out-of-range read returned (%v, %v)", data, err)
-	}
+	mustPanic(t, func() { s.Read(1, math.MaxUint64) })
 	if len(s.data) != 0 {
 		t.Fatal("rejected read allocated storage units")
 	}
@@ -103,17 +92,25 @@ func TestStorageValidBoundaryRanges(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewStorageWithUnitSize(tt.capacity, tt.unitSize)
-			data, err := s.Read(tt.address, uint64(len(tt.data)))
-			if err != nil || !bytes.Equal(data, make([]byte, len(tt.data))) {
-				t.Fatalf("untouched boundary read = (%v, %v)", data, err)
+			data := s.Read(tt.address, uint64(len(tt.data)))
+			if !bytes.Equal(data, make([]byte, len(tt.data))) {
+				t.Fatalf("untouched boundary read = %v", data)
 			}
-			if err := s.Write(tt.address, tt.data); err != nil {
-				t.Fatal(err)
-			}
-			data, err = s.Read(tt.address, uint64(len(tt.data)))
-			if err != nil || !bytes.Equal(data, tt.data) {
-				t.Fatalf("boundary round trip = (%v, %v), want %v", data, err, tt.data)
+			s.Write(tt.address, tt.data)
+			data = s.Read(tt.address, uint64(len(tt.data)))
+			if !bytes.Equal(data, tt.data) {
+				t.Fatalf("boundary round trip = %v, want %v", data, tt.data)
 			}
 		})
 	}
+}
+
+func mustPanic(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic")
+		}
+	}()
+	fn()
 }

--- a/mem/storage_test.go
+++ b/mem/storage_test.go
@@ -10,10 +10,10 @@ var _ = Describe("Storage", func() {
 		storage := NewStorage(4096)
 		storage.Write(0, []byte{1, 2, 3, 4})
 
-		res, _ := storage.Read(0, 2)
+		res := storage.Read(0, 2)
 		Expect(res).To(Equal([]byte{1, 2}))
 
-		res, _ = storage.Read(1, 2)
+		res = storage.Read(1, 2)
 		Expect(res).To(Equal([]byte{2, 3}))
 	})
 
@@ -21,19 +21,13 @@ var _ = Describe("Storage", func() {
 		storage := NewStorage(8192)
 		storage.Write(4094, []byte{1, 2, 3, 4})
 
-		res, _ := storage.Read(4094, 4)
+		res := storage.Read(4094, 4)
 		Expect(res).To(Equal([]byte{1, 2, 3, 4}))
 	})
 
-	It("should return error if accessing over the capacity", func() {
+	It("should panic before accessing beyond capacity", func() {
 		storage := NewStorage(4096)
-		err := storage.Write(4097, []byte{1})
-		Expect(err).To(MatchError(
-			"accessing physical address beyond the storage capacity"))
-
-		_, err = storage.Read(4097, 1)
-		Expect(err).To(MatchError(
-			"accessing physical address beyond the storage capacity"))
+		Expect(func() { storage.Write(4097, []byte{1}) }).To(Panic())
+		Expect(func() { storage.Read(4097, 1) }).To(Panic())
 	})
-
 })

--- a/mem/trace/README.md
+++ b/mem/trace/README.md
@@ -43,7 +43,10 @@ import (
 )
 
 // Create a data recorder
-dataRecorder := datarecording.NewDataRecorder("memory_trace")
+dataRecorder, err := datarecording.NewDataRecorder("memory_trace")
+if err != nil {
+    return err
+}
 
 // Create the tracer
 memTracer := trace.NewDBTracer(dataRecorder)

--- a/mem/trace/example_test.go
+++ b/mem/trace/example_test.go
@@ -54,7 +54,10 @@ func Example() {
 	os.Remove(dbPath + ".sqlite3")
 
 	// Create a data recorder
-	dataRecorder := datarecording.NewDataRecorder(dbPath)
+	dataRecorder, err := datarecording.NewDataRecorder(dbPath)
+	if err != nil {
+		panic(err)
+	}
 
 	// Create a time teller
 	timeTeller := &SimpleTimeTeller{currentTime: 0}
@@ -65,7 +68,7 @@ func Example() {
 	runExampleTrace(memTracer, timeTeller)
 
 	// Flush data to database
-	dataRecorder.Flush()
+	datarecording.MustRecord(dataRecorder.Flush())
 
 	// List available tables
 	tables := dataRecorder.ListTables()

--- a/mem/trace/tracer.go
+++ b/mem/trace/tracer.go
@@ -4,8 +4,8 @@ package trace
 import (
 	"github.com/sarchlab/akita/v5/datarecording"
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
-
 	"github.com/sarchlab/akita/v5/timing"
+
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -33,6 +33,7 @@ type memoryTagEntry struct {
 type dbTracer struct {
 	tracing.NopTracer
 
+	ids                 timing.IDGenerator
 	dataRecorder        datarecording.DataRecorder
 	pendingTransactions map[uint64]*memoryTransactionEntry
 }
@@ -40,13 +41,14 @@ type dbTracer struct {
 // NewDBTracer creates a new database-based Tracer.
 func NewDBTracer(dataRecorder datarecording.DataRecorder) tracing.Tracer {
 	t := &dbTracer{
+		ids:                 timing.NewIDGenerator(),
 		dataRecorder:        dataRecorder,
 		pendingTransactions: make(map[uint64]*memoryTransactionEntry),
 	}
 
 	// Create tables for memory transactions and tags
-	t.dataRecorder.CreateTable("memory_transactions", memoryTransactionEntry{})
-	t.dataRecorder.CreateTable("memory_tags", memoryTagEntry{})
+	datarecording.MustRecord(t.dataRecorder.CreateTable("memory_transactions", memoryTransactionEntry{}))
+	datarecording.MustRecord(t.dataRecorder.CreateTable("memory_tags", memoryTagEntry{}))
 
 	return t
 }
@@ -74,13 +76,13 @@ func (t *dbTracer) StartTask(task tracing.TaskStart) {
 // AddTaskTag records a tag on a memory transaction
 func (t *dbTracer) AddTaskTag(tag tracing.TaskTag) {
 	entry := memoryTagEntry{
-		ID:     timing.GetIDGenerator().Generate(),
+		ID:     t.ids.Generate(),
 		TaskID: tag.TaskID,
 		Time:   float64(tag.Time),
 		What:   tag.What,
 	}
 
-	t.dataRecorder.InsertData("memory_tags", entry)
+	datarecording.MustRecord(t.dataRecorder.InsertData("memory_tags", entry))
 }
 
 // EndTask marks the end of a memory transaction
@@ -91,7 +93,7 @@ func (t *dbTracer) EndTask(task tracing.TaskEnd) {
 	}
 
 	entry.EndTime = float64(task.Time)
-	t.dataRecorder.InsertData("memory_transactions", *entry)
+	datarecording.MustRecord(t.dataRecorder.InsertData("memory_transactions", *entry))
 
 	delete(t.pendingTransactions, task.ID)
 }

--- a/mem/trace/tracer_test.go
+++ b/mem/trace/tracer_test.go
@@ -89,7 +89,7 @@ func (suite *TracerTestSuite) TestStartAndEndTask() {
 
 	suite.tracer.EndTask(tracing.TaskEnd{ID: 1, Time: 200})
 
-	suite.dataRecorder.Flush()
+	datarecording.MustRecord(suite.dataRecorder.Flush())
 
 	suite.verifyBasicTransaction()
 }
@@ -148,7 +148,7 @@ func (suite *TracerTestSuite) TestTaskTag() {
 		Time:   150,
 	})
 
-	suite.dataRecorder.Flush()
+	datarecording.MustRecord(suite.dataRecorder.Flush())
 
 	// Verify the tag was recorded
 	rows, err := suite.db.Query(
@@ -197,7 +197,7 @@ func (suite *TracerTestSuite) TestCompleteMemoryTrace() {
 
 	suite.tracer.EndTask(tracing.TaskEnd{ID: 3, Time: 100})
 
-	suite.dataRecorder.Flush()
+	datarecording.MustRecord(suite.dataRecorder.Flush())
 
 	suite.verifyCompleteTransaction()
 	suite.verifyCompleteTag()
@@ -266,7 +266,7 @@ func (suite *TracerTestSuite) TestTaskWithoutAccessReq() {
 
 	suite.tracer.EndTask(tracing.TaskEnd{ID: 4, Time: 20})
 
-	suite.dataRecorder.Flush()
+	datarecording.MustRecord(suite.dataRecorder.Flush())
 
 	// Verify no transaction was recorded (since Detail is not AccessReq)
 	rows, err := suite.db.Query("SELECT COUNT(*) FROM memory_transactions")
@@ -293,7 +293,7 @@ func (suite *TracerTestSuite) TestAddMilestone() {
 	// This should not panic and should do nothing.
 	suite.tracer.AddMilestone(milestone)
 
-	suite.dataRecorder.Flush()
+	datarecording.MustRecord(suite.dataRecorder.Flush())
 }
 
 func TestTracerTestSuite(t *testing.T) {
@@ -309,7 +309,10 @@ func TestDBTracerEndToEnd(t *testing.T) {
 	}
 	tmpFile.Close()
 
-	recorder := datarecording.NewDataRecorder(tmpFile.Name())
+	recorder, err := datarecording.NewDataRecorder(tmpFile.Name())
+	if err != nil {
+		panic(err)
+	}
 	defer recorder.Close()
 	tracer := NewDBTracer(recorder)
 

--- a/mem/vm/addresstranslator/addresstranslator_test.go
+++ b/mem/vm/addresstranslator/addresstranslator_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Address Translator", func() {
 
 		BeforeEach(func() {
 			req = memprotocol.ReadReq{}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Src = messaging.RemotePort("Agent")
 			req.Dst = topPort.AsRemote()
 			req.Address = 0x100
@@ -187,13 +187,13 @@ var _ = Describe("Address Translator", func() {
 
 		BeforeEach(func() {
 			transReq1 = vmprotocol.TranslationReq{}
-			transReq1.ID = timing.GetIDGenerator().Generate()
+			transReq1.ID = testIDs.Generate()
 			transReq1.PID = 1
 			transReq1.VAddr = 0x100
 			transReq1.DeviceID = 1
 			transReq1.TrafficClass = "vmprotocol.TranslationReq"
 			transReq2 = vmprotocol.TranslationReq{}
-			transReq2.ID = timing.GetIDGenerator().Generate()
+			transReq2.ID = testIDs.Generate()
 			transReq2.PID = 1
 			transReq2.VAddr = 0x100
 			transReq2.DeviceID = 1
@@ -214,7 +214,7 @@ var _ = Describe("Address Translator", func() {
 
 		It("should stall if send failed", func() {
 			req := memprotocol.ReadReq{}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Address = 0x10040
 			req.AccessByteSize = 4
 			req.TrafficBytes = 12
@@ -226,7 +226,7 @@ var _ = Describe("Address Translator", func() {
 					PAddr: 0x20000,
 				},
 			}
-			translationRsp.ID = timing.GetIDGenerator().Generate()
+			translationRsp.ID = testIDs.Generate()
 			translationRsp.RspTo = transReq1.ID
 			translationRsp.TrafficClass = "vmprotocol.TranslationRsp"
 
@@ -254,7 +254,7 @@ var _ = Describe("Address Translator", func() {
 
 		It("should forward read request", func() {
 			req := memprotocol.ReadReq{}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Address = 0x10040
 			req.AccessByteSize = 4
 			req.TrafficBytes = 12
@@ -266,7 +266,7 @@ var _ = Describe("Address Translator", func() {
 					PAddr: 0x20000,
 				},
 			}
-			translationRsp.ID = timing.GetIDGenerator().Generate()
+			translationRsp.ID = testIDs.Generate()
 			translationRsp.RspTo = transReq1.ID
 			translationRsp.TrafficClass = "vmprotocol.TranslationRsp"
 
@@ -312,7 +312,7 @@ var _ = Describe("Address Translator", func() {
 			data := []byte{1, 2, 3, 4}
 			dirty := []bool{false, true, false, true}
 			write := memprotocol.WriteReq{}
-			write.ID = timing.GetIDGenerator().Generate()
+			write.ID = testIDs.Generate()
 			write.Address = 0x10040
 			write.Data = data
 			write.DirtyMask = dirty
@@ -325,7 +325,7 @@ var _ = Describe("Address Translator", func() {
 					PAddr: 0x20000,
 				},
 			}
-			translationRsp.ID = timing.GetIDGenerator().Generate()
+			translationRsp.ID = testIDs.Generate()
 			translationRsp.RspTo = transReq1.ID
 			translationRsp.TrafficClass = "vmprotocol.TranslationRsp"
 
@@ -371,7 +371,7 @@ var _ = Describe("Address Translator", func() {
 
 		BeforeEach(func() {
 			readFromTop = memprotocol.ReadReq{}
-			readFromTop.ID = timing.GetIDGenerator().Generate()
+			readFromTop.ID = testIDs.Generate()
 			readFromTop.Src = messaging.RemotePort("Agent")
 			readFromTop.Dst = topPort.AsRemote()
 			readFromTop.Address = 0x10040
@@ -379,7 +379,7 @@ var _ = Describe("Address Translator", func() {
 			readFromTop.TrafficBytes = 12
 			readFromTop.TrafficClass = "memprotocol.ReadReq"
 			readToBottom = memprotocol.ReadReq{}
-			readToBottom.ID = timing.GetIDGenerator().Generate()
+			readToBottom.ID = testIDs.Generate()
 			readToBottom.Src = bottomPort.AsRemote()
 			readToBottom.Dst = messaging.RemotePort("MemPort")
 			readToBottom.Address = 0x20040
@@ -387,14 +387,14 @@ var _ = Describe("Address Translator", func() {
 			readToBottom.TrafficBytes = 12
 			readToBottom.TrafficClass = "memprotocol.ReadReq"
 			writeFromTop = memprotocol.WriteReq{}
-			writeFromTop.ID = timing.GetIDGenerator().Generate()
+			writeFromTop.ID = testIDs.Generate()
 			writeFromTop.Src = messaging.RemotePort("Agent")
 			writeFromTop.Dst = topPort.AsRemote()
 			writeFromTop.Address = 0x10040
 			writeFromTop.TrafficBytes = 12
 			writeFromTop.TrafficClass = "memprotocol.WriteReq"
 			writeToBottom = memprotocol.WriteReq{}
-			writeToBottom.ID = timing.GetIDGenerator().Generate()
+			writeToBottom.ID = testIDs.Generate()
 			writeToBottom.Src = bottomPort.AsRemote()
 			writeToBottom.Dst = messaging.RemotePort("MemPort")
 			writeToBottom.Address = 0x10040
@@ -434,7 +434,7 @@ var _ = Describe("Address Translator", func() {
 
 		It("should respond data ready", func() {
 			dataReady := memprotocol.DataReadyRsp{}
-			dataReady.ID = timing.GetIDGenerator().Generate()
+			dataReady.ID = testIDs.Generate()
 			dataReady.RspTo = readToBottom.ID
 			dataReady.TrafficBytes = 4
 			dataReady.TrafficClass = "memprotocol.DataReadyRsp"
@@ -455,7 +455,7 @@ var _ = Describe("Address Translator", func() {
 
 		It("should respond write done", func() {
 			done := memprotocol.WriteDoneRsp{}
-			done.ID = timing.GetIDGenerator().Generate()
+			done.ID = testIDs.Generate()
 			done.RspTo = writeToBottom.ID
 			done.TrafficBytes = 4
 			done.TrafficClass = "memprotocol.WriteDoneRsp"
@@ -475,7 +475,7 @@ var _ = Describe("Address Translator", func() {
 
 		It("should stall if TopPort is busy", func() {
 			dataReady := memprotocol.DataReadyRsp{}
-			dataReady.ID = timing.GetIDGenerator().Generate()
+			dataReady.ID = testIDs.Generate()
 			dataReady.RspTo = readToBottom.ID
 			dataReady.TrafficBytes = 4
 			dataReady.TrafficClass = "memprotocol.DataReadyRsp"
@@ -511,31 +511,31 @@ var _ = Describe("Address Translator", func() {
 
 		BeforeEach(func() {
 			readFromTop = memprotocol.ReadReq{}
-			readFromTop.ID = timing.GetIDGenerator().Generate()
+			readFromTop.ID = testIDs.Generate()
 			readFromTop.Address = 0x10040
 			readFromTop.AccessByteSize = 4
 			readFromTop.TrafficBytes = 12
 			readFromTop.TrafficClass = "memprotocol.ReadReq"
 			readToBottom = memprotocol.ReadReq{}
-			readToBottom.ID = timing.GetIDGenerator().Generate()
+			readToBottom.ID = testIDs.Generate()
 			readToBottom.Address = 0x20040
 			readToBottom.AccessByteSize = 4
 			readToBottom.TrafficBytes = 12
 			readToBottom.TrafficClass = "memprotocol.ReadReq"
 			writeFromTop = memprotocol.WriteReq{}
-			writeFromTop.ID = timing.GetIDGenerator().Generate()
+			writeFromTop.ID = testIDs.Generate()
 			writeFromTop.Address = 0x10040
 			writeFromTop.TrafficBytes = 12
 			writeFromTop.TrafficClass = "memprotocol.WriteReq"
 			writeToBottom = memprotocol.WriteReq{}
-			writeToBottom.ID = timing.GetIDGenerator().Generate()
+			writeToBottom.ID = testIDs.Generate()
 			writeToBottom.Address = 0x10040
 			writeToBottom.TrafficBytes = 12
 			writeToBottom.TrafficClass = "memprotocol.WriteReq"
 			flushReq = memcontrolprotocol.Req{
 				Command: memcontrolprotocol.CmdFlush,
 			}
-			flushReq.ID = timing.GetIDGenerator().Generate()
+			flushReq.ID = testIDs.Generate()
 			flushReq.Src = messaging.RemotePort("Agent")
 			flushReq.Dst = ctrlPort.AsRemote()
 			flushReq.TrafficBytes = 4
@@ -543,7 +543,7 @@ var _ = Describe("Address Translator", func() {
 			restartReq = memcontrolprotocol.Req{
 				Command: memcontrolprotocol.CmdReset,
 			}
-			restartReq.ID = timing.GetIDGenerator().Generate()
+			restartReq.ID = testIDs.Generate()
 			restartReq.Src = messaging.RemotePort("Agent")
 			restartReq.Dst = ctrlPort.AsRemote()
 			restartReq.TrafficBytes = 4
@@ -611,7 +611,7 @@ var _ = Describe("Address Translator", func() {
 func fillOutgoing(p messaging.Port, n int) {
 	for i := 0; i < n; i++ {
 		dummy := memprotocol.WriteDoneRsp{}
-		dummy.ID = timing.GetIDGenerator().Generate()
+		dummy.ID = testIDs.Generate()
 		dummy.Src = p.AsRemote()
 		dummy.Dst = messaging.RemotePort("Dummy")
 		dummy.TrafficClass = "memprotocol.WriteDoneRsp"

--- a/mem/vm/addresstranslator/comp.go
+++ b/mem/vm/addresstranslator/comp.go
@@ -112,6 +112,7 @@ func msgToIncomingReqState(msg messaging.Msg) incomingReqState {
 }
 
 func createTranslatedReq(
+	ids timing.IDGenerator,
 	reqState incomingReqState,
 	page vm.Page,
 	log2PageSize uint64,
@@ -124,7 +125,7 @@ func createTranslatedReq(
 	switch reqState.Type {
 	case "memprotocol.ReadReq":
 		clone := memprotocol.ReadReq{}
-		clone.ID = timing.GetIDGenerator().Generate()
+		clone.ID = ids.Generate()
 		clone.Src = bottomPortRemote
 		clone.Dst = memProviderMapper.Find(addr)
 		clone.Address = addr
@@ -136,7 +137,7 @@ func createTranslatedReq(
 		return clone
 	case "memprotocol.WriteReq":
 		clone := memprotocol.WriteReq{}
-		clone.ID = timing.GetIDGenerator().Generate()
+		clone.ID = ids.Generate()
 		clone.Src = bottomPortRemote
 		clone.Dst = memProviderMapper.Find(addr)
 		clone.Data = reqState.Data

--- a/mem/vm/addresstranslator/control_behavior_test.go
+++ b/mem/vm/addresstranslator/control_behavior_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Address Translator control behavior", func() {
 
 	makeRead := func(addr uint64) memprotocol.ReadReq {
 		req := memprotocol.ReadReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.Address = addr
@@ -80,7 +80,7 @@ var _ = Describe("Address Translator control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Ctrl")
 		req.Dst = ctrlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -92,7 +92,7 @@ var _ = Describe("Address Translator control behavior", func() {
 	// as createTranslatedReq does.
 	makeBottomReq := func(addr uint64) memprotocol.ReadReq {
 		req := memprotocol.ReadReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = bottomPort.AsRemote()
 		req.Dst = messaging.RemotePort("MemPort")
 		req.Address = addr
@@ -126,7 +126,7 @@ var _ = Describe("Address Translator control behavior", func() {
 	// DataReadyRsp out Top, and removes the in-flight entry.
 	feedBottomDataReady := func(rspTo uint64) {
 		dataReady := memprotocol.DataReadyRsp{}
-		dataReady.ID = timing.GetIDGenerator().Generate()
+		dataReady.ID = testIDs.Generate()
 		dataReady.Src = messaging.RemotePort("MemPort")
 		dataReady.Dst = bottomPort.AsRemote()
 		dataReady.RspTo = rspTo

--- a/mem/vm/addresstranslator/ctrlmiddleware.go
+++ b/mem/vm/addresstranslator/ctrlmiddleware.go
@@ -192,7 +192,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/vm/addresstranslator/id_fixture_test.go
+++ b/mem/vm/addresstranslator/id_fixture_test.go
@@ -1,0 +1,4 @@
+package addresstranslator
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/vm/addresstranslator/id_mock_test.go
+++ b/mem/vm/addresstranslator/id_mock_test.go
@@ -1,0 +1,4 @@
+package addresstranslator
+import "github.com/sarchlab/akita/v5/timing"
+func (m *MockEngine) IDGenerator() timing.IDGenerator { return mockIDs }
+var mockIDs = timing.NewIDGenerator()

--- a/mem/vm/addresstranslator/milestone_test.go
+++ b/mem/vm/addresstranslator/milestone_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Address Translator milestones", func() {
 
 	makeRead := func(addr uint64) memprotocol.ReadReq {
 		req := memprotocol.ReadReq{Address: addr, AccessByteSize: 4}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.TrafficBytes = 12
@@ -156,7 +156,7 @@ var _ = Describe("Address Translator milestones", func() {
 
 	makeWrite := func(addr uint64, data []byte) memprotocol.WriteReq {
 		req := memprotocol.WriteReq{Address: addr, Data: data}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.TrafficBytes = len(data) + 12
@@ -182,7 +182,7 @@ var _ = Describe("Address Translator milestones", func() {
 		transRsp := vmprotocol.TranslationRsp{
 			Page: vm.Page{PID: 1, VAddr: 0x10000, PAddr: 0x20000},
 		}
-		transRsp.ID = timing.GetIDGenerator().Generate()
+		transRsp.ID = testIDs.Generate()
 		transRsp.RspTo = transReqID
 		transRsp.TrafficClass = "vmprotocol.TranslationRsp"
 		translationPort.Deliver(transRsp)
@@ -200,7 +200,7 @@ var _ = Describe("Address Translator milestones", func() {
 	It("splits admission (buffer task) from processing (req_in) for a read", func() {
 		driveRoundTrip(makeRead(0x10040), func(rspTo uint64) messaging.Msg {
 			rsp := memprotocol.DataReadyRsp{Data: []byte{1, 2, 3, 4}}
-			rsp.ID = timing.GetIDGenerator().Generate()
+			rsp.ID = testIDs.Generate()
 			rsp.RspTo = rspTo
 			rsp.TrafficClass = "memprotocol.DataReadyRsp"
 			return rsp
@@ -243,7 +243,7 @@ var _ = Describe("Address Translator milestones", func() {
 			makeWrite(0x10040, []byte{1, 2, 3, 4}),
 			func(rspTo uint64) messaging.Msg {
 				rsp := memprotocol.WriteDoneRsp{}
-				rsp.ID = timing.GetIDGenerator().Generate()
+				rsp.ID = testIDs.Generate()
 				rsp.RspTo = rspTo
 				rsp.TrafficClass = "memprotocol.WriteDoneRsp"
 				return rsp
@@ -264,8 +264,8 @@ var _ = Describe("Address Translator milestones", func() {
 		// Two in-flight transactions; complete the first (non-last) one. The
 		// removeTransaction append-shift must not redirect the trace finalize
 		// to the surviving transaction shifted into the freed slot.
-		transReq1ID := timing.GetIDGenerator().Generate()
-		transReq2ID := timing.GetIDGenerator().Generate()
+		transReq1ID := testIDs.Generate()
+		transReq2ID := testIDs.Generate()
 
 		req := makeRead(0x10040)
 
@@ -287,7 +287,7 @@ var _ = Describe("Address Translator milestones", func() {
 		transRsp := vmprotocol.TranslationRsp{
 			Page: vm.Page{PID: 1, VAddr: 0x10000, PAddr: 0x20000},
 		}
-		transRsp.ID = timing.GetIDGenerator().Generate()
+		transRsp.ID = testIDs.Generate()
 		transRsp.RspTo = transReq1ID
 		transRsp.TrafficClass = "vmprotocol.TranslationRsp"
 		translationPort.Deliver(transRsp)

--- a/mem/vm/addresstranslator/parsetranslatemw.go
+++ b/mem/vm/addresstranslator/parsetranslatemw.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/modeling"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -53,7 +52,7 @@ func (m *parseTranslateMW) translate() bool {
 	vPageID := addrToPageID(vAddr, spec.Log2PageSize)
 
 	transReq := vmprotocol.TranslationReq{}
-	transReq.ID = timing.GetIDGenerator().Generate()
+	transReq.ID = m.comp.IDGenerator().Generate()
 	transReq.Src = m.translationPort().AsRemote()
 	transReq.Dst = m.comp.Resources().TranslationProviderMapper.Find(vAddr)
 	transReq.PID = item.GetPID()

--- a/mem/vm/addresstranslator/reset_leak_test.go
+++ b/mem/vm/addresstranslator/reset_leak_test.go
@@ -64,7 +64,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	// flight). Tick until the transaction is created and the TranslationReq has
 	// actually gone out the Translation port.
 	read := memprotocol.ReadReq{Address: 0x1040, AccessByteSize: 4}
-	read.ID = timing.GetIDGenerator().Generate()
+	read.ID = testIDs.Generate()
 	read.Src = messaging.RemotePort("Agent")
 	read.Dst = topPort.AsRemote()
 	read.TrafficBytes = 12
@@ -96,7 +96,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	// Reset while the transaction is in flight (translation never answered).
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = ctrlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/vm/addresstranslator/respondpipelinemw.go
+++ b/mem/vm/addresstranslator/respondpipelinemw.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
 
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 
 	// respondPipelineMW handles translation responses and bottom-port responses.
@@ -74,7 +73,7 @@ func (m *respondPipelineMW) parseTranslation() bool {
 	nextTrans := &nextState.Transactions[transIdx]
 	reqState := nextTrans.IncomingReqs[0]
 	spec := m.comp.Spec()
-	translatedReq := createTranslatedReq(reqState, rsp.Page,
+	translatedReq := createTranslatedReq(m.comp.IDGenerator(), reqState, rsp.Page,
 		spec.Log2PageSize, m.bottomPort().AsRemote(),
 		m.comp.Resources().MemProviderMapper)
 
@@ -175,7 +174,7 @@ func (m *respondPipelineMW) respond() bool {
 			reqFromTopState = findReqToBottomByID(nextState.InflightReqToBottom, rsp.RspTo)
 			rspToTop = memprotocol.DataReadyRsp{
 				MsgMeta: messaging.MsgMeta{
-					ID:           timing.GetIDGenerator().Generate(),
+					ID:           m.comp.IDGenerator().Generate(),
 					Src:          m.topPort().AsRemote(),
 					Dst:          reqFromTopState.ReqFromTopSrc,
 					RspTo:        reqFromTopState.ReqFromTopID,
@@ -202,7 +201,7 @@ func (m *respondPipelineMW) respond() bool {
 			reqFromTopState = findReqToBottomByID(nextState.InflightReqToBottom, rsp.RspTo)
 			rspToTop = memprotocol.WriteDoneRsp{
 				MsgMeta: messaging.MsgMeta{
-					ID:           timing.GetIDGenerator().Generate(),
+					ID:           m.comp.IDGenerator().Generate(),
 					Src:          m.topPort().AsRemote(),
 					Dst:          reqFromTopState.ReqFromTopSrc,
 					RspTo:        reqFromTopState.ReqFromTopID,

--- a/mem/vm/gmmu/comp_test.go
+++ b/mem/vm/gmmu/comp_test.go
@@ -99,7 +99,7 @@ var _ = Describe("GMMU", func() {
 
 	makeTranslationReq := func(vAddr uint64) vmprotocol.TranslationReq {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = agentPort
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -211,7 +211,7 @@ var _ = Describe("GMMU", func() {
 			rsp := vmprotocol.TranslationRsp{
 				Page: page,
 			}
-			rsp.ID = timing.GetIDGenerator().Generate()
+			rsp.ID = testIDs.Generate()
 			rsp.Src = lowModulePort
 			rsp.Dst = bottomPort.AsRemote()
 			rsp.RspTo = sentReqToBottom.ID

--- a/mem/vm/gmmu/control_behavior_test.go
+++ b/mem/vm/gmmu/control_behavior_test.go
@@ -75,7 +75,7 @@ var _ = Describe("GMMU control behavior", func() {
 
 	makeTranslationReq := func(vAddr uint64) vmprotocol.TranslationReq {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = agentPort
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -87,7 +87,7 @@ var _ = Describe("GMMU control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Ctrl")
 		req.Dst = ctrlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/vm/gmmu/ctrlmiddleware.go
+++ b/mem/vm/gmmu/ctrlmiddleware.go
@@ -192,7 +192,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/vm/gmmu/id_fixture_test.go
+++ b/mem/vm/gmmu/id_fixture_test.go
@@ -1,0 +1,4 @@
+package gmmu
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/vm/gmmu/milestone_test.go
+++ b/mem/vm/gmmu/milestone_test.go
@@ -137,7 +137,7 @@ var _ = Describe("GMMU milestones", func() {
 
 	makeReq := func(vAddr uint64) vmprotocol.TranslationReq {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = agentPort
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -192,14 +192,14 @@ var _ = Describe("GMMU milestones", func() {
 		// A remote walk is outstanding so the bottom response matches a
 		// transaction and is forwarded upstream.
 		walking := transactionState{
-			ReqID:    timing.GetIDGenerator().Generate(),
+			ReqID:    testIDs.Generate(),
 			ReqSrc:   agentPort,
 			ReqDst:   topPort.AsRemote(),
 			PID:      1,
 			VAddr:    0x1000,
 			DeviceID: 1,
 		}
-		remoteReqID := timing.GetIDGenerator().Generate()
+		remoteReqID := testIDs.Generate()
 		gmmuComp.State.RemoteMemReqs = map[uint64]transactionState{
 			remoteReqID: walking,
 		}
@@ -207,7 +207,7 @@ var _ = Describe("GMMU milestones", func() {
 		rsp := vmprotocol.TranslationRsp{
 			Page: vm.Page{PID: 1, VAddr: 0x1000, PAddr: 0x2000},
 		}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = lowModulePort
 		rsp.Dst = bottomPort.AsRemote()
 		rsp.RspTo = remoteReqID
@@ -295,7 +295,7 @@ var _ = Describe("GMMU milestones", func() {
 
 		// Deliver the remote response.
 		rsp := vmprotocol.TranslationRsp{Page: page}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = lowModulePort
 		rsp.Dst = bottomPort.AsRemote()
 		rsp.RspTo = downstream.ID

--- a/mem/vm/gmmu/reset_leak_test.go
+++ b/mem/vm/gmmu/reset_leak_test.go
@@ -64,7 +64,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	})
 
 	req := vmprotocol.TranslationReq{}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = agentPort
 	req.Dst = topPort.AsRemote()
 	req.PID = 1
@@ -96,7 +96,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	// Reset while the remote walk is in flight; the remote response is never
 	// delivered.
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = ctrlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/vm/gmmu/respondmw.go
+++ b/mem/vm/gmmu/respondmw.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
 
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 
 	// respondMW handles the bottom→top response path:
@@ -88,7 +87,7 @@ func (m *respondMW) handleTranslationRsp(rsp vmprotocol.TranslationRsp) bool {
 	rspToTop := vmprotocol.TranslationRsp{
 		Page: rsp.Page,
 	}
-	rspToTop.ID = timing.GetIDGenerator().Generate()
+	rspToTop.ID = m.comp.IDGenerator().Generate()
 	rspToTop.Src = m.topPort().AsRemote()
 	rspToTop.Dst = reqTransaction.ReqSrc
 	rspToTop.RspTo = rsp.ID

--- a/mem/vm/gmmu/walkmw.go
+++ b/mem/vm/gmmu/walkmw.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
 
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 
 	// walkMW handles the top→page-table walk path:
@@ -90,7 +89,7 @@ func (m *walkMW) startWalking(req vmprotocol.TranslationReq) {
 	state := &m.comp.State
 
 	recvTaskID := tracing.MsgIDAtReceiver(req, m.comp)
-	walkTaskID := timing.GetIDGenerator().Generate()
+	walkTaskID := m.comp.IDGenerator().Generate()
 
 	ts := transactionState{
 		ReqID:      req.ID,
@@ -190,7 +189,7 @@ func (m *walkMW) processRemoteMemReq(
 	walking := state.WalkingTranslations[walkingIndex]
 
 	req := vmprotocol.TranslationReq{}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = m.comp.IDGenerator().Generate()
 	req.Src = m.bottomPort().AsRemote()
 	req.Dst = spec.LowModule
 	req.PID = vm.PID(walking.PID)
@@ -249,7 +248,7 @@ func (m *walkMW) doPageWalkHit(
 	rsp := vmprotocol.TranslationRsp{
 		Page: pageFromPageState(walking.Page),
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = m.comp.IDGenerator().Generate()
 	rsp.Src = m.topPort().AsRemote()
 	rsp.Dst = walking.ReqSrc
 	rsp.RspTo = walking.ReqID

--- a/mem/vm/lruset/lruset_json.go
+++ b/mem/vm/lruset/lruset_json.go
@@ -1,6 +1,9 @@
 package lruset
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // setJSON is the JSON form of a Set. The Set's fields are unexported, so without
 // these methods encoding/json would serialize a Set as an empty object and
@@ -34,6 +37,26 @@ func (s *Set) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	if dto.WayCount < 0 || len(dto.LastVisits) != dto.WayCount {
+		return fmt.Errorf("lruset: invalid way count")
+	}
+	seen := make(map[int]bool)
+	for _, way := range dto.VisitList {
+		if way < 0 || way >= dto.WayCount || seen[way] {
+			return fmt.Errorf("lruset: invalid visit list")
+		}
+		seen[way] = true
+	}
+	for _, way := range dto.KeyMap {
+		if way < 0 || way >= dto.WayCount {
+			return fmt.Errorf("lruset: invalid key mapping")
+		}
+	}
+	for _, visit := range dto.LastVisits {
+		if visit > dto.VisitCount {
+			return fmt.Errorf("lruset: invalid visit counter")
+		}
+	}
 	s.wayCount = dto.WayCount
 	s.visitList = dto.VisitList
 	s.visitCount = dto.VisitCount

--- a/mem/vm/lruset/validation_test.go
+++ b/mem/vm/lruset/validation_test.go
@@ -1,0 +1,25 @@
+package lruset
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRestoreRejectsInvalidLRUState(t *testing.T) {
+	for _, input := range []string{
+		`{"way_count":-1}`,
+		`{"way_count":1,"last_visits":[]}`,
+		`{"way_count":1,"last_visits":[0],"visit_list":[1]}`,
+		`{"way_count":1,"last_visits":[0],"visit_list":[0,0]}`,
+		`{"way_count":1,"last_visits":[0],"key_map":{"key":-1}}`,
+		`{"way_count":1,"last_visits":[2],"visit_count":1}`,
+	} {
+		s := NewSet(2)
+		if err := json.Unmarshal([]byte(input), &s); err == nil {
+			t.Fatalf("accepted %s", input)
+		}
+		if way, ok := s.Evict(); !ok || way != 0 {
+			t.Fatal("invalid JSON changed the original eviction order")
+		}
+	}
+}

--- a/mem/vm/mmu/control_behavior_test.go
+++ b/mem/vm/mmu/control_behavior_test.go
@@ -64,7 +64,7 @@ var _ = Describe("MMU control behavior", func() {
 
 	makeTranslationReq := func(vAddr uint64) vmprotocol.TranslationReq {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -76,7 +76,7 @@ var _ = Describe("MMU control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Ctrl")
 		req.Dst = ctrlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/vm/mmu/ctrlmiddleware.go
+++ b/mem/vm/mmu/ctrlmiddleware.go
@@ -175,7 +175,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/vm/mmu/id_fixture_test.go
+++ b/mem/vm/mmu/id_fixture_test.go
@@ -1,0 +1,4 @@
+package mmu
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/vm/mmu/milestone_test.go
+++ b/mem/vm/mmu/milestone_test.go
@@ -91,7 +91,7 @@ var _ = Describe("MMU milestones", func() {
 
 	makeReq := func(vAddr uint64) vmprotocol.TranslationReq {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent.Top")
 		req.Dst = topPort.AsRemote()
 		req.PID = 1

--- a/mem/vm/mmu/mmu_test.go
+++ b/mem/vm/mmu/mmu_test.go
@@ -83,7 +83,7 @@ var _ = Describe("MMU", func() {
 	Context("parse top", func() {
 		It("should process translation request", func() {
 			translationReq := vmprotocol.TranslationReq{}
-			translationReq.ID = timing.GetIDGenerator().Generate()
+			translationReq.ID = testIDs.Generate()
 			translationReq.Src = messaging.RemotePort("Agent.Top")
 			translationReq.Dst = topPort.AsRemote()
 			translationReq.PID = 1
@@ -116,7 +116,7 @@ var _ = Describe("MMU", func() {
 			mmuComp.State = State{
 				WalkingTranslations: []transactionState{
 					{
-						ReqID:     timing.GetIDGenerator().Generate(),
+						ReqID:     testIDs.Generate(),
 						ReqDst:    topPort.AsRemote(),
 						PID:       1,
 						VAddr:     0x1020,
@@ -146,7 +146,7 @@ var _ = Describe("MMU", func() {
 			mmuComp.State = State{
 				WalkingTranslations: []transactionState{
 					{
-						ReqID:     timing.GetIDGenerator().Generate(),
+						ReqID:     testIDs.Generate(),
 						ReqSrc:    messaging.RemotePort("Agent.Top"),
 						ReqDst:    topPort.AsRemote(),
 						PID:       1,
@@ -191,7 +191,7 @@ var _ = Describe("MMU", func() {
 			mmuComp.State = State{
 				WalkingTranslations: []transactionState{
 					{
-						ReqID:     timing.GetIDGenerator().Generate(),
+						ReqID:     testIDs.Generate(),
 						ReqSrc:    messaging.RemotePort("Agent.Top"),
 						ReqDst:    topPort.AsRemote(),
 						PID:       1,
@@ -252,7 +252,7 @@ var _ = Describe("MMU Integration", func() {
 		pageTable.Insert(page)
 
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = agentPort.AsRemote()
 		req.Dst = topPort.AsRemote()
 		req.PID = 1

--- a/mem/vm/mmu/reset_leak_test.go
+++ b/mem/vm/mmu/reset_leak_test.go
@@ -55,7 +55,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	pageTable.Insert(page)
 
 	req := vmprotocol.TranslationReq{}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = messaging.RemotePort("Agent")
 	req.Dst = topPort.AsRemote()
 	req.PID = 1
@@ -80,7 +80,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	// Reset while the walk is in flight.
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = ctrlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/vm/mmu/state_test.go
+++ b/mem/vm/mmu/state_test.go
@@ -81,7 +81,7 @@ func TestStateAndStateAssignment(t *testing.T) {
 	engine := timing.NewSerialEngine()
 	mmu := buildTestMMU(engine, "TestMMU")
 
-	reqID := timing.GetIDGenerator().Generate()
+	reqID := testIDs.Generate()
 	state := makeTestState(reqID)
 
 	mmu.State = state

--- a/mem/vm/mmu/translationmw.go
+++ b/mem/vm/mmu/translationmw.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sarchlab/akita/v5/mem/vm/vmprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
 
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 
 	// pageTable aggregates all the methods of the page table that are used in the MMU package.
@@ -122,7 +121,7 @@ func (m *translationMW) doPageWalkHit(walkingIndex int) bool {
 	rsp := vmprotocol.TranslationRsp{
 		Page: walking.Page,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = m.comp.IDGenerator().Generate()
 	rsp.Src = m.topPort().AsRemote()
 	rsp.Dst = walking.ReqSrc
 	rsp.RspTo = walking.ReqID
@@ -190,7 +189,7 @@ func (m *translationMW) startWalking(req vmprotocol.TranslationReq) {
 	state := &m.comp.State
 
 	recvTaskID := tracing.MsgIDAtReceiver(req, m.comp)
-	walkTaskID := timing.GetIDGenerator().Generate()
+	walkTaskID := m.comp.IDGenerator().Generate()
 
 	ts := transactionState{
 		ReqID:        req.ID,

--- a/mem/vm/mmuCache/control_behavior_test.go
+++ b/mem/vm/mmuCache/control_behavior_test.go
@@ -65,7 +65,7 @@ var _ = Describe("MMUCache control behavior", func() {
 
 	makeTranslationReq := func(vAddr uint64) vmprotocol.TranslationReq {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Requester")
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -77,7 +77,7 @@ var _ = Describe("MMUCache control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Ctrl")
 		req.Dst = controlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -92,7 +92,7 @@ var _ = Describe("MMUCache control behavior", func() {
 				PID: fwd.PID, VAddr: fwd.VAddr, PAddr: 0x5000, Valid: true,
 			},
 		}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = messaging.RemotePort("LowModule")
 		rsp.Dst = bottomPort.AsRemote()
 		rsp.RspTo = fwd.ID

--- a/mem/vm/mmuCache/ctrlMiddleware_test.go
+++ b/mem/vm/mmuCache/ctrlMiddleware_test.go
@@ -59,12 +59,12 @@ var _ = Describe("MMUCacheCtrlMiddleware", func() {
 
 	It("should restart and drain ports", func() {
 		req := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Requester")
 		req.TrafficClass = "memcontrolprotocol.Req"
 
 		topMsg := vmprotocol.TranslationReq{}
-		topMsg.ID = timing.GetIDGenerator().Generate()
+		topMsg.ID = testIDs.Generate()
 		topMsg.Src = messaging.RemotePort("Requester")
 		topMsg.Dst = topPort.AsRemote()
 		topMsg.PID = 1
@@ -76,10 +76,10 @@ var _ = Describe("MMUCacheCtrlMiddleware", func() {
 		bottomMsg := vmprotocol.TranslationRsp{
 			Page: vm.Page{},
 		}
-		bottomMsg.ID = timing.GetIDGenerator().Generate()
+		bottomMsg.ID = testIDs.Generate()
 		bottomMsg.Src = messaging.RemotePort("LowModule")
 		bottomMsg.Dst = bottomPort.AsRemote()
-		bottomMsg.RspTo = timing.GetIDGenerator().Generate()
+		bottomMsg.RspTo = testIDs.Generate()
 		bottomMsg.TrafficClass = "vmprotocol.TranslationRsp"
 		bottomPort.Deliver(bottomMsg)
 
@@ -102,7 +102,7 @@ var _ = Describe("MMUCacheCtrlMiddleware", func() {
 
 	It("should reject Flush as unsupported", func() {
 		req := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdFlush}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Requester")
 		req.Dst = controlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -132,7 +132,7 @@ var _ = Describe("MMUCacheCtrlMiddleware", func() {
 		Expect(found).To(BeTrue())
 
 		req := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdInvalidate}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Requester")
 		req.Dst = controlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -153,7 +153,7 @@ var _ = Describe("MMUCacheCtrlMiddleware", func() {
 		next.CurrentState = mmuCacheStateEnable
 
 		req := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdInvalidate}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Requester")
 		req.Dst = controlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -201,7 +201,7 @@ var _ = Describe("MMUCacheCtrlMiddleware", func() {
 		setVisit(&next.Table[0], 1)
 
 		req := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdInvalidate, PID: 1}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Requester")
 		req.Dst = control2.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -230,7 +230,7 @@ var _ = Describe("MMUCacheCtrlMiddleware", func() {
 		msg := memcontrolprotocol.Req{
 			Command: memcontrolprotocol.CmdPause,
 		}
-		msg.ID = timing.GetIDGenerator().Generate()
+		msg.ID = testIDs.Generate()
 		msg.Src = messaging.RemotePort("Requester")
 		msg.Dst = controlPort.AsRemote()
 		msg.TrafficBytes = 4

--- a/mem/vm/mmuCache/ctrlmiddleware.go
+++ b/mem/vm/mmuCache/ctrlmiddleware.go
@@ -354,7 +354,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/vm/mmuCache/id_fixture_test.go
+++ b/mem/vm/mmuCache/id_fixture_test.go
@@ -1,0 +1,4 @@
+package mmuCache
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/vm/mmuCache/milestone_test.go
+++ b/mem/vm/mmuCache/milestone_test.go
@@ -129,7 +129,7 @@ var _ = Describe("MMUCache milestones", func() {
 
 	makeTopReq := func(vAddr uint64) vmprotocol.TranslationReq {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("UpModule")
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -159,7 +159,7 @@ var _ = Describe("MMUCache milestones", func() {
 			Valid: true,
 		}
 		rsp := vmprotocol.TranslationRsp{Page: page}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = messaging.RemotePort("LowModule")
 		rsp.Dst = bottomPort.AsRemote()
 		rsp.RspTo = bottomReqID
@@ -288,7 +288,7 @@ var _ = Describe("MMUCache milestones", func() {
 
 		// Reset while the walk is in flight.
 		reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-		reset.ID = timing.GetIDGenerator().Generate()
+		reset.ID = testIDs.Generate()
 		reset.Src = messaging.RemotePort("CtrlAgent")
 		reset.Dst = comp.GetPortByName("Control").AsRemote()
 		reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/vm/mmuCache/mmuCache_middleware_test.go
+++ b/mem/vm/mmuCache/mmuCache_middleware_test.go
@@ -56,7 +56,7 @@ var _ = Describe("MMUCacheMiddleware", func() {
 
 	It("should send full latency on miss", func() {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("UpModule")
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -83,7 +83,7 @@ var _ = Describe("MMUCacheMiddleware", func() {
 
 	It("should reduce latency on upper-level hit", func() {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("UpModule")
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -122,10 +122,10 @@ var _ = Describe("MMUCacheMiddleware", func() {
 		rsp := vmprotocol.TranslationRsp{
 			Page: page,
 		}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = messaging.RemotePort("LowModule")
 		rsp.Dst = bottomPort.AsRemote()
-		rsp.RspTo = timing.GetIDGenerator().Generate()
+		rsp.RspTo = testIDs.Generate()
 		rsp.TrafficClass = "vmprotocol.TranslationRsp"
 		bottomPort.Deliver(rsp)
 
@@ -185,7 +185,7 @@ var _ = Describe("MMUCacheMiddleware", func() {
 			Command:   memcontrolprotocol.CmdInvalidate,
 			Addresses: []uint64{dropAddr},
 		}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Requester")
 		req.Dst = controlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/vm/mmuCache/mmucachemiddleware.go
+++ b/mem/vm/mmuCache/mmucachemiddleware.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sarchlab/akita/v5/modeling"
 
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -149,7 +148,7 @@ func (m *mmuCacheMiddleware) sendReqToBottom(
 	res := m.comp.Resources()
 
 	reqToBottom := vmprotocol.TranslationReq{}
-	reqToBottom.ID = timing.GetIDGenerator().Generate()
+	reqToBottom.ID = m.comp.IDGenerator().Generate()
 	reqToBottom.Src = m.bottomPort().AsRemote()
 	reqToBottom.Dst = res.LowModulePort
 	reqToBottom.PID = req.PID
@@ -232,7 +231,7 @@ func (m *mmuCacheMiddleware) handleRsp(rsp vmprotocol.TranslationRsp) bool {
 	rspToTop := vmprotocol.TranslationRsp{
 		Page: rsp.Page,
 	}
-	rspToTop.ID = timing.GetIDGenerator().Generate()
+	rspToTop.ID = m.comp.IDGenerator().Generate()
 	rspToTop.Src = m.topPort().AsRemote()
 	rspToTop.Dst = res.UpModulePort
 	rspToTop.RspTo = rsp.RspTo

--- a/mem/vm/mmuCache/reset_leak_test.go
+++ b/mem/vm/mmuCache/reset_leak_test.go
@@ -55,7 +55,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	// Bottom port and opens both the top req_in and the forwarded req_out, then
 	// waits on the bottom response — which never comes, so the walk is in flight.
 	req := vmprotocol.TranslationReq{}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = messaging.RemotePort("Requester")
 	req.Dst = topPort.AsRemote()
 	req.PID = 1
@@ -91,7 +91,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	// Reset while the walk is in flight (bottom response deliberately withheld).
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = controlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/vm/tlb/control_behavior_test.go
+++ b/mem/vm/tlb/control_behavior_test.go
@@ -57,7 +57,7 @@ var _ = Describe("TLB control behavior", func() {
 
 	makeLookup := func(vAddr uint64) vmprotocol.TranslationReq {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -69,7 +69,7 @@ var _ = Describe("TLB control behavior", func() {
 
 	makeCtrlReq := func(cmd memcontrolprotocol.Command) memcontrolprotocol.Req {
 		req := memcontrolprotocol.Req{Command: cmd}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Ctrl")
 		req.Dst = controlPort.AsRemote()
 		req.TrafficClass = "memcontrolprotocol.Req"
@@ -89,7 +89,7 @@ var _ = Describe("TLB control behavior", func() {
 			Valid: true,
 		}
 		rsp := vmprotocol.TranslationRsp{Page: page}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = remotePort
 		rsp.Dst = bottomPort.AsRemote()
 		rsp.RspTo = req.ID

--- a/mem/vm/tlb/ctrlmiddleware.go
+++ b/mem/vm/tlb/ctrlmiddleware.go
@@ -338,7 +338,7 @@ func makeCtrlRsp(
 		Success: success,
 		Error:   errStr,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = timing.IDsFor(port.Component()).Generate()
 	rsp.Src = port.AsRemote()
 	rsp.Dst = dst
 	rsp.RspTo = rspTo

--- a/mem/vm/tlb/id_fixture_test.go
+++ b/mem/vm/tlb/id_fixture_test.go
@@ -1,0 +1,4 @@
+package tlb
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/mem/vm/tlb/milestone_test.go
+++ b/mem/vm/tlb/milestone_test.go
@@ -150,7 +150,7 @@ var _ = Describe("TLB milestones", func() {
 
 	makeReq := func(vAddr uint64) vmprotocol.TranslationReq {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -274,7 +274,7 @@ var _ = Describe("TLB milestones", func() {
 		rsp := vmprotocol.TranslationRsp{
 			Page: vm.Page{PID: 1, VAddr: 0x100, PAddr: 0x200, Valid: true},
 		}
-		rsp.ID = timing.GetIDGenerator().Generate()
+		rsp.ID = testIDs.Generate()
 		rsp.Src = remotePort
 		rsp.Dst = bottomPort.AsRemote()
 		rsp.RspTo = fetch.ID

--- a/mem/vm/tlb/reset_leak_test.go
+++ b/mem/vm/tlb/reset_leak_test.go
@@ -51,7 +51,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 	// shadow req_out). The bottom fetch is never answered, so the miss stays in
 	// flight.
 	req := vmprotocol.TranslationReq{}
-	req.ID = timing.GetIDGenerator().Generate()
+	req.ID = testIDs.Generate()
 	req.Src = messaging.RemotePort("Agent")
 	req.Dst = topPort.AsRemote()
 	req.PID = 1
@@ -86,7 +86,7 @@ func TestResetEndsInflightTracingTasks(t *testing.T) { //nolint:funlen
 
 	// Reset while the miss is in flight.
 	reset := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-	reset.ID = timing.GetIDGenerator().Generate()
+	reset.ID = testIDs.Generate()
 	reset.Src = messaging.RemotePort("Cmd")
 	reset.Dst = controlPort.AsRemote()
 	reset.TrafficClass = "memcontrolprotocol.Req"

--- a/mem/vm/tlb/tlb_test.go
+++ b/mem/vm/tlb/tlb_test.go
@@ -63,7 +63,7 @@ var _ = Describe("TLB", func() {
 
 	It("should insert req into pipeline when topPort has req", func() {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = messaging.RemotePort("Agent")
 		req.Dst = topPort.AsRemote()
 		req.PID = 1
@@ -95,7 +95,7 @@ var _ = Describe("TLB", func() {
 			setVisit(&next.Sets[0], 1)
 
 			req = vmprotocol.TranslationReq{}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Src = messaging.RemotePort("Agent")
 			req.PID = 1
 			req.VAddr = uint64(0x100)
@@ -130,7 +130,7 @@ var _ = Describe("TLB", func() {
 			setVisit(&next.Sets[0], 1)
 
 			req = vmprotocol.TranslationReq{}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Src = messaging.RemotePort("Agent")
 			req.PID = 1
 			req.VAddr = 0x100
@@ -166,14 +166,14 @@ var _ = Describe("TLB", func() {
 
 		BeforeEach(func() {
 			req = vmprotocol.TranslationReq{}
-			req.ID = timing.GetIDGenerator().Generate()
+			req.ID = testIDs.Generate()
 			req.Src = messaging.RemotePort("Agent")
 			req.PID = 1
 			req.VAddr = 0x100
 			req.DeviceID = 1
 			req.TrafficClass = "vmprotocol.TranslationReq"
 			fetchBottom = vmprotocol.TranslationReq{}
-			fetchBottom.ID = timing.GetIDGenerator().Generate()
+			fetchBottom.ID = testIDs.Generate()
 			fetchBottom.PID = 1
 			fetchBottom.VAddr = 0x100
 			fetchBottom.DeviceID = 1
@@ -187,7 +187,7 @@ var _ = Describe("TLB", func() {
 			rsp = vmprotocol.TranslationRsp{
 				Page: page,
 			}
-			rsp.ID = timing.GetIDGenerator().Generate()
+			rsp.ID = testIDs.Generate()
 			rsp.Src = messaging.RemotePort("Agent")
 			rsp.Dst = bottomPort.AsRemote()
 			rsp.RspTo = fetchBottom.ID
@@ -282,7 +282,7 @@ var _ = Describe("TLB", func() {
 				Addresses: []uint64{0x1000},
 				PID:       1,
 			}
-			invReq.ID = timing.GetIDGenerator().Generate()
+			invReq.ID = testIDs.Generate()
 			invReq.Src = messaging.RemotePort("Agent")
 			invReq.Dst = controlPort.AsRemote()
 			invReq.TrafficClass = "memcontrolprotocol.Req"
@@ -307,7 +307,7 @@ var _ = Describe("TLB", func() {
 			next.TLBState = tlbStateEnable
 
 			invReq := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdInvalidate}
-			invReq.ID = timing.GetIDGenerator().Generate()
+			invReq.ID = testIDs.Generate()
 			invReq.Src = messaging.RemotePort("Agent")
 			invReq.Dst = controlPort.AsRemote()
 			invReq.TrafficClass = "memcontrolprotocol.Req"
@@ -333,7 +333,7 @@ var _ = Describe("TLB", func() {
 			setVisit(&next.Sets[0], 1)
 
 			invReq := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdInvalidate, PID: 1}
-			invReq.ID = timing.GetIDGenerator().Generate()
+			invReq.ID = testIDs.Generate()
 			invReq.Src = messaging.RemotePort("Agent")
 			invReq.Dst = controlPort.AsRemote()
 			invReq.TrafficClass = "memcontrolprotocol.Req"
@@ -357,7 +357,7 @@ var _ = Describe("TLB", func() {
 			setVisit(&next.Sets[0], 0)
 
 			resetReq := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-			resetReq.ID = timing.GetIDGenerator().Generate()
+			resetReq.ID = testIDs.Generate()
 			resetReq.Src = messaging.RemotePort("Agent")
 			resetReq.Dst = controlPort.AsRemote()
 			resetReq.TrafficClass = "memcontrolprotocol.Req"
@@ -376,7 +376,7 @@ var _ = Describe("TLB", func() {
 
 		It("should handle restart request", func() {
 			restartReq := memcontrolprotocol.Req{Command: memcontrolprotocol.CmdReset}
-			restartReq.ID = timing.GetIDGenerator().Generate()
+			restartReq.ID = testIDs.Generate()
 			restartReq.Src = messaging.RemotePort("Agent")
 			restartReq.Dst = controlPort.AsRemote()
 			restartReq.TrafficClass = "memcontrolprotocol.Req"
@@ -396,7 +396,7 @@ var _ = Describe("TLB", func() {
 			pauseMsg := memcontrolprotocol.Req{
 				Command: memcontrolprotocol.CmdPause,
 			}
-			pauseMsg.ID = timing.GetIDGenerator().Generate()
+			pauseMsg.ID = testIDs.Generate()
 			pauseMsg.Src = messaging.RemotePort("Agent")
 			pauseMsg.Dst = controlPort.AsRemote()
 			pauseMsg.TrafficBytes = 4
@@ -415,7 +415,7 @@ var _ = Describe("TLB", func() {
 			pause := memcontrolprotocol.Req{
 				Command: memcontrolprotocol.CmdPause,
 			}
-			pause.ID = timing.GetIDGenerator().Generate()
+			pause.ID = testIDs.Generate()
 			pause.Src = messaging.RemotePort("Agent")
 			pause.Dst = controlPort.AsRemote()
 			pause.TrafficBytes = 4
@@ -437,7 +437,7 @@ var _ = Describe("TLB", func() {
 			enable := memcontrolprotocol.Req{
 				Command: memcontrolprotocol.CmdEnable,
 			}
-			enable.ID = timing.GetIDGenerator().Generate()
+			enable.ID = testIDs.Generate()
 			enable.Src = messaging.RemotePort("Agent")
 			enable.Dst = controlPort.AsRemote()
 			enable.TrafficBytes = 4
@@ -455,7 +455,7 @@ var _ = Describe("TLB", func() {
 			drainMsg := memcontrolprotocol.Req{
 				Command: memcontrolprotocol.CmdDrain,
 			}
-			drainMsg.ID = timing.GetIDGenerator().Generate()
+			drainMsg.ID = testIDs.Generate()
 			drainMsg.Src = messaging.RemotePort("Agent")
 			drainMsg.Dst = controlPort.AsRemote()
 			drainMsg.TrafficBytes = 4
@@ -525,7 +525,7 @@ var _ = Describe("TLB Integration", func() {
 		lowModule.onDeliver = func(msg messaging.Msg) {
 			translationReq := msg.(vmprotocol.TranslationReq)
 			rsp := vmprotocol.TranslationRsp{Page: page}
-			rsp.ID = timing.GetIDGenerator().Generate()
+			rsp.ID = testIDs.Generate()
 			rsp.Src = lowModule.port.AsRemote()
 			rsp.Dst = translationReq.Src
 			rsp.RspTo = translationReq.ID
@@ -536,7 +536,7 @@ var _ = Describe("TLB Integration", func() {
 
 	It("should do tlb miss", func() {
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = agent.port.AsRemote()
 		req.Dst = tlbComp.GetPortByName("Top").AsRemote()
 		req.PID = 1
@@ -554,7 +554,7 @@ var _ = Describe("TLB Integration", func() {
 	It("should have faster hit than miss", func() {
 		time1 := engine.CurrentTime()
 		req := vmprotocol.TranslationReq{}
-		req.ID = timing.GetIDGenerator().Generate()
+		req.ID = testIDs.Generate()
 		req.Src = agent.port.AsRemote()
 		req.Dst = tlbComp.GetPortByName("Top").AsRemote()
 		req.PID = 1
@@ -571,7 +571,7 @@ var _ = Describe("TLB Integration", func() {
 		time2 := engine.CurrentTime()
 
 		req2 := vmprotocol.TranslationReq{}
-		req2.ID = timing.GetIDGenerator().Generate()
+		req2.ID = testIDs.Generate()
 		req2.Src = agent.port.AsRemote()
 		req2.Dst = tlbComp.GetPortByName("Top").AsRemote()
 		req2.PID = 1

--- a/mem/vm/tlb/tlbmiddleware.go
+++ b/mem/vm/tlb/tlbmiddleware.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sarchlab/akita/v5/modeling"
 
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -89,7 +88,7 @@ func (m *tlbMiddleware) insertIntoPipeline() bool {
 		// milestones.
 		tracing.TraceReqReceive(m.comp, msg)
 
-		pid := timing.GetIDGenerator().Generate()
+		pid := m.comp.IDGenerator().Generate()
 		tracing.StartTask(m.comp, tracing.TaskStart{
 			ID:       pid,
 			ParentID: tracing.MsgIDAtReceiver(msg, m.comp),
@@ -208,7 +207,7 @@ func (m *tlbMiddleware) respondMSHREntry() bool {
 	rspToTop := vmprotocol.TranslationRsp{
 		Page: page,
 	}
-	rspToTop.ID = timing.GetIDGenerator().Generate()
+	rspToTop.ID = m.comp.IDGenerator().Generate()
 	rspToTop.Src = m.topPort().AsRemote()
 	rspToTop.Dst = reqMsg.Src
 	rspToTop.RspTo = reqMsg.ID
@@ -319,7 +318,7 @@ func (m *tlbMiddleware) sendRspToTop(
 	rsp := vmprotocol.TranslationRsp{
 		Page: page,
 	}
-	rsp.ID = timing.GetIDGenerator().Generate()
+	rsp.ID = m.comp.IDGenerator().Generate()
 	rsp.Src = m.topPort().AsRemote()
 	rsp.Dst = msg.Src
 	rsp.RspTo = msg.ID
@@ -361,7 +360,7 @@ func (m *tlbMiddleware) fetchBottom(msg vmprotocol.TranslationReq) bool {
 	mapper := m.comp.Resources().TranslationProviderMapper
 
 	fetchBottom := vmprotocol.TranslationReq{}
-	fetchBottom.ID = timing.GetIDGenerator().Generate()
+	fetchBottom.ID = m.comp.IDGenerator().Generate()
 	fetchBottom.Src = m.bottomPort().AsRemote()
 	fetchBottom.Dst = findTranslationPort(mapper, msg.VAddr)
 	fetchBottom.PID = msg.PID

--- a/messaging/port.go
+++ b/messaging/port.go
@@ -128,12 +128,18 @@ func (p *defaultPort) CanSend() bool {
 // the port has capacity with CanSend before calling Send; sending into a full
 // outgoing buffer is a programming error and will panic.
 func (p *defaultPort) Send(msg Msg) {
+	wasEmpty := p.sendLocked(msg)
+	if wasEmpty {
+		p.conn.NotifySend()
+	}
+}
+func (p *defaultPort) sendLocked(msg Msg) bool {
 	p.lock.Lock()
+	defer p.lock.Unlock()
 
 	p.msgMustBeValid(msg)
 
 	if !p.outgoingBuf.CanPush() {
-		p.lock.Unlock()
 		panic(fmt.Sprintf(
 			"Send called on port %s with full outgoing buffer; "+
 				"caller must check CanSend first",
@@ -150,11 +156,8 @@ func (p *defaultPort) Send(msg Msg) {
 		Item:   msg,
 	}
 	p.InvokeHook(hookCtx)
-	p.lock.Unlock()
 
-	if wasEmpty {
-		p.conn.NotifySend()
-	}
+	return wasEmpty
 }
 
 // CanDeliver checks if the port can accept an incoming message without error.
@@ -169,10 +172,16 @@ func (p *defaultPort) CanDeliver() bool {
 // the port has capacity with CanDeliver before calling Deliver; delivering
 // into a full incoming buffer is a programming error and will panic.
 func (p *defaultPort) Deliver(msg Msg) {
+	wasEmpty := p.deliverLocked(msg)
+	if p.comp != nil && wasEmpty {
+		p.comp.NotifyRecv(p)
+	}
+}
+func (p *defaultPort) deliverLocked(msg Msg) bool {
 	p.lock.Lock()
+	defer p.lock.Unlock()
 
 	if !p.incomingBuf.CanPush() {
-		p.lock.Unlock()
 		panic(fmt.Sprintf(
 			"Deliver called on port %s with full incoming buffer; "+
 				"caller must check CanDeliver first",
@@ -190,29 +199,20 @@ func (p *defaultPort) Deliver(msg Msg) {
 	p.InvokeHook(hookCtx)
 
 	p.incomingBuf.PushTyped(msg)
-	p.lock.Unlock()
 
-	if p.comp != nil && wasEmpty {
-		p.comp.NotifyRecv(p)
-	}
+	return wasEmpty
 }
 
 // RetrieveIncoming is used by the component to take a message from the
 // incoming buffer.
 func (p *defaultPort) RetrieveIncoming() Msg {
-	p.lock.Lock()
-
-	msg := p.incomingBuf.Pop()
+	msg, freed := p.popBuffer(&p.incomingBuf)
 	if msg == nil {
-		p.lock.Unlock()
 		return nil
 	}
-
-	if p.incomingBuf.Size() == p.incomingBuf.Capacity()-1 {
+	if freed {
 		p.conn.NotifyAvailable(p)
 	}
-
-	p.lock.Unlock()
 
 	hookCtx := hooking.HookCtx{
 		Domain: p,
@@ -227,19 +227,13 @@ func (p *defaultPort) RetrieveIncoming() Msg {
 // RetrieveOutgoing is used by the component to take a message from the outgoing
 // buffer.
 func (p *defaultPort) RetrieveOutgoing() Msg {
-	p.lock.Lock()
-
-	msg := p.outgoingBuf.Pop()
+	msg, freed := p.popBuffer(&p.outgoingBuf)
 	if msg == nil {
-		p.lock.Unlock()
 		return nil
 	}
-
-	if p.outgoingBuf.Size() == p.outgoingBuf.Capacity()-1 {
+	if freed {
 		p.comp.NotifyPortFree(p)
 	}
-
-	p.lock.Unlock()
 
 	hookCtx := hooking.HookCtx{
 		Domain: p,
@@ -330,4 +324,11 @@ func srcDstMustNotBeTheSame(msg Msg) {
 	if msg.Meta().Src == msg.Meta().Dst {
 		panic("sending back to src")
 	}
+}
+
+func (p *defaultPort) popBuffer(buf *queueing.Buffer[Msg]) (Msg, bool) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	msg := buf.Pop()
+	return msg, msg != nil && buf.Size() == buf.Capacity()-1
 }

--- a/messaging/port_checkpoint.go
+++ b/messaging/port_checkpoint.go
@@ -59,11 +59,16 @@ func (p *defaultPort) LoadCheckpoint(r io.Reader) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	if err := loadBuffer(&p.incomingBuf, dto.Incoming, p.name, "incoming"); err != nil {
+	incoming, outgoing := p.incomingBuf, p.outgoingBuf
+	if err := loadBuffer(&incoming, dto.Incoming, p.name, "incoming"); err != nil {
 		return err
 	}
 
-	return loadBuffer(&p.outgoingBuf, dto.Outgoing, p.name, "outgoing")
+	if err := loadBuffer(&outgoing, dto.Outgoing, p.name, "outgoing"); err != nil {
+		return err
+	}
+	p.incomingBuf, p.outgoingBuf = incoming, outgoing
+	return nil
 }
 
 // saveBuffer captures a buffer's capacity and its type-tagged contents.
@@ -98,6 +103,9 @@ func loadBuffer(
 		return fmt.Errorf("messaging: port %q %s: %w", portName, label, err)
 	}
 
+	if len(elements) > buf.Capacity() {
+		return fmt.Errorf("messaging: port %q %s exceeds capacity", portName, label)
+	}
 	buf.Restore(elements)
 
 	return nil

--- a/messaging/port_checkpoint_test.go
+++ b/messaging/port_checkpoint_test.go
@@ -79,3 +79,20 @@ func TestPortCheckpointRoundTripWithMessages(t *testing.T) {
 		t.Fatalf("outgoing = %+v", out)
 	}
 }
+
+func TestPortRestoreDoesNotApplyIncomingBeforeOutgoingValidation(t *testing.T) {
+	RegisterMsg(registryTestMsg{})
+	src := newCkptPort(1, 2)
+	src.incomingBuf.PushTyped(registryTestMsg{Value: 7})
+	var buf bytes.Buffer
+	if err := src.SaveCheckpoint(&buf); err != nil {
+		t.Fatal(err)
+	}
+	dst := newCkptPort(1, 1)
+	if err := dst.LoadCheckpoint(&buf); err == nil {
+		t.Fatal("invalid outgoing capacity accepted")
+	}
+	if dst.incomingBuf.Size() != 0 || dst.outgoingBuf.Size() != 0 {
+		t.Fatal("failed restore changed target buffers")
+	}
+}

--- a/modeling/eventdriven.go
+++ b/modeling/eventdriven.go
@@ -22,8 +22,8 @@ type TimerFiredEvent struct {
 }
 
 // MakeTimerFiredEvent creates a new TimerFiredEvent.
-func MakeTimerFiredEvent(handlerID string, time timing.VTimeInPicoSec) TimerFiredEvent {
-	return TimerFiredEvent{EventBase: timing.MakeEventBase(time, handlerID)}
+func MakeTimerFiredEvent(ids timing.IDGenerator, handlerID string, time timing.VTimeInPicoSec) TimerFiredEvent {
+	return TimerFiredEvent{EventBase: timing.MakeEventBase(ids, time, handlerID)}
 }
 
 // EventDrivenComponent is a generic component that reacts to events rather
@@ -77,7 +77,7 @@ func (c *EventDrivenComponent[S, T, R]) ScheduleWakeAt(t timing.VTimeInPicoSec) 
 
 	c.pendingWakeup = t
 
-	c.engine.Schedule(MakeTimerFiredEvent(c.Name(), t))
+	c.engine.Schedule(MakeTimerFiredEvent(c.IDGenerator(), c.Name(), t))
 }
 
 // ScheduleWakeNow schedules a wakeup at the current engine time.
@@ -87,14 +87,14 @@ func (c *EventDrivenComponent[S, T, R]) ScheduleWakeNow() {
 
 // Handle processes an event. For TimerFiredEvent, it resets the dedup guard
 // and calls the processor.
-func (c *EventDrivenComponent[S, T, R]) Handle(e timing.Event) error {
+func (c *EventDrivenComponent[S, T, R]) Handle(e timing.Event) {
 	c.Lock()
 	defer c.Unlock()
 
 	c.pendingWakeup = math.MaxUint64
 	c.processor.Process(c, e.Time())
 
-	return nil
+	return
 }
 
 // NotifyRecv is called when a port receives a message. It schedules an
@@ -107,4 +107,8 @@ func (c *EventDrivenComponent[S, T, R]) NotifyRecv(port messaging.Port) {
 // immediate wakeup.
 func (c *EventDrivenComponent[S, T, R]) NotifyPortFree(port messaging.Port) {
 	c.ScheduleWakeNow()
+}
+
+func (c *EventDrivenComponent[S, T, R]) IDGenerator() timing.IDGenerator {
+	return timing.IDsFor(c.engine)
 }

--- a/modeling/eventdriven_test.go
+++ b/modeling/eventdriven_test.go
@@ -121,12 +121,9 @@ func TestEventDrivenHandle(t *testing.T) {
 		WithProcessor(proc).
 		Build("EDComp")
 
-	evt := timing.MakeEventBase(10, comp.Name())
+	evt := timing.MakeEventBase(testIDs, 10, comp.Name())
 
-	err := comp.Handle(evt)
-	if err != nil {
-		t.Fatalf("Handle() returned error: %v", err)
-	}
+	comp.Handle(evt)
 
 	if proc.callCount != 1 {
 		t.Errorf("processor called %d times, want 1", proc.callCount)

--- a/modeling/example_test.go
+++ b/modeling/example_test.go
@@ -29,10 +29,10 @@ type PingSpec struct {
 }
 
 type PingState struct {
-	NumPingNeedToSend int                 `json:"num_ping_need_to_send"`
-	NextSeqID         int                 `json:"next_seq_id"`
+	NumPingNeedToSend int                     `json:"num_ping_need_to_send"`
+	NextSeqID         int                     `json:"next_seq_id"`
 	StartTimes        []timing.VTimeInPicoSec `json:"start_times"`
-	CompletedPings    int                 `json:"completed_pings"`
+	CompletedPings    int                     `json:"completed_pings"`
 }
 
 type pingTransaction struct {
@@ -112,7 +112,7 @@ func (m *pingMiddleware) sendRsp() bool {
 
 	rsp := PingRsp{
 		MsgMeta: messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Src: m.outPort.AsRemote(),
 			Dst: trans.req.Src,
 		},
@@ -137,7 +137,7 @@ func (m *pingMiddleware) sendPing() bool {
 
 	req := PingReq{
 		MsgMeta: messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Src: m.outPort.AsRemote(),
 			Dst: m.pingDst,
 		},

--- a/modeling/id_external_fixture_test.go
+++ b/modeling/id_external_fixture_test.go
@@ -1,0 +1,4 @@
+package modeling_test
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/modeling/id_fixture_test.go
+++ b/modeling/id_fixture_test.go
@@ -1,0 +1,4 @@
+package modeling
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/modeling/ticker.go
+++ b/modeling/ticker.go
@@ -16,9 +16,9 @@ type TickEvent struct {
 }
 
 // MakeTickEvent creates a new TickEvent
-func MakeTickEvent(handlerID string, time timing.VTimeInPicoSec) TickEvent {
+func MakeTickEvent(ids timing.IDGenerator, handlerID string, time timing.VTimeInPicoSec) TickEvent {
 	evt := TickEvent{}
-	evt.ID = timing.GetIDGenerator().Generate()
+	evt.ID = ids.Generate()
 	evt.HandlerID_ = handlerID
 	evt.Time_ = time
 	evt.Secondary = false
@@ -80,45 +80,43 @@ func NewSecondaryTickScheduler(
 // TickNow schedule a Tick event at the current time.
 func (t *TickScheduler) TickNow() {
 	t.lock.Lock()
+	defer t.lock.Unlock()
 	time := t.CurrentTime()
 
 	if t.hasScheduledTick && t.nextTickTime >= time {
-		t.lock.Unlock()
 		return
 	}
 
 	t.nextTickTime = t.freq.ThisTick(time)
 	t.hasScheduledTick = true
-	tick := MakeTickEvent(t.handlerID, t.nextTickTime)
+	tick := MakeTickEvent(t.IDGenerator(), t.handlerID, t.nextTickTime)
 
 	if t.secondary {
 		tick.Secondary = true
 	}
 
 	t.engine.Schedule(tick)
-	t.lock.Unlock()
 }
 
 // TickLater will schedule a tick event at the cycle after the now time.
 func (t *TickScheduler) TickLater() {
 	t.lock.Lock()
+	defer t.lock.Unlock()
 	time := t.freq.NextTick(t.CurrentTime())
 
 	if t.hasScheduledTick && t.nextTickTime >= time {
-		t.lock.Unlock()
 		return
 	}
 
 	t.nextTickTime = time
 	t.hasScheduledTick = true
-	tick := MakeTickEvent(t.handlerID, t.nextTickTime)
+	tick := MakeTickEvent(t.IDGenerator(), t.handlerID, t.nextTickTime)
 
 	if t.secondary {
 		tick.Secondary = true
 	}
 
 	t.engine.Schedule(tick)
-	t.lock.Unlock()
 }
 
 func (t *TickScheduler) CurrentTime() timing.VTimeInPicoSec {
@@ -178,13 +176,13 @@ func (c *TickingComponent) NotifyRecv(
 }
 
 // Handle triggers the tick function of the TickingComponent
-func (c *TickingComponent) Handle(e timing.Event) error {
+func (c *TickingComponent) Handle(e timing.Event) {
 	madeProgress := c.ticker.Tick()
 	if madeProgress {
 		c.TickLater()
 	}
 
-	return nil
+	return
 }
 
 // NewTickingComponent creates a new ticking component
@@ -230,3 +228,5 @@ func NewSecondaryTickingComponent(
 
 	return tc
 }
+
+func (t *TickScheduler) IDGenerator() timing.IDGenerator { return timing.IDsFor(t.engine) }

--- a/modeling/ticker_test.go
+++ b/modeling/ticker_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Ticking Component", func() {
 	It("should tick when the ticker make progress in a tick", func() {
 		ticker.progress = true
 
-		tc.Handle(MakeTickEvent(tc.Name(), timing.VTimeInPicoSec(10000)))
+		tc.Handle(MakeTickEvent(testIDs, tc.Name(), timing.VTimeInPicoSec(10000)))
 
 		Expect(engine.scheduled).To(HaveLen(1))
 		Expect(engine.scheduled[0].Time()).To(Equal(timing.VTimeInPicoSec(11000)))
@@ -70,7 +70,7 @@ var _ = Describe("Ticking Component", func() {
 		func() {
 			ticker.progress = true
 
-			tc.Handle(MakeTickEvent(tc.Name(), timing.VTimeInPicoSec(10000)))
+			tc.Handle(MakeTickEvent(testIDs, tc.Name(), timing.VTimeInPicoSec(10000)))
 			tc.TickNow()
 
 			Expect(engine.scheduled).To(HaveLen(1))
@@ -81,7 +81,7 @@ var _ = Describe("Ticking Component", func() {
 	It("should stop ticking if no progress is made", func() {
 		ticker.progress = false
 
-		tc.Handle(MakeTickEvent(tc.Name(), timing.VTimeInPicoSec(10000)))
+		tc.Handle(MakeTickEvent(testIDs, tc.Name(), timing.VTimeInPicoSec(10000)))
 
 		Expect(engine.scheduled).To(BeEmpty())
 	})

--- a/monitoring2/doc.go
+++ b/monitoring2/doc.go
@@ -10,5 +10,8 @@
 //	monitor.RegisterEngine(engine)
 //	monitor.RegisterComponent(component)
 //	monitor.RegisterVisTracer(tracer)
-//	monitor.StartServer()
+//	if err := monitor.StartServer(); err != nil {
+//	    return err
+//	}
+//	defer monitor.StopServer() // call after the engine has stopped
 package monitoring2

--- a/monitoring2/failure_test.go
+++ b/monitoring2/failure_test.go
@@ -1,6 +1,7 @@
 package monitoring2
 
 import (
+	"github.com/sarchlab/akita/v5/timing"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -41,5 +42,19 @@ func TestStopServerJoinsAdmittedRequests(t *testing.T) {
 	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatal("accepted request after stop")
+	}
+}
+
+func TestMonitorPanicFailsStandaloneManagedEngine(t *testing.T) {
+	m := NewMonitor()
+	e := timing.NewSerialEngine()
+	m.RegisterEngine(e)
+	h := m.containRequests(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("invalid monitored model")
+	}))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/tick/test", nil))
+	if w.Code != http.StatusInternalServerError || e.Run() == nil {
+		t.Fatal("monitor hid the standalone engine failure")
 	}
 }

--- a/monitoring2/failure_test.go
+++ b/monitoring2/failure_test.go
@@ -1,7 +1,10 @@
 package monitoring2
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +12,54 @@ import (
 
 	"github.com/sarchlab/akita/v5/timing"
 )
+
+func TestBufferPaginationCannotFailSimulation(t *testing.T) {
+	for _, tc := range []struct {
+		query  string
+		status int
+		count  int
+	}{
+		{"limit=-1", http.StatusBadRequest, 0},
+		{"offset=-1&limit=1", http.StatusBadRequest, 0},
+		{fmt.Sprintf("offset=1&limit=%d", int(^uint(0)>>1)), http.StatusOK, 1},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			m := NewMonitor()
+			e := timing.NewSerialEngine()
+			m.RegisterEngine(e)
+			m.RegisterComponent(newBufferOnlyComponent("a", 10, 5))
+			m.RegisterComponent(newBufferOnlyComponent("b", 10, 7))
+			h := m.containRequests(http.HandlerFunc(m.hangDetectorBuffers))
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/hangdetector/buffers?"+tc.query, nil))
+			if w.Code != tc.status || e.Supervisor().Err() != nil {
+				t.Fatalf("status=%d failure=%v body=%s", w.Code, e.Supervisor().Err(), w.Body.String())
+			}
+			if tc.status == http.StatusOK {
+				var buffers []bufferRsp
+				if err := json.Unmarshal(w.Body.Bytes(), &buffers); err != nil || len(buffers) != tc.count {
+					t.Fatalf("invalid page: %s, %v", w.Body.String(), err)
+				}
+			}
+			if err := e.Run(); err != nil {
+				t.Fatalf("request invalidated engine: %v", err)
+			}
+		})
+	}
+}
+
+func TestProfileCaptureHonorsCancellation(t *testing.T) {
+	m := NewMonitor()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	r := httptest.NewRequest(http.MethodGet, "/api/profile?seconds=2", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	started := time.Now()
+	m.collectProfile(w, r)
+	if w.Code != http.StatusRequestTimeout || time.Since(started) > time.Second {
+		t.Fatalf("profile ignored cancellation: status=%d elapsed=%s", w.Code, time.Since(started))
+	}
+}
 
 func TestStopServerJoinsAdmittedRequests(t *testing.T) {
 	m := NewMonitor()

--- a/monitoring2/failure_test.go
+++ b/monitoring2/failure_test.go
@@ -1,11 +1,13 @@
 package monitoring2
 
 import (
-	"github.com/sarchlab/akita/v5/timing"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/sarchlab/akita/v5/timing"
 )
 
 func TestStopServerJoinsAdmittedRequests(t *testing.T) {
@@ -56,5 +58,68 @@ func TestMonitorPanicFailsStandaloneManagedEngine(t *testing.T) {
 	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/tick/test", nil))
 	if w.Code != http.StatusInternalServerError || e.Run() == nil {
 		t.Fatal("monitor hid the standalone engine failure")
+	}
+}
+
+func TestInspectionDuringShutdownDoesNotFailEngine(t *testing.T) {
+	for _, phase := range []string{"pause", "resume"} {
+		t.Run(phase, func(t *testing.T) {
+			err, _ := inspectDuringShutdown(t, phase, nil)
+			if err != nil {
+				t.Fatalf("healthy shutdown failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestUnexpectedInspectionPanicDuringShutdownStillFails(t *testing.T) {
+	err, _ := inspectDuringShutdown(t, "resume", "broken inspected state")
+	var failure *timing.FailureError
+	if !errors.As(err, &failure) || failure.Cause != "broken inspected state" {
+		t.Fatalf("lost original inspection failure: %v", err)
+	}
+}
+
+func inspectDuringShutdown(t *testing.T, phase string, cause any) (error, int) {
+	t.Helper()
+	m := NewMonitor()
+	e := timing.NewSerialEngine()
+	m.RegisterEngine(e)
+	entered, release := make(chan struct{}), make(chan struct{})
+	w := httptest.NewRecorder()
+	h := m.containRequests(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		if phase == "pause" {
+			close(entered)
+			<-release
+		}
+		resume := m.pauseForInspection()
+		defer resume()
+		if phase == "resume" {
+			close(entered)
+			<-release
+		}
+		if cause != nil {
+			panic(cause)
+		}
+	}))
+	go h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/component/test", nil))
+	<-entered
+	closing, stopped := make(chan struct{}), make(chan error, 1)
+	go func() {
+		stopped <- e.Supervisor().Close(func() {
+			close(closing)
+			if err := m.StopServer(); err != nil {
+				panic(err)
+			}
+		})
+	}()
+	<-closing
+	close(release)
+	select {
+	case err := <-stopped:
+		return err, w.Code
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not join inspection")
+		return nil, 0
 	}
 }

--- a/monitoring2/failure_test.go
+++ b/monitoring2/failure_test.go
@@ -1,0 +1,45 @@
+package monitoring2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestStopServerJoinsAdmittedRequests(t *testing.T) {
+	m := NewMonitor()
+	entered, release, exited := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	h := m.containRequests(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(entered)
+		<-release
+	}))
+	go func() {
+		defer close(exited)
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	}()
+	<-entered
+	stopped := make(chan error, 1)
+	go func() { stopped <- m.StopServer() }()
+	select {
+	case err := <-stopped:
+		close(release)
+		t.Fatalf("returned before request settled: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case err := <-stopped:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stop did not settle")
+	}
+	<-exited
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatal("accepted request after stop")
+	}
+}

--- a/monitoring2/failure_test.go
+++ b/monitoring2/failure_test.go
@@ -7,11 +7,45 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/sarchlab/akita/v5/datarecording"
 	"github.com/sarchlab/akita/v5/timing"
 )
+
+func TestExecutionInfoUsesLiteralRecordingPath(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "trace.sqlite3")
+	name := base + "?literal#"
+	r, err := datarecording.NewDataRecorder(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := executionInfoEntry{Property: "Command", Value: "expected recording"}
+	if err := r.CreateTable("exec_info", entry); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.InsertData("exec_info", entry); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	m := NewMonitor()
+	m.SetTraceDBPath(name + ".sqlite3")
+	w := httptest.NewRecorder()
+	m.apiExecutionInfo(w, httptest.NewRequest(http.MethodGet, "/api/execution/info", nil))
+	var entries []executionInfoEntry
+	err = json.Unmarshal(w.Body.Bytes(), &entries)
+	if err != nil || w.Code != http.StatusOK || len(entries) != 1 || entries[0] != entry {
+		t.Fatalf("read wrong recording: status=%d body=%s err=%v", w.Code, w.Body.String(), err)
+	}
+	if _, err := os.Stat(base); !os.IsNotExist(err) {
+		t.Fatalf("monitor created an unintended file: %v", err)
+	}
+}
 
 func TestBufferPaginationCannotFailSimulation(t *testing.T) {
 	for _, tc := range []struct {

--- a/monitoring2/monitor.go
+++ b/monitoring2/monitor.go
@@ -48,6 +48,14 @@ type monitorPort interface {
 }
 
 type Monitor struct {
+	progressIDs timing.IDGenerator
+	// Callbacks are configured before starting the server.
+	OnWarning  func(error)
+	OnFailure  func(any)
+	serverDone chan struct{}
+	workMu     sync.Mutex
+	stopping   bool
+	work       sync.WaitGroup
 	// Configuration (set before StartServer).
 	port      int
 	engine    timing.Engine
@@ -69,6 +77,7 @@ type Monitor struct {
 // started until StartServer() is called.
 func NewMonitor() *Monitor {
 	return &Monitor{
+		progressIDs:  timing.NewIDGenerator(),
 		fs:           static.GetAssets(),
 		progressBars: []*daisen2.ProgressBar{},
 	}
@@ -123,7 +132,7 @@ func (m *Monitor) SetTraceDBPath(path string) {
 // CreateProgressBar creates a new progress bar tracked by the monitor.
 func (m *Monitor) CreateProgressBar(name string, total uint64) *daisen2.ProgressBar {
 	bar := &daisen2.ProgressBar{
-		ID:    timing.GetIDGenerator().Generate(),
+		ID:    m.progressIDs.Generate(),
 		Name:  name,
 		Total: total,
 	}
@@ -153,7 +162,7 @@ func (m *Monitor) CompleteProgressBar(pb *daisen2.ProgressBar) {
 }
 
 // StartServer initializes and starts the monitoring HTTP server.
-func (m *Monitor) StartServer() {
+func (m *Monitor) StartServer() error {
 	// Build combined mux.
 	mux := http.NewServeMux()
 
@@ -182,20 +191,26 @@ func (m *Monitor) StartServer() {
 	m.setupStaticRoutes(mux)
 
 	// Find port and start listener.
-	listener := m.findPort()
+	listener, err := m.findPort()
+	if err != nil {
+		return err
+	}
 	port := listener.Addr().(*net.TCPAddr).Port
 
 	fmt.Fprintf(os.Stderr,
 		"Monitoring simulation with http://localhost:%d\n", port)
 
-	m.httpServer = &http.Server{Handler: mux}
+	m.httpServer = &http.Server{Handler: m.containRequests(mux)}
+	m.serverDone = make(chan struct{})
 
 	go func() {
-		err := m.httpServer.Serve(listener)
-		if err != nil && err != http.ErrServerClosed {
-			log.Panic(err)
+		defer close(m.serverDone)
+		defer m.recoverFailure()
+		if err := m.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+			m.warning(err)
 		}
 	}()
+	return nil
 }
 
 func (m *Monitor) setupStaticRoutes(mux *http.ServeMux) {
@@ -214,14 +229,14 @@ func (m *Monitor) setupStaticRoutes(mux *http.ServeMux) {
 	mux.Handle("/", fServer)
 }
 
-func (m *Monitor) findPort() net.Listener {
+func (m *Monitor) findPort() (net.Listener, error) {
 	if m.port > 0 {
 		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", m.port))
 		if err != nil {
-			log.Panicf("failed to listen on port %d: %v", m.port, err)
+			return nil, fmt.Errorf("failed to listen on port %d: %w", m.port, err)
 		}
 
-		return listener
+		return listener, nil
 	}
 
 	startPort := 32776
@@ -231,20 +246,69 @@ func (m *Monitor) findPort() net.Listener {
 		listener, err := net.Listen("tcp",
 			fmt.Sprintf(":%d", startPort+i))
 		if err == nil {
-			return listener
+			return listener, nil
 		}
 	}
 
-	log.Panic("failed to find available port")
-
-	return nil
+	return nil, errors.New("failed to find available port")
 }
 
 // StopServer gracefully shuts down the monitoring server.
-func (m *Monitor) StopServer() {
-	if m.httpServer != nil {
-		m.httpServer.Close()
+func (m *Monitor) StopServer() error {
+	m.workMu.Lock()
+	m.stopping = true
+	m.workMu.Unlock()
+	defer m.work.Wait()
+	if m.httpServer == nil {
+		return nil
 	}
+	err := m.httpServer.Close()
+	if m.serverDone != nil {
+		<-m.serverDone
+	}
+	return err
+}
+func (m *Monitor) warning(err error) {
+	if m.OnWarning != nil {
+		m.OnWarning(err)
+	} else {
+		log.Printf("monitor: %v", err)
+	}
+}
+func (m *Monitor) recoverFailure() {
+	if p := recover(); p != nil {
+		if m.OnFailure != nil {
+			m.OnFailure(p)
+		} else {
+			m.warning(fmt.Errorf("panic: %v", p))
+		}
+	}
+}
+func (m *Monitor) containRequests(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !m.beginWork() {
+			http.Error(w, "monitor is stopping", http.StatusServiceUnavailable)
+			return
+		}
+		defer m.work.Done()
+		defer func() {
+			if p := recover(); p != nil {
+				if m.OnFailure != nil {
+					m.OnFailure(p)
+				}
+				http.Error(w, "monitor operation failed", http.StatusInternalServerError)
+			}
+		}()
+		if e, ok := m.engine.(timing.ManagedEngine); ok && e.Supervisor().Err() != nil {
+			switch r.URL.Path {
+			case "/api/engine/state", "/api/now", "/api/mode":
+			default:
+				http.Error(w, "simulation failed; model inspection and mutation are unavailable", http.StatusConflict)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // ---- Buffer inspection ----
@@ -361,40 +425,43 @@ func (m *Monitor) apiMode(w http.ResponseWriter, _ *http.Request) {
 func (m *Monitor) serveIndex(w http.ResponseWriter, _ *http.Request) {
 	f, err := m.fs.Open("index.html")
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	p, err := readAll(f)
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	_, err = w.Write(p)
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 
 func (m *Monitor) pauseEngine(w http.ResponseWriter, _ *http.Request) {
 	m.engineControlMu.Lock()
+	defer m.engineControlMu.Unlock()
 	if !m.enginePaused {
 		m.engine.Pause()
 		m.enginePaused = true
 	}
 	response := m.engineStateResponseLocked()
-	m.engineControlMu.Unlock()
 
 	m.writeEngineState(w, response)
 }
 
 func (m *Monitor) continueEngine(w http.ResponseWriter, _ *http.Request) {
 	m.engineControlMu.Lock()
+	defer m.engineControlMu.Unlock()
 	if m.enginePaused {
 		m.engine.Continue()
 		m.enginePaused = false
 	}
 	response := m.engineStateResponseLocked()
-	m.engineControlMu.Unlock()
 
 	m.writeEngineState(w, response)
 }
@@ -413,6 +480,9 @@ func (m *Monitor) apiEngineState(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (m *Monitor) engineStateResponseLocked() engineStateRsp {
+	if e, ok := m.engine.(timing.ManagedEngine); ok && e.Supervisor().Err() != nil {
+		return engineStateRsp{State: "failed"}
+	}
 	if m.enginePaused {
 		return engineStateRsp{State: "paused", Paused: true}
 	}
@@ -438,6 +508,12 @@ func (m *Monitor) now(w http.ResponseWriter, _ *http.Request) {
 
 func (m *Monitor) pauseForInspection() func() {
 	m.engineControlMu.Lock()
+	defer func() {
+		if p := recover(); p != nil {
+			m.engineControlMu.Unlock()
+			panic(p)
+		}
+	}()
 
 	if m.enginePaused {
 		return func() {
@@ -448,16 +524,22 @@ func (m *Monitor) pauseForInspection() func() {
 	m.engine.Pause()
 
 	return func() {
+		defer m.engineControlMu.Unlock()
 		m.engine.Continue()
-		m.engineControlMu.Unlock()
 	}
 }
 
-func (m *Monitor) run(_ http.ResponseWriter, _ *http.Request) {
+func (m *Monitor) run(w http.ResponseWriter, _ *http.Request) {
+	if !m.beginWork() {
+		http.Error(w, "monitor is stopping", http.StatusServiceUnavailable)
+		return
+	}
 	go func() {
+		defer m.work.Done()
+		defer m.recoverFailure()
 		err := m.engine.Run()
 		if err != nil {
-			panic(err)
+			m.warning(err)
 		}
 	}()
 }
@@ -518,7 +600,8 @@ func (m *Monitor) listComponentDetails(
 
 	err := serializer.Serialize(w)
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 
@@ -538,9 +621,14 @@ func (m *Monitor) listFieldValue(w http.ResponseWriter, r *http.Request) {
 
 	err := json.Unmarshal([]byte(jsonString), &req)
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
+	m.writeFieldValue(w, r, req)
+}
+
+func (m *Monitor) writeFieldValue(w http.ResponseWriter, r *http.Request, req fieldReq) {
 	name := req.CompName
 	fields := strings.Split(req.FieldName, ".")
 
@@ -571,7 +659,8 @@ func (m *Monitor) listFieldValue(w http.ResponseWriter, r *http.Request) {
 		if monitorStrip(value).Kind() == reflect.Slice {
 			err = writeSlicePage(w, value, sliceOffset, sliceLimit)
 			if err != nil {
-				log.Panic(err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
 			}
 
 			return
@@ -591,7 +680,8 @@ func (m *Monitor) listFieldValue(w http.ResponseWriter, r *http.Request) {
 
 	err = serializer.Serialize(w)
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 
@@ -996,7 +1086,8 @@ func (m *Monitor) findComponentOr404(
 
 		_, err := w.Write([]byte("Component not found"))
 		if err != nil {
-			log.Panic(err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return nil
 		}
 	}
 
@@ -1013,7 +1104,8 @@ func writeFieldNotFound(w http.ResponseWriter, cause error) {
 
 	_, err := fmt.Fprintf(w, "Field not found: %s", cause)
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 
@@ -1030,12 +1122,14 @@ func (m *Monitor) listProgressBars(
 
 	b, err := json.Marshal(progressBars)
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	_, err = w.Write(b)
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 
@@ -1125,17 +1219,20 @@ func (m *Monitor) listResources(w http.ResponseWriter, _ *http.Request) {
 
 	proc, err := process.NewProcess(int32(pid))
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	cpuPercent, err := proc.CPUPercent()
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	memorySize, err := proc.MemoryInfo()
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	rsp := resourceRsp{
@@ -1145,12 +1242,14 @@ func (m *Monitor) listResources(w http.ResponseWriter, _ *http.Request) {
 
 	b, err := json.Marshal(rsp)
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	_, err = w.Write(b)
 	if err != nil {
-		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 
@@ -1382,4 +1481,15 @@ func readAll(f http.File) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+// beginWork closes admission before StopServer joins requests and run workers.
+func (m *Monitor) beginWork() bool {
+	m.workMu.Lock()
+	defer m.workMu.Unlock()
+	if m.stopping {
+		return false
+	}
+	m.work.Add(1)
+	return true
 }

--- a/monitoring2/monitor.go
+++ b/monitoring2/monitor.go
@@ -987,6 +987,9 @@ func buffersParseParams(
 	if err != nil {
 		return sortMethod, 0, 0, err
 	}
+	if limitNumber < 0 {
+		return sortMethod, 0, 0, errors.New("limit must be non-negative")
+	}
 
 	offsetStr := r.URL.Query().Get("offset")
 	if offsetStr == "" {
@@ -996,6 +999,9 @@ func buffersParseParams(
 	offsetNumber, err := strconv.Atoi(offsetStr)
 	if err != nil {
 		return sortMethod, limitNumber, 0, err
+	}
+	if offsetNumber < 0 {
+		return sortMethod, limitNumber, 0, errors.New("offset must be non-negative")
 	}
 
 	return sortMethod, limitNumber, offsetNumber, nil
@@ -1050,7 +1056,7 @@ func (m *Monitor) sortAndSelectBuffers(
 		return []bufferState{}
 	}
 
-	if offset+limit > len(sortedBuffers) {
+	if limit > len(sortedBuffers)-offset {
 		limit = len(sortedBuffers) - offset
 	}
 
@@ -1272,7 +1278,15 @@ func (m *Monitor) collectProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	time.Sleep(time.Duration(seconds) * time.Second)
+	timer := time.NewTimer(time.Duration(seconds) * time.Second)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-r.Context().Done():
+		pprof.StopCPUProfile()
+		http.Error(w, r.Context().Err().Error(), http.StatusRequestTimeout)
+		return
+	}
 
 	pprof.StopCPUProfile()
 

--- a/monitoring2/monitor.go
+++ b/monitoring2/monitor.go
@@ -567,6 +567,8 @@ func (m *Monitor) tick(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resume := m.pauseForInspection()
+	defer resume()
 	tickingComp.TickLater()
 	w.WriteHeader(200)
 }

--- a/monitoring2/monitor.go
+++ b/monitoring2/monitor.go
@@ -277,11 +277,7 @@ func (m *Monitor) warning(err error) {
 }
 func (m *Monitor) recoverFailure() {
 	if p := recover(); p != nil {
-		if m.OnFailure != nil {
-			m.OnFailure(p)
-		} else {
-			m.warning(fmt.Errorf("panic: %v", p))
-		}
+		m.fail(p)
 	}
 }
 func (m *Monitor) containRequests(next http.Handler) http.Handler {
@@ -293,9 +289,7 @@ func (m *Monitor) containRequests(next http.Handler) http.Handler {
 		defer m.work.Done()
 		defer func() {
 			if p := recover(); p != nil {
-				if m.OnFailure != nil {
-					m.OnFailure(p)
-				}
+				m.fail(p)
 				http.Error(w, "monitor operation failed", http.StatusInternalServerError)
 			}
 		}()
@@ -1492,4 +1486,14 @@ func (m *Monitor) beginWork() bool {
 	}
 	m.work.Add(1)
 	return true
+}
+
+func (m *Monitor) fail(cause any) {
+	if m.OnFailure != nil {
+		m.OnFailure(cause)
+	} else if e, ok := m.engine.(timing.ManagedEngine); ok {
+		e.Supervisor().Fail("monitor", cause)
+	} else {
+		m.warning(fmt.Errorf("panic: %v", cause))
+	}
 }

--- a/monitoring2/monitor.go
+++ b/monitoring2/monitor.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/pprof/profile"
 	"github.com/sarchlab/akita/v5/daisen2"
+	"github.com/sarchlab/akita/v5/internal/sqlitefile"
 	"github.com/sarchlab/akita/v5/monitoring2/static"
 
 	"github.com/sarchlab/akita/v5/timing"
@@ -1172,7 +1173,11 @@ func (m *Monitor) readExecutionInfo() ([]executionInfoEntry, error) {
 		return nil, err
 	}
 
-	db, err := sql.Open("sqlite", absPath)
+	dsn, err := sqlitefile.DSN(absPath)
+	if err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", dsn+"?mode=ro")
 	if err != nil {
 		return nil, err
 	}

--- a/monitoring2/monitor.go
+++ b/monitoring2/monitor.go
@@ -289,8 +289,7 @@ func (m *Monitor) containRequests(next http.Handler) http.Handler {
 		defer m.work.Done()
 		defer func() {
 			if p := recover(); p != nil {
-				m.fail(p)
-				http.Error(w, "monitor operation failed", http.StatusInternalServerError)
+				m.requestFailure(w, p)
 			}
 		}()
 		if e, ok := m.engine.(timing.ManagedEngine); ok && e.Supervisor().Err() != nil {
@@ -517,10 +516,7 @@ func (m *Monitor) pauseForInspection() func() {
 
 	m.engine.Pause()
 
-	return func() {
-		defer m.engineControlMu.Unlock()
-		m.engine.Continue()
-	}
+	return m.resumeAfterInspection
 }
 
 func (m *Monitor) run(w http.ResponseWriter, _ *http.Request) {
@@ -1496,4 +1492,39 @@ func (m *Monitor) fail(cause any) {
 	} else {
 		m.warning(fmt.Errorf("panic: %v", cause))
 	}
+}
+
+// An inspection's deferred resume must not replace an existing model panic
+// with the expected closed-operation panic during concurrent shutdown.
+func (m *Monitor) resumeAfterInspection() {
+	defer m.engineControlMu.Unlock()
+	defer func() {
+		if p := recover(); p != nil {
+			if m.closedOperation(p) {
+				m.warning(timing.ErrClosed)
+				return
+			}
+			panic(p)
+		}
+	}()
+	m.engine.Continue()
+}
+
+func (m *Monitor) closedOperation(cause any) bool {
+	err, ok := cause.(error)
+	if !ok || err != timing.ErrClosed {
+		return false
+	}
+	e, ok := m.engine.(timing.ManagedEngine)
+	return ok && e.Supervisor().State() == "closed"
+}
+
+func (m *Monitor) requestFailure(w http.ResponseWriter, cause any) {
+	if m.closedOperation(cause) {
+		m.warning(timing.ErrClosed)
+		http.Error(w, "simulation is closed", http.StatusServiceUnavailable)
+		return
+	}
+	m.fail(cause)
+	http.Error(w, "monitor operation failed", http.StatusInternalServerError)
 }

--- a/monitoring2/monitor_test.go
+++ b/monitoring2/monitor_test.go
@@ -567,6 +567,7 @@ func (c *tickableComponent) TickLater()                    { c.tickCalls++ }
 
 func TestTickInvokesTickLaterOnTickingComponent(t *testing.T) {
 	monitor := NewMonitor()
+	monitor.RegisterEngine(&fakeEngine{})
 	tickable := newTickableComponent("ticker")
 	monitor.RegisterComponent(tickable)
 

--- a/monitoring2/monitor_test.go
+++ b/monitoring2/monitor_test.go
@@ -802,8 +802,11 @@ func TestHangDetectorBuffersRejectsInvalidSort(t *testing.T) {
 func newTestDBTracer(t *testing.T) *tracing.DBTracer {
 	t.Helper()
 
-	recorder := datarecording.NewDataRecorder(
+	recorder, err := datarecording.NewDataRecorder(
 		filepath.Join(t.TempDir(), "tracer"))
+	if err != nil {
+		panic(err)
+	}
 	t.Cleanup(func() {
 		_ = recorder.Close()
 	})

--- a/monitoring2/serial_tick_test.go
+++ b/monitoring2/serial_tick_test.go
@@ -1,0 +1,73 @@
+package monitoring2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/synctest"
+
+	"github.com/sarchlab/akita/v5/timing"
+)
+
+type serialTickComponent struct {
+	*tickableComponent
+	engine           *timing.SerialEngine
+	entered, release chan struct{}
+	active           bool
+	events           int
+}
+
+func (c *serialTickComponent) Handle(evt timing.Event) {
+	c.active = true
+	if evt.Time() == 1 {
+		close(c.entered)
+		<-c.release
+	}
+	c.events++
+	c.active = false
+}
+
+func (c *serialTickComponent) TickLater() {
+	if c.active {
+		panic("monitor scheduled while a model callback was active")
+	}
+	c.engine.Schedule(timing.MakeEventBase(c.engine.IDGenerator(), c.engine.CurrentTime()+1, c.Name()))
+}
+
+func TestMonitorTickWaitsForSerialCallback(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		e := timing.NewSerialEngine()
+		c := &serialTickComponent{
+			tickableComponent: newTickableComponent("ticker"), engine: e,
+			entered: make(chan struct{}), release: make(chan struct{}),
+		}
+		e.RegisterHandler(c.Name(), c)
+		e.Schedule(timing.MakeEventBase(e.IDGenerator(), 1, c.Name()))
+		m := NewMonitor()
+		m.RegisterEngine(e)
+		m.RegisterComponent(c)
+		done := make(chan error, 1)
+		go func() { done <- e.Run() }()
+		<-c.entered
+		w := httptest.NewRecorder()
+		requested := make(chan struct{})
+		go func() {
+			m.containRequests(http.HandlerFunc(m.tick)).ServeHTTP(w,
+				httptest.NewRequest(http.MethodPost, "/api/tick/ticker", nil))
+			close(requested)
+		}()
+		synctest.Wait()
+		select {
+		case <-requested:
+			t.Error("tick request completed before the active callback finished")
+		default:
+		}
+		close(c.release)
+		<-requested
+		err := <-done
+		if w.Code != http.StatusOK || err != nil || c.events != 2 {
+			t.Fatalf("status=%d run=%v events=%d", w.Code, err, c.events)
+		}
+		t.Logf("HTTP tick waited for the active callback, returned 200, and its scheduled event completed")
+	})
+}

--- a/noc/acceptance/dgx_single_p2p/main.go
+++ b/noc/acceptance/dgx_single_p2p/main.go
@@ -32,7 +32,9 @@ func main() {
 
 	t.MustHaveReceivedAllMsgs()
 	t.ReportBandwidthAchieved(engine.CurrentTime())
-	sim.Terminate()
+	if err := sim.Terminate(); err != nil {
+		panic(err)
+	}
 	atexit.Exit(0)
 }
 

--- a/noc/acceptance/dgx_single_p2p_all/main.go
+++ b/noc/acceptance/dgx_single_p2p_all/main.go
@@ -57,7 +57,9 @@ func main() {
 
 			t.MustHaveReceivedAllMsgs()
 			t.ReportBandwidthAchieved(engine.CurrentTime())
-			sim.Terminate()
+			if err := sim.Terminate(); err != nil {
+				panic(err)
+			}
 		}
 	}
 

--- a/noc/acceptance/dgx_single_random/main.go
+++ b/noc/acceptance/dgx_single_random/main.go
@@ -57,7 +57,9 @@ func main() {
 	t.MustHaveReceivedAllMsgs()
 	t.ReportBandwidthAchieved(engine.CurrentTime())
 
-	sim.Terminate()
+	if err := sim.Terminate(); err != nil {
+		panic(err)
+	}
 	atexit.Exit(0)
 }
 

--- a/noc/acceptance/mesh/main.go
+++ b/noc/acceptance/mesh/main.go
@@ -63,6 +63,8 @@ func main() {
 
 	test.MustHaveReceivedAllMsgs()
 	test.ReportBandwidthAchieved(engine.CurrentTime())
-	sim.Terminate()
+	if err := sim.Terminate(); err != nil {
+		panic(err)
+	}
 	fmt.Println("passed!")
 }

--- a/noc/acceptance/one_switch/main.go
+++ b/noc/acceptance/one_switch/main.go
@@ -32,7 +32,9 @@ func main() {
 
 	t.MustHaveReceivedAllMsgs()
 	t.ReportBandwidthAchieved(engine.CurrentTime())
-	sim.Terminate()
+	if err := sim.Terminate(); err != nil {
+		panic(err)
+	}
 	atexit.Exit(0)
 }
 

--- a/noc/acceptance/one_to_one/main.go
+++ b/noc/acceptance/one_to_one/main.go
@@ -34,7 +34,9 @@ func main() {
 
 	t.MustHaveReceivedAllMsgs()
 	t.ReportBandwidthAchieved(engine.CurrentTime())
-	s.Terminate()
+	if err := s.Terminate(); err != nil {
+		panic(err)
+	}
 	atexit.Exit(0)
 }
 

--- a/noc/acceptance/pcie_p2p/main.go
+++ b/noc/acceptance/pcie_p2p/main.go
@@ -32,7 +32,9 @@ func main() {
 
 	t.MustHaveReceivedAllMsgs()
 	t.ReportBandwidthAchieved(engine.CurrentTime())
-	sim.Terminate()
+	if err := sim.Terminate(); err != nil {
+		panic(err)
+	}
 	atexit.Exit(0)
 }
 

--- a/noc/acceptance/pcie_random/main.go
+++ b/noc/acceptance/pcie_random/main.go
@@ -36,7 +36,9 @@ func main() {
 
 	t.MustHaveReceivedAllMsgs()
 	t.ReportBandwidthAchieved(engine.CurrentTime())
-	sim.Terminate()
+	if err := sim.Terminate(); err != nil {
+		panic(err)
+	}
 	atexit.Exit(0)
 }
 

--- a/noc/acceptance/simbuild.go
+++ b/noc/acceptance/simbuild.go
@@ -27,5 +27,9 @@ func NewSimulation() *simulation.Simulation {
 		b = b.WithVisTracingOnStart().WithOutputFileName("trace")
 	}
 
-	return b.Build()
+	sim, err := b.Build()
+	if err != nil {
+		panic(err)
+	}
+	return sim
 }

--- a/noc/acceptance/test.go
+++ b/noc/acceptance/test.go
@@ -64,7 +64,7 @@ func (t *Test) GenerateMsgs(n uint64) {
 
 		msg := TrafficMsg{
 			MsgMeta: messaging.MsgMeta{
-				ID:           timing.GetIDGenerator().Generate(),
+				ID:           t.agents[0].IDGenerator().Generate(),
 				Src:          srcPort.AsRemote(),
 				Dst:          dstPort.AsRemote(),
 				TrafficBytes: rand.Intn(4096),

--- a/noc/acceptance/three_agent_one_switch/main.go
+++ b/noc/acceptance/three_agent_one_switch/main.go
@@ -32,7 +32,9 @@ func main() {
 
 	t.MustHaveReceivedAllMsgs()
 	t.ReportBandwidthAchieved(engine.CurrentTime())
-	sim.Terminate()
+	if err := sim.Terminate(); err != nil {
+		panic(err)
+	}
 	atexit.Exit(0)
 }
 

--- a/noc/directconnection/checkpoint_test.go
+++ b/noc/directconnection/checkpoint_test.go
@@ -17,7 +17,10 @@ func TestDirectConnectionCursorRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "ck.tar.gz")
 	const buildID = "conn-test"
 
-	sim := simulation.MakeBuilder().WithoutMonitoring().Build()
+	sim, err := simulation.MakeBuilder().WithoutMonitoring().Build()
+	if err != nil {
+		panic(err)
+	}
 	defer func() {
 		sim.Terminate()
 		os.Remove("akita_sim_" + sim.ID() + ".sqlite3")

--- a/noc/directconnection/directconnection_test.go
+++ b/noc/directconnection/directconnection_test.go
@@ -20,7 +20,7 @@ type testMsg struct {
 func newTestMsg() testMsg {
 	return testMsg{
 		MsgMeta: messaging.MsgMeta{
-			ID: timing.GetIDGenerator().Generate(),
+			ID: testIDs.Generate(),
 		},
 	}
 }
@@ -63,7 +63,7 @@ var _ = Describe("DirectConnection", func() {
 	It("should forward when handling tick event", func() {
 		engine.EXPECT().CurrentTime().Return(timing.VTimeInPicoSec(10000))
 
-		tick := modeling.MakeTickEvent(connection.Name(), timing.VTimeInPicoSec(10000))
+		tick := modeling.MakeTickEvent(testIDs, connection.Name(), timing.VTimeInPicoSec(10000))
 
 		msg1 := newTestMsg()
 		msg1.Src = port1.AsRemote()
@@ -96,7 +96,7 @@ var _ = Describe("DirectConnection", func() {
 	})
 
 	It("should keep outgoing messages queued when delivery is blocked", func() {
-		tick := modeling.MakeTickEvent(connection.Name(), timing.VTimeInPicoSec(10000))
+		tick := modeling.MakeTickEvent(testIDs, connection.Name(), timing.VTimeInPicoSec(10000))
 
 		msg := newTestMsg()
 		msg.Src = port1.AsRemote()
@@ -184,7 +184,7 @@ var _ = Describe("Direct Connection Integration", func() {
 				for msg.Dst == msg.Src {
 					msg.Dst = agents[rand.Intn(len(agents))].OutPort.AsRemote()
 				}
-				msg.ID = timing.GetIDGenerator().Generate()
+				msg.ID = testIDs.Generate()
 				agent.msgsOut = append(agent.msgsOut, msg)
 			}
 			agent.TickLater()
@@ -237,7 +237,7 @@ func directConnectionTest(seed int64) timing.VTimeInPicoSec {
 				msg.Dst = agents[r.Intn(len(agents))].OutPort.AsRemote()
 			}
 
-			msg.ID = timing.GetIDGenerator().Generate()
+			msg.ID = testIDs.Generate()
 
 			agent.msgsOut = append(agent.msgsOut, msg)
 		}

--- a/noc/directconnection/id_fixture_test.go
+++ b/noc/directconnection/id_fixture_test.go
@@ -1,0 +1,4 @@
+package directconnection
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/noc/directconnection/id_mock_test.go
+++ b/noc/directconnection/id_mock_test.go
@@ -1,0 +1,4 @@
+package directconnection
+import "github.com/sarchlab/akita/v5/timing"
+func (m *MockEngine) IDGenerator() timing.IDGenerator { return mockIDs }
+var mockIDs = timing.NewIDGenerator()

--- a/noc/networking/switching/endpoint/endpoint_test.go
+++ b/noc/networking/switching/endpoint/endpoint_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sarchlab/akita/v5/noc/packetization"
 
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -63,7 +62,7 @@ var _ = Describe("End Point", func() {
 
 	It("should send flits", func() {
 		msg := messaging.MsgMeta{
-			ID:           timing.GetIDGenerator().Generate(),
+			ID:           testIDs.Generate(),
 			Src:          devicePort.AsRemote(),
 			TrafficBytes: 33,
 		}
@@ -110,18 +109,18 @@ var _ = Describe("End Point", func() {
 
 	It("should receive message", func() {
 		msg := messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Dst: devicePort.AsRemote(),
 		}
 
 		flit0 := packetization.Flit{}
-		flit0.ID = timing.GetIDGenerator().Generate()
+		flit0.ID = testIDs.Generate()
 		flit0.TrafficClass = reflect.TypeOf(msg).String()
 		flit0.SeqID = 0
 		flit0.NumFlitInMsg = 2
 		flit0.Msg = msg
 		flit1 := packetization.Flit{}
-		flit1.ID = timing.GetIDGenerator().Generate()
+		flit1.ID = testIDs.Generate()
 		flit1.TrafficClass = reflect.TypeOf(msg).String()
 		flit1.SeqID = 1
 		flit1.NumFlitInMsg = 2

--- a/noc/networking/switching/endpoint/id_fixture_test.go
+++ b/noc/networking/switching/endpoint/id_fixture_test.go
@@ -1,0 +1,4 @@
+package endpoint
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/noc/networking/switching/endpoint/id_mock_test.go
+++ b/noc/networking/switching/endpoint/id_mock_test.go
@@ -1,0 +1,4 @@
+package endpoint
+import "github.com/sarchlab/akita/v5/timing"
+func (m *MockEngine) IDGenerator() timing.IDGenerator { return mockIDs }
+var mockIDs = timing.NewIDGenerator()

--- a/noc/networking/switching/endpoint/outgoingmw.go
+++ b/noc/networking/switching/endpoint/outgoingmw.go
@@ -14,6 +14,7 @@ import (
 )
 
 func msgMetaToFlits(
+	ids timing.IDGenerator,
 	meta messaging.MsgMeta,
 	spec Spec,
 	networkPortRemote messaging.RemotePort,
@@ -32,7 +33,7 @@ func msgMetaToFlits(
 	for i := 0; i < numFlit; i++ {
 		flits[i] = packetization.Flit{
 			MsgMeta: messaging.MsgMeta{
-				ID:  timing.GetIDGenerator().Generate(),
+				ID:  ids.Generate(),
 				Src: networkPortRemote,
 				Dst: defaultSwitchDst,
 			},
@@ -184,9 +185,9 @@ func (m *outgoingMW) prepareFlits() bool {
 		// simulation), travels in every flit as MsgTaskID, and is the parent of
 		// each per-flit flit_e2e task. It is parented to the message's own ID so
 		// it nests under that req_out when one exists.
-		msgTaskID := timing.GetIDGenerator().Generate()
+		msgTaskID := m.comp.IDGenerator().Generate()
 		flits := msgMetaToFlits(
-			meta, spec, networkPortRemote, m.defaultSwitchDst, msgTaskID)
+			m.comp.IDGenerator(), meta, spec, networkPortRemote, m.defaultSwitchDst, msgTaskID)
 
 		state.FlitsToSend = append(state.FlitsToSend, flits...)
 

--- a/noc/networking/switching/switches/checkpoint_test.go
+++ b/noc/networking/switching/switches/checkpoint_test.go
@@ -18,7 +18,10 @@ func TestSwitchArbCursorRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "ck.tar.gz")
 	const buildID = "switch-test"
 
-	sim := simulation.MakeBuilder().WithoutMonitoring().Build()
+	sim, err := simulation.MakeBuilder().WithoutMonitoring().Build()
+	if err != nil {
+		panic(err)
+	}
 	defer func() {
 		sim.Terminate()
 		os.Remove("akita_sim_" + sim.ID() + ".sqlite3")

--- a/noc/networking/switching/switches/id_fixture_test.go
+++ b/noc/networking/switching/switches/id_fixture_test.go
@@ -1,0 +1,4 @@
+package switches
+import "github.com/sarchlab/akita/v5/timing"
+
+var testIDs = timing.NewIDGenerator()

--- a/noc/networking/switching/switches/id_mock_test.go
+++ b/noc/networking/switching/switches/id_mock_test.go
@@ -1,0 +1,4 @@
+package switches
+import "github.com/sarchlab/akita/v5/timing"
+func (m *MockEngine) IDGenerator() timing.IDGenerator { return mockIDs }
+var mockIDs = timing.NewIDGenerator()

--- a/noc/networking/switching/switches/receivepipelinemw.go
+++ b/noc/networking/switching/switches/receivepipelinemw.go
@@ -5,7 +5,6 @@ import (
 	"github.com/sarchlab/akita/v5/noc/packetization"
 
 	"github.com/sarchlab/akita/v5/messaging"
-	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 )
 
@@ -47,7 +46,7 @@ func (m *receivePipelineMW) startProcessing() (madeProgress bool) {
 			}
 
 			flit := itemI.(packetization.Flit)
-			taskID := timing.GetIDGenerator().Generate()
+			taskID := m.comp.IDGenerator().Generate()
 			item := routedFlit{
 				Flit:    flit,
 				TaskID:  taskID,

--- a/noc/networking/switching/switches/switch_test.go
+++ b/noc/networking/switching/switches/switch_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/queueing"
-	"github.com/sarchlab/akita/v5/timing"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -108,12 +107,12 @@ var _ = Describe("Switch", func() {
 
 	It("should start processing", func() {
 		msg := messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Src: dstPort.AsRemote(),
 			Dst: dstPort.AsRemote(),
 		}
 		flit := packetization.Flit{}
-		flit.ID = timing.GetIDGenerator().Generate()
+		flit.ID = testIDs.Generate()
 		flit.Dst = port1.AsRemote()
 		flit.TrafficClass = reflect.TypeOf(msg).String()
 		flit.Msg = msg
@@ -133,12 +132,12 @@ var _ = Describe("Switch", func() {
 
 	It("should not start processing if pipeline is busy", func() {
 		msg := messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Src: dstPort.AsRemote(),
 			Dst: dstPort.AsRemote(),
 		}
 		flit := packetization.Flit{}
-		flit.ID = timing.GetIDGenerator().Generate()
+		flit.ID = testIDs.Generate()
 		flit.Dst = port1.AsRemote()
 		flit.TrafficClass = reflect.TypeOf(msg).String()
 		flit.Msg = msg
@@ -174,12 +173,12 @@ var _ = Describe("Switch", func() {
 
 	It("should route", func() {
 		msg := messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Src: dstPort.AsRemote(),
 			Dst: dstPort.AsRemote(),
 		}
 		flit := packetization.Flit{}
-		flit.ID = timing.GetIDGenerator().Generate()
+		flit.ID = testIDs.Generate()
 		flit.TrafficClass = reflect.TypeOf(msg).String()
 		flit.Msg = msg
 
@@ -204,12 +203,12 @@ var _ = Describe("Switch", func() {
 
 	It("should not route if forward buffer is full", func() {
 		msg := messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Src: dstPort.AsRemote(),
 			Dst: dstPort.AsRemote(),
 		}
 		flit := packetization.Flit{}
-		flit.ID = timing.GetIDGenerator().Generate()
+		flit.ID = testIDs.Generate()
 		flit.TrafficClass = reflect.TypeOf(msg).String()
 		flit.Msg = msg
 
@@ -231,12 +230,12 @@ var _ = Describe("Switch", func() {
 
 	It("should forward", func() {
 		msg := messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Src: dstPort.AsRemote(),
 			Dst: dstPort.AsRemote(),
 		}
 		flit := packetization.Flit{}
-		flit.ID = timing.GetIDGenerator().Generate()
+		flit.ID = testIDs.Generate()
 		flit.TrafficClass = reflect.TypeOf(msg).String()
 		flit.Msg = msg
 		// Place flit in forward buffer of port1, targeting sendOutBuffer of port2
@@ -256,12 +255,12 @@ var _ = Describe("Switch", func() {
 
 	It("should not forward if the output buffer is busy", func() {
 		msg := messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Src: dstPort.AsRemote(),
 			Dst: dstPort.AsRemote(),
 		}
 		flit := packetization.Flit{}
-		flit.ID = timing.GetIDGenerator().Generate()
+		flit.ID = testIDs.Generate()
 		flit.TrafficClass = reflect.TypeOf(msg).String()
 		flit.Msg = msg
 		// Fill sendOut buffer to capacity, forward buffer targets port2
@@ -282,12 +281,12 @@ var _ = Describe("Switch", func() {
 
 	It("should send flits out", func() {
 		msg := messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Src: dstPort.AsRemote(),
 			Dst: dstPort.AsRemote(),
 		}
 		flit := packetization.Flit{}
-		flit.ID = timing.GetIDGenerator().Generate()
+		flit.ID = testIDs.Generate()
 		flit.TrafficClass = reflect.TypeOf(msg).String()
 		flit.Msg = msg
 
@@ -309,12 +308,12 @@ var _ = Describe("Switch", func() {
 
 	It("should wait if port is busy sending flits out", func() {
 		msg := messaging.MsgMeta{
-			ID:  timing.GetIDGenerator().Generate(),
+			ID:  testIDs.Generate(),
 			Src: dstPort.AsRemote(),
 			Dst: dstPort.AsRemote(),
 		}
 		flit := packetization.Flit{}
-		flit.ID = timing.GetIDGenerator().Generate()
+		flit.ID = testIDs.Generate()
 		flit.TrafficClass = reflect.TypeOf(msg).String()
 		flit.Msg = msg
 

--- a/noc/packetization/id_mock_test.go
+++ b/noc/packetization/id_mock_test.go
@@ -1,0 +1,4 @@
+package packetization
+import "github.com/sarchlab/akita/v5/timing"
+func (m *MockEngine) IDGenerator() timing.IDGenerator { return mockIDs }
+var mockIDs = timing.NewIDGenerator()

--- a/queueing/buffer_json.go
+++ b/queueing/buffer_json.go
@@ -1,6 +1,9 @@
 package queueing
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // bufferState is the JSON form of a Buffer: its name, capacity, and FIFO
 // contents. Buffer's fields are unexported, so without these methods
@@ -29,6 +32,9 @@ func (b *Buffer[T]) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	if s.Cap < 0 || len(s.Elements) > s.Cap {
+		return fmt.Errorf("queueing: invalid buffer capacity or occupancy")
+	}
 	b.name = s.Name
 	b.cap = s.Cap
 	b.elements = s.Elements

--- a/queueing/pipeline_json.go
+++ b/queueing/pipeline_json.go
@@ -1,6 +1,9 @@
 package queueing
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // pipelineState is the JSON form of a Pipeline: its geometry and the items
 // currently occupying it. Pipeline's fields are unexported, so without these
@@ -29,6 +32,18 @@ func (p *Pipeline[T]) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	if s.Width < 0 || s.NumStages < 0 {
+		return fmt.Errorf("queueing: invalid pipeline geometry")
+	}
+	occupied := make(map[[2]int]bool)
+	for _, stage := range s.Stages {
+		key := [2]int{stage.Lane, stage.Stage}
+		if stage.Lane < 0 || stage.Lane >= s.Width ||
+			stage.Stage < 0 || stage.Stage >= s.NumStages || stage.CycleLeft < 0 || occupied[key] {
+			return fmt.Errorf("queueing: invalid pipeline occupancy")
+		}
+		occupied[key] = true
+	}
 	p.width = s.Width
 	p.numStages = s.NumStages
 	p.stages = s.Stages

--- a/queueing/validation_test.go
+++ b/queueing/validation_test.go
@@ -1,0 +1,36 @@
+package queueing
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBufferRejectsInvalidJSONBeforeAssignment(t *testing.T) {
+	for _, input := range []string{
+		`{"cap":-1}`, `{"cap":1,"elements":[1,2]}`,
+	} {
+		b := NewBuffer[int]("original", 2)
+		b.PushTyped(9)
+		if err := json.Unmarshal([]byte(input), &b); err == nil {
+			t.Fatalf("accepted %s", input)
+		}
+		if b.Name() != "original" || b.Capacity() != 2 || b.Peek() != 9 {
+			t.Fatal("invalid JSON mutated target")
+		}
+	}
+}
+
+func TestPipelineRejectsInvalidGeometryAndOccupancy(t *testing.T) {
+	for _, input := range []string{
+		`{"width":-1}`, `{"num_stages":-1}`,
+		`{"width":1,"num_stages":1,"stages":[{"lane":1}]}`,
+		`{"width":1,"num_stages":1,"stages":[{"stage":1}]}`,
+		`{"width":1,"num_stages":1,"stages":[{"cycle_left":-1}]}`,
+		`{"width":1,"num_stages":1,"stages":[{},{}]}`,
+	} {
+		var p Pipeline[int]
+		if err := json.Unmarshal([]byte(input), &p); err == nil {
+			t.Fatalf("accepted %s", input)
+		}
+	}
+}

--- a/simulation/ERROR_HANDLING.md
+++ b/simulation/ERROR_HANDLING.md
@@ -39,11 +39,14 @@ launches; do not start unmanaged goroutines that touch simulation state.
 and records terminal failure.
 
 The serial engine's event queue and model belong to the goroutine calling
-`Run`/`RunUntil`. During execution, only callbacks on that goroutine may schedule
-events or mutate engine state. Background tooling must not access that queue or
+`Run`/`RunUntil`. While dispatch is running, only callbacks on that goroutine may
+schedule events or mutate engine state. Background tooling must not access that queue or
 model; worker supervision does not grant concurrent access. Setup, registration,
 and checkpoint operations require stopped execution and host coordination.
-The parallel engine separately supports scheduling from its workers.
+External scheduling requires a completed run or an acknowledged `Pause`, with
+host coordination preventing concurrent access or resume. The monitor uses this
+pause protocol when its tick endpoint schedules an event. The parallel engine
+separately supports scheduling from its workers.
 
 Do not recursively call `Run`, `Setup`, or checkpoint operations from their
 callbacks. Concurrent managed operations return an error. `Pause` and

--- a/simulation/ERROR_HANDLING.md
+++ b/simulation/ERROR_HANDLING.md
@@ -98,6 +98,11 @@ it, so two simulations cannot overwrite each other's recording. Use distinct
 output paths, and choose a new path or explicitly remove a discarded recording
 before retrying.
 
+Output filenames are literal paths, including `?` and `#`; they cannot inject
+SQLite connection options or alias another recording. A connection initialization
+error removes the newly claimed unused file when possible. Later recording
+failures retain partial output for diagnosis.
+
 ## Optional features and output validity
 
 An unavailable monitor or source archive produces a warning through

--- a/simulation/ERROR_HANDLING.md
+++ b/simulation/ERROR_HANDLING.md
@@ -65,7 +65,11 @@ engine time, or call `Terminate`. Do not inspect or mutate component state.
 Further run/setup/checkpoint operations return errors. Direct scheduling or
 resuming violates the failed-instance precondition and panics; using it inside
 `Setup` returns the already recorded failure. The monitor rejects model
-inspection and mutation on failed instances.
+inspection and mutation on failed instances. `timing.ErrClosed` identifies an
+operation rejected during healthy shutdown. An in-flight monitor inspection
+may encounter it while releasing its pause; that specific condition produces
+a diagnostic without invalidating completed results. Other panics still fail
+the simulation, including panics already unwinding when inspection cleanup runs.
 
 Recovery covers ordinary Go panics in managed setup, hooks, handlers, and
 workers. It cannot contain fatal runtime failures such as out-of-memory,

--- a/simulation/ERROR_HANDLING.md
+++ b/simulation/ERROR_HANDLING.md
@@ -1,0 +1,154 @@
+# Error handling and simulation ownership in v5
+
+Akita supports several independent simulations in one Go process. Model
+precondition violations panic. The owning simulation contains ordinary Go
+panics and returns a `*timing.FailureError` from its managed boundary. Failure
+is terminal: containment does not roll back model state or allow resuming it.
+
+## Managed boundaries
+
+Use `Builder.Build` callbacks for component construction, `Simulation.Setup`
+for subsequent setup or externally initiated mutations while execution is
+stopped, and `Simulation.Run` or the engine's `Run`/`RunUntil` for execution.
+All return errors. Check those errors before using the result.
+
+```go
+sim, err := simulation.MakeBuilder().WithoutMonitoring().Build(
+    func(sim *simulation.Simulation) error {
+        // Build components, register handlers, and schedule initial events here.
+        // A panic or returned error fails only this simulation.
+        return nil
+    },
+)
+if err != nil {
+    return err // failed setup already released its owned resources
+}
+if err := sim.Run(); err != nil {
+    _ = sim.Terminate() // cleanup cannot escape as a panic
+    return err
+}
+return sim.Terminate() // final recording errors matter too
+```
+
+Standalone serial and parallel engines expose `Supervisor()` for the same
+managed setup/worker/cleanup contract. Extensions start workers with
+`sim.Go(name, func(context.Context) error)` inside an active managed operation.
+A worker must finish or respond to cancellation. Handle rejected worker
+launches; do not start unmanaged goroutines that touch simulation state.
+`Run` waits for owned workers and processes events they schedule before
+returning. `Cancel` stops cooperative work and records terminal failure.
+
+Do not recursively call `Run`, `Setup`, or checkpoint operations from their
+callbacks. Concurrent managed operations return an error. `Pause` and
+`Terminate` are host operations: do not call them from an event callback or
+owned worker, because they wait for that work to settle. External `Pause`
+waits for admitted event callbacks to leave model state; `Continue` resumes.
+It is still the host's responsibility to stop other extension producers before
+inspecting their state or saving a checkpoint.
+
+Direct access to public model state, direct handler calls, and unmanaged
+host callbacks remain the caller's responsibility. Akita cannot intercept
+arbitrary Go assignments. Use a managed boundary to contain their failures.
+
+## Failure and diagnostics
+
+`State()` reports `ready`, `running`, `failed`, or `closed`. `ready` means no
+managed operation is active; it does not imply that a previously executed
+instance is fresh enough to restore. `failed` takes precedence over `closed`.
+`Err()` returns the first failure. `Failures()` preserves later worker and
+cleanup failures as diagnostic snapshots, including stack traces. An error
+panic remains available through `errors.Is`/`errors.As`; string and other panic
+values are retained in `FailureError.Cause`.
+
+After failure, inspect these diagnostics, the simulation ID, warnings, and
+engine time, or call `Terminate`. Do not inspect or mutate component state.
+Further run/setup/checkpoint operations return errors. Direct scheduling or
+resuming violates the failed-instance precondition and panics; using it inside
+`Setup` returns the already recorded failure. The monitor rejects model
+inspection and mutation on failed instances.
+
+Recovery covers ordinary Go panics in managed setup, hooks, handlers, and
+workers. It cannot contain fatal runtime failures such as out-of-memory,
+unsafe/native memory corruption, `os.Exit`, or kill a noncooperative goroutine.
+A host needing isolation against those failures still needs separate processes.
+
+## IDs, tracing, and resources
+
+Every engine owns its ID generator. Use `sim.GetIDGenerator()`,
+`engine.IDGenerator()` on concrete engines, or `timing.IDsFor(engine)` through
+an interface, and pass that source into event/message construction. Components
+expose `IDGenerator()` for their middleware. IDs need only be unique within one
+simulation; two independent simulations may generate the same numeric IDs.
+Tracing task associations belong to that sequence and are checkpointed with it.
+Custom ID generators must implement the full concurrent association contract.
+
+The process-global ID generator, reset, and generator-selection APIs have been
+removed. Never share a generator or mutable model resources between independent
+simulations. Shared immutable configuration is fine. Hosts supplying mutable
+resources or database handles explicitly take responsibility for isolation;
+`NewDataRecorderWithDB` transfers closing responsibility to the recorder.
+
+Recorders no longer register process-wide exit callbacks. Always finalize
+explicitly. Output creation rejects an existing database instead of deleting
+it, so two simulations cannot overwrite each other's recording. Use distinct
+output paths, and choose a new path or explicitly remove a discarded recording
+before retrying.
+
+## Optional features and output validity
+
+An unavailable monitor or source archive produces a warning through
+`Warnings()` and logging. Warnings are recorded in execution metadata during
+successful finalization. Missing source may prevent source browsing, but it
+does not invalidate numerical results. Unexpected panics or state corruption
+are never treated as optional degradation.
+
+A database write, requested trace, final flush, index build, or close failure
+fails the simulation. Partial recordings may remain for diagnosis. An end
+timestamp alone is not evidence of valid output. Successful `Terminate`
+publishes `<output-base>.complete` only after recording and database close
+succeed. Absence of that marker means completion has not been established;
+copy it alongside completed recordings. The returned termination error remains
+the authoritative signal to the running host.
+
+Recorder I/O methods return errors. `datarecording.MustRecord(err)` adapts an
+I/O failure to a panic inside a managed model/tracing callback. Standalone
+recording clients should handle errors directly. A failed flush retains its
+batch for retry; retry `Flush`, not the insertion that triggered automatic
+flushing. `Close` always releases the database and is final, even on failure.
+
+## Fresh restore and validation
+
+Rebuild a new compatible simulation and load its checkpoint before execution.
+Do not rewind an existing run. A target may attempt restore only once. Any
+restore failure invalidates the entire target, including failures during
+preflight. Discard it and construct another target to retry. Earlier entities
+may already have changed; global transactional rollback is not provided.
+Other simulations' IDs, resources, and output remain untouched.
+
+Container geometry, storage addresses, and event references are validated
+before local assignment. Port restore stages both buffers together. These local
+checks reduce partial mutation but do not make arbitrary entity serializers
+transactional. Save checkpoints only while the simulation and its producers
+are stopped. Failed instances cannot produce valid checkpoints.
+
+## Interface migration
+
+- `Handler.Handle(Event)` has no error result. Normal modeled failures remain
+  protocol responses; backpressure and lookup misses remain ordinary results.
+- `Storage.Read(address, length)` returns `[]byte`; `Storage.Write(address,
+  data)` has no result. Empty, overflowing, and out-of-capacity ranges panic
+  before allocating storage units or modifying bytes.
+- `Builder.Build(...setupCallbacks)` returns `(*Simulation, error)`.
+  `Simulation.Terminate()` returns an error.
+- `MakeEventBase`, `MakeTickEvent`, and `MakeTimerFiredEvent` take the owning
+  `IDGenerator` as their first argument. Tracing domains implement `IDSource`.
+- `NewDataRecorder` and `NewReader` return `(value, error)`.
+  `CreateTable`, `InsertData`, and `Flush` return errors.
+- Monitor start/stop and replay-server creation/start/stop return errors.
+  Trace-reader queries return errors instead of panic or partial success.
+- JSON, codecs, checkpoint serializers, explicit validators, external I/O,
+  request validation, and provider operations retain their error contracts.
+
+Run `go run ./examples/failureisolation` for a two-simulation example. It reports
+one failed event in the first simulation and three completed events in its peer,
+then exits successfully because the injected failure was contained as expected.

--- a/simulation/ERROR_HANDLING.md
+++ b/simulation/ERROR_HANDLING.md
@@ -35,14 +35,23 @@ managed setup/worker/cleanup contract. Extensions start workers with
 `sim.Go(name, func(context.Context) error)` inside an active managed operation.
 A worker must finish or respond to cancellation. Handle rejected worker
 launches; do not start unmanaged goroutines that touch simulation state.
-`Run` waits for owned workers and processes events they schedule before
-returning. `Cancel` stops cooperative work and records terminal failure.
+`Run` joins owned workers before returning. `Cancel` stops cooperative work
+and records terminal failure.
+
+The serial engine's event queue and model belong to the goroutine calling
+`Run`/`RunUntil`. During execution, only callbacks on that goroutine may schedule
+events or mutate engine state. Background tooling must not access that queue or
+model; worker supervision does not grant concurrent access. Setup, registration,
+and checkpoint operations require stopped execution and host coordination.
+The parallel engine separately supports scheduling from its workers.
 
 Do not recursively call `Run`, `Setup`, or checkpoint operations from their
 callbacks. Concurrent managed operations return an error. `Pause` and
 `Terminate` are host operations: do not call them from an event callback or
 owned worker, because they wait for that work to settle. External `Pause`
 waits for admitted event callbacks to leave model state; `Continue` resumes.
+The serial event loop acknowledges pause at an event boundary without locking
+its queue or each dispatch. Hosts must coordinate inspection and resume calls.
 It is still the host's responsibility to stop other extension producers before
 inspecting their state or saving a checkpoint.
 

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -155,3 +155,5 @@ worked example, and the gotchas.
 
 See `examples/checkpointdemo` for a runnable save/load demo and
 `mem/acceptancetests/checkpointresume` for a mid-transaction resume oracle.
+
+See [v5 error handling and ownership](ERROR_HANDLING.md) for managed setup, failure isolation, and interface migration.

--- a/simulation/builder.go
+++ b/simulation/builder.go
@@ -1,8 +1,11 @@
 package simulation
 
 import (
+	"errors"
+	"fmt"
 	"io/fs"
 	"maps"
+	"os"
 
 	"github.com/rs/xid"
 	"github.com/sarchlab/akita/v5/datarecording"
@@ -95,22 +98,35 @@ func (b Builder) parametersMustBeValid() {
 	}
 }
 
-// Build builds the simulation.
-func (b Builder) Build() *Simulation {
-	b.parametersMustBeValid()
-
+// Build creates a simulation and contains setup panics. Optional callbacks
+// construct components inside the same boundary. On failure the returned
+// instance contains diagnostics and has already released its owned resources.
+func (b Builder) Build(setup ...func(*Simulation) error) (*Simulation, error) {
 	s := b.createSimulation()
-
-	b.createDataRecorder(s)
 	b.createEngine(s)
-	b.createIDGenerator(s)
-	b.createMetaRecorder(s)
-	b.createSourceRecorder(s)
-	b.createTopologyRecorder(s)
-	b.createVisTracer(s)
-	b.createServer(s)
-
-	return s
+	s.supervisor = s.engine.(timing.ManagedEngine).Supervisor()
+	s.supervisor.SetID(s.id)
+	err := s.supervisor.Execute("setup", func() error {
+		b.parametersMustBeValid()
+		b.createIDGenerator(s)
+		b.createDataRecorder(s)
+		b.createMetaRecorder(s)
+		b.createSourceRecorder(s)
+		b.createTopologyRecorder(s)
+		b.createVisTracer(s)
+		b.createServer(s)
+		for _, fn := range setup {
+			if err := fn(s); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		_ = s.Terminate()
+		return s, s.Err()
+	}
+	return s, nil
 }
 
 // createSourceRecorder records the simulator source into the trace so it is
@@ -122,7 +138,7 @@ func (b Builder) createSourceRecorder(s *Simulation) {
 	}
 
 	if err := recordSourceArchives(s.dataRecorder, b.sourceFSes); err != nil {
-		panic(err)
+		s.warn("source archive", err)
 	}
 }
 
@@ -153,7 +169,14 @@ func (b Builder) createDataRecorder(s *Simulation) {
 		outputPath = "akita_sim_" + s.id
 	}
 	s.outputPath = outputPath
-	s.dataRecorder = datarecording.NewDataRecorder(outputPath)
+	recorder, err := datarecording.NewDataRecorder(outputPath)
+	if err != nil {
+		panic(err)
+	}
+	s.dataRecorder = recorder
+	if err := os.Remove(outputPath + ".complete"); err != nil && !errors.Is(err, os.ErrNotExist) {
+		panic(err)
+	}
 }
 
 func (b Builder) createEngine(s *Simulation) {
@@ -168,10 +191,9 @@ func (b Builder) createEngine(s *Simulation) {
 	}
 }
 
-// createIDGenerator registers the process-wide ID generator as an entity so its
-// counter is captured in the state snapshot.
+// createIDGenerator registers this engine's sequence for checkpoint ownership.
 func (b Builder) createIDGenerator(s *Simulation) {
-	s.registerEntity(timing.GetIDGenerator().(Entity))
+	s.registerEntity(s.engine.(timing.IDSource).IDGenerator().(Entity))
 }
 
 func (b Builder) createMetaRecorder(s *Simulation) {
@@ -199,7 +221,12 @@ func (b Builder) createServer(s *Simulation) {
 	monitor.RegisterEngine(s.engine)
 	monitor.RegisterVisTracer(s.visTracer)
 	monitor.SetTraceDBPath(s.outputPath + ".sqlite3")
-	monitor.StartServer()
+	monitor.OnWarning = func(err error) { s.warn("monitor", err) }
+	monitor.OnFailure = func(cause any) { s.supervisor.Fail("monitor", cause) }
+	if err := monitor.StartServer(); err != nil {
+		s.warn("monitor", fmt.Errorf("start: %w", err))
+		return
+	}
 
 	s.monitor = monitor
 }

--- a/simulation/builder.go
+++ b/simulation/builder.go
@@ -114,7 +114,6 @@ func (b Builder) Build(setup ...func(*Simulation) error) (*Simulation, error) {
 		b.createSourceRecorder(s)
 		b.createTopologyRecorder(s)
 		b.createVisTracer(s)
-		b.createServer(s)
 		for _, fn := range setup {
 			if err := fn(s); err != nil {
 				return err
@@ -122,6 +121,10 @@ func (b Builder) Build(setup ...func(*Simulation) error) (*Simulation, error) {
 		}
 		return nil
 	})
+	if err == nil {
+		// Publish the monitor only after setup and its owned workers settle.
+		err = s.supervisor.Execute("start monitor", func() error { b.createServer(s); return nil })
+	}
 	if err != nil {
 		_ = s.Terminate()
 		return s, s.Err()
@@ -218,6 +221,12 @@ func (b Builder) createServer(s *Simulation) {
 		monitor.WithPortNumber(b.monitorPort)
 	}
 
+	for _, comp := range s.components {
+		monitor.RegisterComponent(comp)
+	}
+	for _, port := range s.ports {
+		monitor.RegisterPort(port)
+	}
 	monitor.RegisterEngine(s.engine)
 	monitor.RegisterVisTracer(s.visTracer)
 	monitor.SetTraceDBPath(s.outputPath + ".sqlite3")

--- a/simulation/checkpoint.go
+++ b/simulation/checkpoint.go
@@ -15,6 +15,14 @@ import (
 // Entity payload serializers land in later milestones, so this currently
 // returns an error for the first entity that has no serializer.
 func (s *Simulation) SaveCheckpoint(path, buildID string) error {
+	var saveErr error
+	err := s.supervisor.Execute("save checkpoint", func() error { saveErr = s.saveCheckpoint(path, buildID); return nil })
+	if err != nil {
+		return err
+	}
+	return saveErr
+}
+func (s *Simulation) saveCheckpoint(path, buildID string) error {
 	if err := s.checkpointPreflight(); err != nil {
 		return err
 	}
@@ -46,6 +54,15 @@ func (s *Simulation) SaveCheckpoint(path, buildID string) error {
 // checks the build identity and that the saved entity set matches the rebuilt
 // one, then hands each entity its payload.
 func (s *Simulation) LoadCheckpoint(path, buildID string) error {
+	return s.supervisor.Execute("restore checkpoint", func() error {
+		if !s.supervisor.Fresh() || s.restored {
+			return fmt.Errorf("checkpoint: restore requires a fresh, never executed instance")
+		}
+		s.restored = true
+		return s.loadCheckpoint(path, buildID)
+	})
+}
+func (s *Simulation) loadCheckpoint(path, buildID string) error {
 	if err := s.checkpointPreflight(); err != nil {
 		return err
 	}

--- a/simulation/failure_test.go
+++ b/simulation/failure_test.go
@@ -1,0 +1,224 @@
+package simulation
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func makeIsolated(t *testing.T, parallel bool, setup ...func(*Simulation) error) (*Simulation, error) {
+	t.Helper()
+	b := MakeBuilder().WithoutMonitoring().WithoutSourceRecording().
+		WithOutputFileName(filepath.Join(t.TempDir(), "result"))
+	if parallel {
+		b = b.WithParallelEngine()
+	}
+	return b.Build(setup...)
+}
+
+func TestSetupFailureDoesNotAffectAnotherSimulation(t *testing.T) {
+	for _, parallel := range []bool{false, true} {
+		good, err := makeIsolated(t, parallel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before := good.GetIDGenerator().Generate()
+		bad, err := makeIsolated(t, parallel, func(s *Simulation) error {
+			s.GetIDGenerator().Generate()
+			panic("invalid setup")
+		})
+		if err == nil || bad.Err() == nil {
+			t.Fatal("setup panic escaped failure boundary")
+		}
+		if next := good.GetIDGenerator().Generate(); next != before+1 {
+			t.Fatalf("another simulation changed IDs: %d -> %d", before, next)
+		}
+		if err := good.Run(); err != nil {
+			t.Fatal(err)
+		}
+		if err := good.Terminate(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(good.outputPath + ".complete"); err != nil {
+			t.Fatal("successful output is not complete", err)
+		}
+		if _, err := os.Stat(bad.outputPath + ".complete"); !errors.Is(err, os.ErrNotExist) {
+			t.Fatal("failed output marked complete")
+		}
+	}
+}
+
+type failingRecorder struct {
+	closeErr   error
+	closePanic any
+	closed     bool
+}
+
+func (*failingRecorder) CreateTable(string, any) error { return nil }
+func (*failingRecorder) InsertData(string, any) error  { return nil }
+func (*failingRecorder) ListTables() []string          { return nil }
+func (*failingRecorder) Flush() error                  { return nil }
+func (r *failingRecorder) Close() error {
+	r.closed = true
+	if r.closePanic != nil {
+		panic(r.closePanic)
+	}
+	return r.closeErr
+}
+
+func TestFinalizationFailureIsContainedAndNeverComplete(t *testing.T) {
+	sentinel := errors.New("close failed")
+	for _, panicValue := range []any{nil, "cleanup panic"} {
+		good, err := makeIsolated(t, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bad, err := makeIsolated(t, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := bad.dataRecorder.Close(); err != nil {
+			t.Fatal(err)
+		}
+		fake := &failingRecorder{closeErr: sentinel, closePanic: panicValue}
+		bad.dataRecorder = fake
+		bad.metaRecorder = nil
+		bad.topologyRecorder = nil
+		bad.visTracer = nil
+		if err := bad.Terminate(); err == nil || !fake.closed {
+			t.Fatalf("finalization failure lost: %v", err)
+		}
+		if _, err := os.Stat(bad.outputPath + ".complete"); !errors.Is(err, os.ErrNotExist) {
+			t.Fatal("failed output marked complete")
+		}
+		if err := good.Terminate(); err != nil {
+			t.Fatal("another simulation failed", err)
+		}
+	}
+}
+
+type restoreProbe struct {
+	value int
+	fail  bool
+}
+
+func (*restoreProbe) Name() string { return "probe" }
+func (p *restoreProbe) SaveCheckpoint(w io.Writer) error {
+	_, err := w.Write([]byte{byte(p.value)})
+	return err
+}
+func (p *restoreProbe) LoadCheckpoint(r io.Reader) error {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	p.value = int(b[0])
+	if p.fail {
+		return errors.New("bad checkpoint component")
+	}
+	return nil
+}
+func TestRestoreFailureDiscardsOnlyFreshTarget(t *testing.T) {
+	source, err := makeIsolated(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Terminate()
+	source.RegisterResource(&restoreProbe{value: 7})
+	for i := 0; i < 10; i++ {
+		source.GetIDGenerator().Generate()
+	}
+	file := filepath.Join(t.TempDir(), "checkpoint.tar.gz")
+	if err := source.SaveCheckpoint(file, "test"); err != nil {
+		t.Fatal(err)
+	}
+	bad, err := makeIsolated(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bad.Terminate()
+	probe := &restoreProbe{fail: true}
+	bad.RegisterResource(probe)
+	if err := bad.LoadCheckpoint(file, "test"); err == nil {
+		t.Fatal("bad restore succeeded")
+	}
+	if probe.value != 7 {
+		t.Fatal("test did not exercise a partially applied target")
+	}
+	if bad.Run() == nil || bad.SaveCheckpoint(file+".invalid", "test") == nil || bad.LoadCheckpoint(file, "test") == nil {
+		t.Fatal("failed target reused")
+	}
+	if source.GetIDGenerator().Generate() != 11 {
+		t.Fatal("restoring target changed source ID sequence")
+	}
+	fresh, err := makeIsolated(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Terminate()
+	fresh.RegisterResource(&restoreProbe{})
+	if err := fresh.LoadCheckpoint(file, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if fresh.GetIDGenerator().Generate() != 11 || source.GetIDGenerator().Generate() != 12 {
+		t.Fatal("restored sequences are not independent")
+	}
+	if err := fresh.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if err := fresh.LoadCheckpoint(file, "test"); err == nil {
+		t.Fatal("restored an executed target")
+	}
+}
+
+func TestOptionalCapabilitiesDegradeWithDiagnostics(t *testing.T) {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+	s, err := MakeBuilder().WithMonitorPort(port).WithVisTracingOnStart().
+		WithSourceFS("broken", unavailableSourceFS{}).
+		WithOutputFileName(filepath.Join(t.TempDir(), "result")).Build()
+	if err != nil {
+		t.Fatal("optional monitor failure invalidated setup", err)
+	}
+	defer s.Terminate()
+	if s.GetMonitor() != nil || len(s.Warnings()) != 2 {
+		t.Fatalf("optional failures were not both reported: %v", s.Warnings())
+	}
+	if err := s.Run(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFailureDiagnosticsAreIndependentSnapshots(t *testing.T) {
+	s, err := makeIsolated(t, false, func(*Simulation) error { return errors.New("setup") })
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	first := s.Failures()[0]
+	original := append([]byte(nil), first.Stack...)
+	first.Operation = "changed"
+	first.Stack[0] ^= 255
+	if s.Failures()[0].Operation == "changed" || !bytes.Equal(s.Failures()[0].Stack, original) {
+		t.Fatal("caller mutated diagnostics")
+	}
+	if !strings.Contains(s.Err().Error(), s.ID()) {
+		t.Fatal("simulation identity missing")
+	}
+}
+
+// The root itself cannot be opened, so ArchiveFS must surface an I/O error.
+type unavailableSourceFS struct{}
+
+func (unavailableSourceFS) Open(string) (fs.File, error) {
+	return nil, fs.ErrPermission
+}

--- a/simulation/failure_test.go
+++ b/simulation/failure_test.go
@@ -222,3 +222,23 @@ type unavailableSourceFS struct{}
 func (unavailableSourceFS) Open(string) (fs.File, error) {
 	return nil, fs.ErrPermission
 }
+
+func TestMonitorIsPublishedOnlyAfterManagedSetup(t *testing.T) {
+	var configured bool
+	s, err := MakeBuilder().WithoutSourceRecording().
+		WithOutputFileName(filepath.Join(t.TempDir(), "result")).
+		Build(func(s *Simulation) error {
+			if s.GetMonitor() != nil {
+				t.Fatal("monitor exposed partially constructed components")
+			}
+			configured = true
+			return nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Terminate()
+	if !configured || s.GetMonitor() == nil {
+		t.Fatal("monitor not published after setup")
+	}
+}

--- a/simulation/meta_recorder.go
+++ b/simulation/meta_recorder.go
@@ -33,7 +33,7 @@ func newMetaRecorder(
 		recorder:   recorder,
 		timeTeller: timeTeller,
 	}
-	r.recorder.CreateTable(r.tableName, simulationInfo{})
+	datarecording.MustRecord(r.recorder.CreateTable(r.tableName, simulationInfo{}))
 	r.Start()
 	return r
 }
@@ -56,7 +56,7 @@ func (r *metaRecorder) Start() {
 			strconv.FormatUint(uint64(r.timeTeller.CurrentTime()), 10))
 	}
 
-	r.recorder.Flush()
+	datarecording.MustRecord(r.recorder.Flush())
 }
 
 func (r *metaRecorder) End() {
@@ -72,12 +72,12 @@ func (r *metaRecorder) End() {
 			strconv.FormatUint(uint64(r.timeTeller.CurrentTime()), 10))
 	}
 
-	r.recorder.Flush()
+	datarecording.MustRecord(r.recorder.Flush())
 }
 
 func (r *metaRecorder) insertEntry(property, value string) {
-	r.recorder.InsertData(r.tableName, simulationInfo{
+	datarecording.MustRecord(r.recorder.InsertData(r.tableName, simulationInfo{
 		Property: property,
 		Value:    value,
-	})
+	}))
 }

--- a/simulation/meta_recorder_test.go
+++ b/simulation/meta_recorder_test.go
@@ -25,7 +25,10 @@ func TestMetaRecorderWritesExecInfo(t *testing.T) {
 	defer os.Remove(dbFile)
 
 	clock := &fakeTimeTeller{now: 10}
-	recorder := datarecording.NewDataRecorder(path)
+	recorder, err := datarecording.NewDataRecorder(path)
+	if err != nil {
+		panic(err)
+	}
 	metaRecorder := newMetaRecorder(recorder, clock)
 
 	values := readExecInfo(t, dbFile)
@@ -54,7 +57,10 @@ func TestMetaRecorderWritesExecInfo(t *testing.T) {
 func readExecInfo(t *testing.T, dbFile string) map[string]string {
 	t.Helper()
 
-	reader := datarecording.NewReader(dbFile)
+	reader, err := datarecording.NewReader(dbFile)
+	if err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 	reader.MapTable("exec_info", simulationInfo{})
 

--- a/simulation/monitor_shutdown_test.go
+++ b/simulation/monitor_shutdown_test.go
@@ -1,0 +1,102 @@
+package simulation
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type shutdownInspectionProbe struct {
+	block   atomic.Bool
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (p *shutdownInspectionProbe) Name() string {
+	if p.block.Load() {
+		p.once.Do(func() { close(p.entered) })
+		<-p.release
+	}
+	return "shutdown-probe"
+}
+
+func TestHealthyOutputCompletesWithAnInflightMonitorInspection(t *testing.T) {
+	s, probe, url := buildShutdownInspection(t)
+	var release sync.Once
+	unblock := func() { release.Do(func() { close(probe.release) }) }
+	defer func() { unblock(); _ = s.Terminate() }()
+	if err := s.Run(); err != nil {
+		t.Fatal(err)
+	}
+	probe.block.Store(true)
+	requestDone := make(chan struct{})
+	go func() {
+		defer close(requestDone)
+		client := &http.Client{Timeout: 2 * time.Second}
+		if response, err := client.Get(url); err == nil {
+			_ = response.Body.Close()
+		}
+	}()
+	select {
+	case <-probe.entered:
+	case <-time.After(time.Second):
+		t.Fatal("inspection did not reach the component")
+	}
+	terminated := make(chan error, 1)
+	go func() { terminated <- s.Terminate() }()
+	awaitClosedSimulation(t, s)
+	unblock()
+	if err := <-terminated; err != nil {
+		t.Fatal("monitor inspection invalidated healthy output", err)
+	}
+	<-requestDone
+	if _, err := os.Stat(s.outputPath + ".complete"); err != nil {
+		t.Fatal("healthy output was not published", err)
+	}
+}
+
+func buildShutdownInspection(t *testing.T) (*Simulation, *shutdownInspectionProbe, string) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	probe := &shutdownInspectionProbe{entered: make(chan struct{}), release: make(chan struct{})}
+	s, err := MakeBuilder().WithMonitorPort(port).WithoutSourceRecording().WithVisTracingOnStart().
+		WithOutputFileName(filepath.Join(t.TempDir(), "result")).Build(func(s *Simulation) error {
+		s.RegisterComponent(probe)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.GetMonitor() == nil {
+		_ = s.Terminate()
+		t.Fatal("monitor did not start")
+	}
+	return s, probe, fmt.Sprintf("http://127.0.0.1:%d/api/component/shutdown-probe", port)
+}
+
+func awaitClosedSimulation(t *testing.T, s *Simulation) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for s.State() != "closed" {
+		select {
+		case <-deadline:
+			t.Fatal("shutdown did not begin")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}

--- a/simulation/output.go
+++ b/simulation/output.go
@@ -1,0 +1,23 @@
+package simulation
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// Publish completion only after the marker is fully written and closed. A failed
+// write must not leave an empty marker that a host could mistake for success.
+func markOutputComplete(outputPath string) error {
+	marker := outputPath + ".complete"
+	file, err := os.CreateTemp(filepath.Dir(marker), filepath.Base(marker)+".*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(file.Name())
+	_, writeErr := file.WriteString("complete\n")
+	if err := errors.Join(writeErr, file.Close()); err != nil {
+		return err
+	}
+	return os.Rename(file.Name(), marker)
+}

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -1,8 +1,12 @@
 package simulation
 
 import (
-	"github.com/sarchlab/akita/v5/datarecording"
+	"context"
+	"fmt"
+	"log"
+	"sync"
 
+	"github.com/sarchlab/akita/v5/datarecording"
 	"github.com/sarchlab/akita/v5/monitoring2"
 	"github.com/sarchlab/akita/v5/naming"
 	"github.com/sarchlab/akita/v5/timing"
@@ -10,6 +14,10 @@ import (
 )
 
 type Simulation struct {
+	supervisor       *timing.Supervisor
+	warningsMu       sync.Mutex
+	warnings         []string
+	restored         bool
 	id               string
 	outputPath       string
 	engine           timing.Engine
@@ -76,6 +84,9 @@ func (s *Simulation) Components() []Component {
 // typed Register methods pass the concrete object, which satisfies Entity, so
 // the inventory holds the live entity itself.
 func (s *Simulation) registerEntity(e Entity) {
+	if s.supervisor != nil {
+		s.supervisor.Check()
+	}
 	name := e.Name()
 	if name == "" {
 		panic("entity name cannot be empty")
@@ -219,23 +230,81 @@ func (s *Simulation) GetPortByName(name string) Port {
 	return s.ports[idx]
 }
 
-// Terminate terminates the simulation.
-func (s *Simulation) Terminate() {
-	if s.monitor != nil {
-		s.monitor.StopServer()
-	}
-
-	if s.visTracer != nil {
-		s.visTracer.Terminate()
-	}
-
-	if s.metaRecorder != nil {
-		s.metaRecorder.End()
-	}
-
-	if s.topologyRecorder != nil {
-		s.topologyRecorder.Record(s.components, s.ports)
-	}
-
-	s.dataRecorder.Close()
+// Run executes this simulation. Extension workers must use Go, and external
+// model mutations must use Setup while execution is stopped.
+func (s *Simulation) Run() error { return s.engine.Run() }
+func (s *Simulation) Setup(fn func(*Simulation) error) error {
+	return s.supervisor.Execute("setup", func() error { return fn(s) })
 }
+func (s *Simulation) Go(name string, fn func(context.Context) error) error {
+	return s.supervisor.Go(name, fn)
+}
+func (s *Simulation) Context() context.Context         { return s.supervisor.Context() }
+func (s *Simulation) Err() error                       { return s.supervisor.Err() }
+func (s *Simulation) Failures() []*timing.FailureError { return s.supervisor.Failures() }
+func (s *Simulation) GetIDGenerator() timing.IDGenerator {
+	return s.engine.(timing.IDSource).IDGenerator()
+}
+
+// Warnings reports optional capabilities that are unavailable. It never treats
+// lost requested results as optional.
+func (s *Simulation) Warnings() []string {
+	s.warningsMu.Lock()
+	defer s.warningsMu.Unlock()
+	return append([]string(nil), s.warnings...)
+}
+func (s *Simulation) warn(feature string, err error) {
+	message := fmt.Sprintf("%s unavailable: %v", feature, err)
+	s.warningsMu.Lock()
+	s.warnings = append(s.warnings, message)
+	s.warningsMu.Unlock()
+	log.Printf("simulation %s: %s", s.id, message)
+}
+
+// Terminate joins cooperative work and releases resources. Only healthy state
+// is inspected for topology recording. A .complete marker is published only
+// after all requested recording and close operations succeed; an end timestamp
+// alone is never evidence of successful output.
+func (s *Simulation) Terminate() error {
+	return s.supervisor.Close(func() {
+		if s.monitor != nil {
+			s.supervisor.Protect("stop monitor", nil, func() error {
+				if err := s.monitor.StopServer(); err != nil {
+					s.warn("monitor shutdown", err)
+				}
+				return nil
+			})
+		}
+		if s.Err() == nil {
+			if s.visTracer != nil {
+				s.supervisor.Protect("finish tracing", nil, func() error { s.visTracer.Terminate(); return nil })
+			}
+			if s.Err() == nil && s.topologyRecorder != nil {
+				s.supervisor.Protect("record topology", nil, func() error {
+					s.topologyRecorder.Record(s.components, s.ports)
+					return nil
+				})
+			}
+			if s.Err() == nil && s.metaRecorder != nil {
+				s.supervisor.Protect("record end", nil, func() error {
+					for _, warning := range s.Warnings() {
+						s.metaRecorder.insertEntry("Warning", warning)
+					}
+					s.metaRecorder.End()
+					return nil
+				})
+			}
+		}
+		if s.dataRecorder != nil {
+			s.supervisor.Protect("close recording", nil, s.dataRecorder.Close)
+		}
+		if s.Err() == nil && s.outputPath != "" {
+			s.supervisor.Protect("mark complete", nil, func() error {
+				return markOutputComplete(s.outputPath)
+			})
+		}
+	})
+}
+
+func (s *Simulation) Cancel()       { s.supervisor.Cancel() }
+func (s *Simulation) State() string { return s.supervisor.State() }

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -236,6 +236,9 @@ func (s *Simulation) Run() error { return s.engine.Run() }
 func (s *Simulation) Setup(fn func(*Simulation) error) error {
 	return s.supervisor.Execute("setup", func() error { return fn(s) })
 }
+
+// Go supervises background tooling. With a serial engine, workers must not
+// schedule events or access model state while execution is active.
 func (s *Simulation) Go(name string, fn func(context.Context) error) error {
 	return s.supervisor.Go(name, fn)
 }

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -111,7 +111,13 @@ var _ = Describe("Simulation", func() {
 	)
 
 	BeforeEach(func() {
-		simulation = MakeBuilder().WithoutMonitoring().Build()
+		{
+			var err error
+			simulation, err = MakeBuilder().WithoutMonitoring().Build()
+			if err != nil {
+				panic(err)
+			}
+		}
 		port = testPort{name: "port"}
 		comp = testComponent{name: "comp", ports: []Port{port}}
 	})
@@ -235,7 +241,13 @@ var _ = Describe("Simulation", func() {
 			builder := MakeBuilder().
 				WithoutMonitoring().
 				WithOutputFileName("test_custom_output")
-			customSim = builder.Build()
+			{
+				var err error
+				customSim, err = builder.Build()
+				if err != nil {
+					panic(err)
+				}
+			}
 
 			Expect(customSim).ToNot(BeNil())
 			Expect(customSim.GetDataRecorder()).ToNot(BeNil())
@@ -246,7 +258,10 @@ var _ = Describe("Simulation", func() {
 		It("should reject an entity that has no serializer", func() {
 			// A bare component/port has no checkpoint serializer yet, so save
 			// must fail loudly and not leave an archive behind.
-			noSerializerSim := MakeBuilder().WithoutMonitoring().Build()
+			noSerializerSim, err := MakeBuilder().WithoutMonitoring().Build()
+			if err != nil {
+				panic(err)
+			}
 			defer func() {
 				noSerializerSim.Terminate()
 				os.Remove("akita_sim_" + noSerializerSim.ID() + ".sqlite3")
@@ -258,7 +273,7 @@ var _ = Describe("Simulation", func() {
 
 			path := filepath.Join(GinkgoT().TempDir(), "checkpoint.tar.gz")
 
-			err := noSerializerSim.SaveCheckpoint(path, "test-build")
+			err = noSerializerSim.SaveCheckpoint(path, "test-build")
 
 			Expect(err).To(MatchError(ContainSubstring(
 				"has no checkpoint serializer")))
@@ -267,10 +282,13 @@ var _ = Describe("Simulation", func() {
 		})
 
 		It("should reject checkpoints for parallel engines", func() {
-			parallelSim := MakeBuilder().
+			parallelSim, err := MakeBuilder().
 				WithoutMonitoring().
 				WithParallelEngine().
 				Build()
+			if err != nil {
+				panic(err)
+			}
 			defer func() {
 				parallelSim.Terminate()
 				os.Remove("akita_sim_" + parallelSim.ID() + ".sqlite3")
@@ -278,7 +296,7 @@ var _ = Describe("Simulation", func() {
 
 			path := filepath.Join(GinkgoT().TempDir(), "checkpoint.tar.gz")
 
-			err := parallelSim.SaveCheckpoint(path, "test-build")
+			err = parallelSim.SaveCheckpoint(path, "test-build")
 
 			Expect(err).To(MatchError(ContainSubstring(
 				"only timing.SerialEngine is supported")))
@@ -363,7 +381,13 @@ var _ = Describe("Global state manager", func() {
 	var sim *Simulation
 
 	BeforeEach(func() {
-		sim = MakeBuilder().WithoutMonitoring().Build()
+		{
+			var err error
+			sim, err = MakeBuilder().WithoutMonitoring().Build()
+			if err != nil {
+				panic(err)
+			}
+		}
 	})
 
 	AfterEach(func() {
@@ -398,7 +422,10 @@ var _ = Describe("Global state manager", func() {
 	Describe("Deterministic entity inventory", func() {
 		It("should list entities in stable registration order across rebuilds", func() {
 			build := func() []string {
-				s := MakeBuilder().WithoutMonitoring().Build()
+				s, err := MakeBuilder().WithoutMonitoring().Build()
+				if err != nil {
+					panic(err)
+				}
 				defer func() {
 					s.Terminate()
 					os.Remove("akita_sim_" + s.ID() + ".sqlite3")
@@ -450,7 +477,10 @@ type roundTripState struct {
 
 var _ = Describe("Checkpoint round trip", func() {
 	It("restores component state, storage, ID counter, and engine time", func() {
-		sim := MakeBuilder().WithoutMonitoring().Build()
+		sim, err := MakeBuilder().WithoutMonitoring().Build()
+		if err != nil {
+			panic(err)
+		}
 		defer func() {
 			sim.Terminate()
 			os.Remove("akita_sim_" + sim.ID() + ".sqlite3")
@@ -473,11 +503,11 @@ var _ = Describe("Checkpoint round trip", func() {
 
 		// Establish runtime state across all four entity kinds.
 		comp.State = roundTripState{Count: 7}
-		Expect(storage.Write(0, []byte{1, 2, 3, 4})).To(Succeed())
+		storage.Write(0, []byte{1, 2, 3, 4})
 		for i := 0; i < 5; i++ {
-			timing.GetIDGenerator().Generate()
+			sim.GetIDGenerator().Generate()
 		}
-		savedCounter := timing.GetIDGeneratorNextID()
+		savedCounter := sim.GetIDGenerator().(interface{ NextID() uint64 }).NextID()
 		engine.SetCurrentTime(100)
 
 		path := filepath.Join(GinkgoT().TempDir(), "checkpoint.tar.gz")
@@ -485,19 +515,19 @@ var _ = Describe("Checkpoint round trip", func() {
 
 		// Mutate every piece of runtime state away from the checkpoint.
 		comp.State = roundTripState{Count: 999}
-		Expect(storage.Write(0, []byte{0, 0, 0, 0})).To(Succeed())
-		timing.GetIDGenerator().Generate()
-		timing.GetIDGenerator().Generate()
+		storage.Write(0, []byte{0, 0, 0, 0})
+		sim.GetIDGenerator().Generate()
+		sim.GetIDGenerator().Generate()
 		engine.SetCurrentTime(500)
 
 		// Restore and confirm every piece came back.
 		Expect(sim.LoadCheckpoint(path, "test-build")).To(Succeed())
 
 		Expect(comp.State.Count).To(Equal(7))
-		data, err := storage.Read(0, 4)
+		data := storage.Read(0, 4)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(data).To(Equal([]byte{1, 2, 3, 4}))
-		Expect(timing.GetIDGeneratorNextID()).To(Equal(savedCounter))
+		Expect(sim.GetIDGenerator().(interface{ NextID() uint64 }).NextID()).To(Equal(savedCounter))
 		Expect(engine.CurrentTime()).To(Equal(timing.VTimeInPicoSec(100)))
 	})
 })
@@ -527,7 +557,10 @@ func (m *resumeWorkerMW) Tick() bool {
 }
 
 func buildResumeSim() (*Simulation, *modeling.Component[resumeSpec, resumeState, modeling.None]) {
-	sim := MakeBuilder().WithoutMonitoring().Build()
+	sim, err := MakeBuilder().WithoutMonitoring().Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := sim.GetEngine().(*timing.SerialEngine)
 	w := modeling.NewBuilder[resumeSpec, resumeState, modeling.None]().
 		WithEngine(engine).
@@ -604,7 +637,10 @@ func buildTickCountSim() (
 	*Simulation,
 	*modeling.Component[tickCountSpec, tickCountState, modeling.None],
 ) {
-	sim := MakeBuilder().WithoutMonitoring().Build()
+	sim, err := MakeBuilder().WithoutMonitoring().Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := sim.GetEngine().(*timing.SerialEngine)
 	c := modeling.NewBuilder[tickCountSpec, tickCountState, modeling.None]().
 		WithEngine(engine).
@@ -680,7 +716,10 @@ func buildWakeSim() (
 	*Simulation,
 	*modeling.EventDrivenComponent[wakeSpec, wakeState, modeling.None],
 ) {
-	sim := MakeBuilder().WithoutMonitoring().Build()
+	sim, err := MakeBuilder().WithoutMonitoring().Build()
+	if err != nil {
+		panic(err)
+	}
 	engine := sim.GetEngine().(*timing.SerialEngine)
 	c := modeling.NewEventDrivenBuilder[wakeSpec, wakeState, modeling.None]().
 		WithEngine(engine).

--- a/simulation/source_recorder.go
+++ b/simulation/source_recorder.go
@@ -37,14 +37,14 @@ func recordSourceArchives(
 	recorder datarecording.DataRecorder,
 	explicitFSes map[string]fs.FS,
 ) error {
-	recorder.CreateTable(sourceTableName, sourceArchiveEntry{})
+	datarecording.MustRecord(recorder.CreateTable(sourceTableName, sourceArchiveEntry{}))
 
 	insert := func(root string, gztar []byte) {
-		recorder.InsertData(sourceTableName, sourceArchiveEntry{
+		datarecording.MustRecord(recorder.InsertData(sourceTableName, sourceArchiveEntry{
 			Root:    root,
 			Format:  sourceArchiveFormat,
 			Content: base64.StdEncoding.EncodeToString(gztar),
-		})
+		}))
 	}
 
 	// Akita's own source, read from disk so it matches what ran. When the
@@ -72,6 +72,6 @@ func recordSourceArchives(
 		insert(root, gztar)
 	}
 
-	recorder.Flush()
+	datarecording.MustRecord(recorder.Flush())
 	return nil
 }

--- a/simulation/topology_recorder.go
+++ b/simulation/topology_recorder.go
@@ -61,8 +61,8 @@ type topologyRecorder struct {
 // for a run that registers nothing. The rows are written later by Record.
 func newTopologyRecorder(recorder datarecording.DataRecorder) *topologyRecorder {
 	r := &topologyRecorder{recorder: recorder}
-	r.recorder.CreateTable(componentSpecTableName, componentSpecEntry{})
-	r.recorder.CreateTable(portTableName, portEntry{})
+	datarecording.MustRecord(r.recorder.CreateTable(componentSpecTableName, componentSpecEntry{}))
+	datarecording.MustRecord(r.recorder.CreateTable(portTableName, portEntry{}))
 
 	return r
 }
@@ -72,7 +72,7 @@ func newTopologyRecorder(recorder datarecording.DataRecorder) *topologyRecorder 
 func (r *topologyRecorder) Record(components []Component, ports []Port) {
 	r.recordComponentSpecs(components)
 	r.recordPorts(ports)
-	r.recorder.Flush()
+	datarecording.MustRecord(r.recorder.Flush())
 }
 
 func (r *topologyRecorder) recordComponentSpecs(components []Component) {
@@ -86,7 +86,7 @@ func (r *topologyRecorder) recordComponentSpecs(components []Component) {
 			}
 		}
 
-		r.recorder.InsertData(componentSpecTableName, entry)
+		datarecording.MustRecord(r.recorder.InsertData(componentSpecTableName, entry))
 	}
 }
 
@@ -101,11 +101,11 @@ func (r *topologyRecorder) recordPorts(ports []Port) {
 		conn, _ := reflectName(p, "Connection")
 		comp, _ := reflectName(p, "Component")
 
-		r.recorder.InsertData(portTableName, portEntry{
+		datarecording.MustRecord(r.recorder.InsertData(portTableName, portEntry{
 			Component:  comp,
 			Port:       p.Name(),
 			Connection: conn,
-		})
+		}))
 	}
 }
 

--- a/simulation/topology_recorder_test.go
+++ b/simulation/topology_recorder_test.go
@@ -70,7 +70,10 @@ func TestTopologyRecorderRecordsComponentSpecs(t *testing.T) {
 	os.Remove(dbFile)
 	defer os.Remove(dbFile)
 
-	recorder := datarecording.NewDataRecorder(path)
+	recorder, err := datarecording.NewDataRecorder(path)
+	if err != nil {
+		panic(err)
+	}
 	r := newTopologyRecorder(recorder)
 
 	components := []Component{
@@ -107,7 +110,10 @@ func TestTopologyRecorderRecordsPorts(t *testing.T) {
 	os.Remove(dbFile)
 	defer os.Remove(dbFile)
 
-	recorder := datarecording.NewDataRecorder(path)
+	recorder, err := datarecording.NewDataRecorder(path)
+	if err != nil {
+		panic(err)
+	}
 	r := newTopologyRecorder(recorder)
 
 	connA := &namedEntity{name: "ConnA"}
@@ -155,7 +161,10 @@ func readComponentSpecs(
 ) map[string]componentSpecEntry {
 	t.Helper()
 
-	reader := datarecording.NewReader(dbFile)
+	reader, err := datarecording.NewReader(dbFile)
+	if err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 	reader.MapTable(componentSpecTableName, componentSpecEntry{})
 
@@ -183,7 +192,10 @@ func readPorts(
 ) []portEntry {
 	t.Helper()
 
-	reader := datarecording.NewReader(dbFile)
+	reader, err := datarecording.NewReader(dbFile)
+	if err != nil {
+		panic(err)
+	}
 	defer reader.Close()
 	reader.MapTable(portTableName, portEntry{})
 

--- a/timing/README.md
+++ b/timing/README.md
@@ -29,22 +29,22 @@ type Event interface {
 }
 ```
 
-Embed `EventBase` to get the standard fields and getters. `MakeEventBase(t, handlerID)`
-returns an `EventBase` value with a fresh ID from the global ID generator:
+Embed `EventBase` to get the standard fields and getters. `MakeEventBase(ids, t, handlerID)`
+returns an `EventBase` value with a fresh ID from the owning engine:
 
 ```go
 type tickEvent struct {
     timing.EventBase
 }
 
-evt := tickEvent{timing.MakeEventBase(now, comp.Name())}
+evt := tickEvent{timing.MakeEventBase(engine.IDGenerator(), now, comp.Name())}
 ```
 
 ### Handler
 
 ```go
 type Handler interface {
-    Handle(e Event) error
+    Handle(e Event)
 }
 ```
 
@@ -97,10 +97,18 @@ later := freq.NCyclesLater(3, now)
 
 ## ID Generation
 
-`GetIDGenerator().Generate()` returns unique `uint64` IDs. By default IDs are
-sequential and deterministic; call `UseParallelIDGenerator()` before first use
-for faster but non-deterministic IDs (or `UseSequentialIDGenerator()` to be
-explicit). The generator's counter is part of the simulation state snapshot.
+`engine.IDGenerator().Generate()` returns IDs unique within that engine's
+simulation. The generator is safe for concurrent use and is included in the
+simulation checkpoint. Pass it explicitly to event and message constructors;
+independent simulations must not share a generator.
+
+## Failure boundaries
+
+`Run` and serial `RunUntil` return a `*timing.FailureError` for a panic in a
+handler, hook, or owned worker. Failure cancels and joins this engine's workers
+and is terminal. Other engine instances remain usable. Use `Supervisor.Execute`
+for setup and `Supervisor.Go` for cooperative workers. See the
+[ownership and migration guide](../simulation/ERROR_HANDLING.md).
 
 ## Hooks
 

--- a/timing/engine.go
+++ b/timing/engine.go
@@ -33,3 +33,10 @@ type Engine interface {
 	// Continue will continue the paused simulation.
 	Continue()
 }
+
+// ManagedEngine owns the failure boundary and ID sequence for one simulation.
+type ManagedEngine interface {
+	Engine
+	IDSource
+	Supervisor() *Supervisor
+}

--- a/timing/engine_bench_test.go
+++ b/timing/engine_bench_test.go
@@ -1,0 +1,32 @@
+package timing
+
+import "testing"
+
+type dispatchBenchHandler struct {
+	engine *SerialEngine
+	left   int
+}
+
+func (h *dispatchBenchHandler) Handle(evt Event) {
+	h.left--
+	if h.left > 0 {
+		next := evt.Time() + 1
+		h.engine.Schedule(EventBase{ID: uint64(next), Time_: next, HandlerID_: "bench"})
+	}
+}
+func BenchmarkSerialEngineEvents(b *testing.B) {
+	e := NewSerialEngine()
+	h := &dispatchBenchHandler{engine: e}
+	e.RegisterHandler("bench", h)
+	const perRun = 10000
+	b.ReportAllocs()
+	for b.Loop() {
+		h.left = perRun
+		next := e.CurrentTime() + 1
+		e.Schedule(EventBase{ID: uint64(next), Time_: next, HandlerID_: "bench"})
+		if err := e.Run(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*perRun), "ns/event")
+}

--- a/timing/event.go
+++ b/timing/event.go
@@ -18,16 +18,16 @@ type Event interface {
 
 // EventBase provides the basic fields and getters for other events.
 type EventBase struct {
-	ID         uint64     `json:"id"`
+	ID         uint64         `json:"id"`
 	Time_      VTimeInPicoSec `json:"time"`
-	HandlerID_ string     `json:"handler_id"`
-	Secondary  bool       `json:"secondary"`
+	HandlerID_ string         `json:"handler_id"`
+	Secondary  bool           `json:"secondary"`
 }
 
 // MakeEventBase creates a new EventBase as a value.
-func MakeEventBase(t VTimeInPicoSec, handlerID string) EventBase {
+func MakeEventBase(ids IDGenerator, t VTimeInPicoSec, handlerID string) EventBase {
 	return EventBase{
-		ID:         GetIDGenerator().Generate(),
+		ID:         ids.Generate(),
 		Time_:      t,
 		HandlerID_: handlerID,
 		Secondary:  false,
@@ -54,5 +54,5 @@ func (e EventBase) IsSecondary() bool {
 // One event is always constrained to one Handler, which means the event can
 // only be scheduled by one handler and can only directly modify that handler.
 type Handler interface {
-	Handle(e Event) error
+	Handle(e Event)
 }

--- a/timing/eventcodec_test.go
+++ b/timing/eventcodec_test.go
@@ -53,7 +53,7 @@ func TestEventRegistryUnknownType(t *testing.T) {
 // MakeEventBase round-trips without the caller registering EventBase: the timing
 // package registers its own built-in event type.
 func TestEventBaseRegisteredByDefault(t *testing.T) {
-	e := MakeEventBase(42, "h")
+	e := MakeEventBase(testIDs, 42, "h")
 	e.ID = 7
 
 	if err := eventCodec.CheckRoundTrip(e); err != nil {

--- a/timing/eventqueue_order_test.go
+++ b/timing/eventqueue_order_test.go
@@ -48,9 +48,9 @@ type orderRecordingHandler struct {
 	order []int
 }
 
-func (h *orderRecordingHandler) Handle(e Event) error {
+func (h *orderRecordingHandler) Handle(e Event) {
 	h.order = append(h.order, e.(*orderEvent).id)
-	return nil
+	return
 }
 
 func TestSerialEngineFiresSameTimeInScheduleOrder(t *testing.T) {

--- a/timing/failure_test.go
+++ b/timing/failure_test.go
@@ -146,31 +146,27 @@ func TestManagedWorkersCancelAndJoin(t *testing.T) {
 	}
 }
 
-func TestWorkerCanWakeEmptyEngine(t *testing.T) {
-	for name, newEngine := range engines() {
-		t.Run(name, func(t *testing.T) {
-			e := newEngine()
-			var count atomic.Int32
-			registrar(e).RegisterHandler("component", failureHandler(func(evt Event) {
-				count.Add(1)
-				if evt.Time() == 1 {
-					if err := e.Supervisor().Go("producer", func(context.Context) error {
-						time.Sleep(time.Millisecond)
-						e.Schedule(MakeEventBase(e.IDGenerator(), 2, "component"))
-						return nil
-					}); err != nil {
-						panic(err)
-					}
-				}
-			}))
-			e.Schedule(MakeEventBase(e.IDGenerator(), 1, "component"))
-			if err := runWithDeadline(t, e.Run); err != nil {
-				t.Fatal(err)
+func TestWorkerCanWakeEmptyParallelEngine(t *testing.T) {
+	e := NewParallelEngine()
+	var count atomic.Int32
+	e.RegisterHandler("component", failureHandler(func(evt Event) {
+		count.Add(1)
+		if evt.Time() == 1 {
+			if err := e.Supervisor().Go("producer", func(context.Context) error {
+				time.Sleep(time.Millisecond)
+				e.Schedule(MakeEventBase(e.IDGenerator(), 2, "component"))
+				return nil
+			}); err != nil {
+				panic(err)
 			}
-			if count.Load() != 2 {
-				t.Fatalf("run returned before worker event: %d", count.Load())
-			}
-		})
+		}
+	}))
+	e.Schedule(MakeEventBase(e.IDGenerator(), 1, "component"))
+	if err := runWithDeadline(t, e.Run); err != nil {
+		t.Fatal(err)
+	}
+	if count.Load() != 2 {
+		t.Fatalf("run returned before worker event: %d", count.Load())
 	}
 }
 

--- a/timing/failure_test.go
+++ b/timing/failure_test.go
@@ -1,0 +1,304 @@
+package timing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sarchlab/akita/v5/hooking"
+)
+
+type failureHandler func(Event)
+
+func (f failureHandler) Handle(evt Event) { f(evt) }
+
+type failureHook func(hooking.HookCtx)
+
+func (f *failureHook) Func(ctx hooking.HookCtx) { (*f)(ctx) }
+
+func engines() map[string]func() ManagedEngine {
+	return map[string]func() ManagedEngine{
+		"serial":   func() ManagedEngine { return NewSerialEngine() },
+		"parallel": func() ManagedEngine { return NewParallelEngine() },
+	}
+}
+func registrar(e ManagedEngine) HandlerRegistrar { return e.(HandlerRegistrar) }
+func runWithDeadline(t *testing.T, fn func() error) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("operation stranded workers or a paused dispatcher")
+		return nil
+	}
+}
+func expectPanic(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Error("failed instance accepted operation")
+		}
+	}()
+	fn()
+}
+
+func TestFailureIsIsolatedAcrossEngines(t *testing.T) {
+	for name, newEngine := range engines() {
+		t.Run(name, func(t *testing.T) {
+			for _, where := range []string{"before hook", "handler", "after hook"} {
+				t.Run(where, func(t *testing.T) {
+					for _, cause := range []any{"bad state", errors.New("bad state"), struct{ Code int }{7}} {
+						checkIsolatedFailure(t, newEngine, where, cause)
+					}
+				})
+			}
+		})
+	}
+}
+func checkIsolatedFailure(t *testing.T, newEngine func() ManagedEngine, where string, cause any) {
+	t.Helper()
+	bad, good := newEngine(), newEngine()
+	bad.Supervisor().SetID("bad")
+	good.Supervisor().SetID("good")
+	var after atomic.Int32
+	hook := failureHook(func(ctx hooking.HookCtx) {
+		if where == "before hook" && ctx.Pos == HookPosBeforeEvent {
+			panic(cause)
+		}
+		if ctx.Pos == HookPosAfterEvent {
+			after.Add(1)
+			if where == "after hook" {
+				panic(cause)
+			}
+		}
+	})
+	bad.AcceptHook(&hook)
+	registrar(bad).RegisterHandler("component", failureHandler(func(Event) {
+		if where == "handler" {
+			panic(cause)
+		}
+	}))
+	var goodCount atomic.Int32
+	registrar(good).RegisterHandler("component", failureHandler(func(Event) { goodCount.Add(1) }))
+	for i := 1; i <= 100; i++ {
+		bad.Schedule(MakeEventBase(bad.IDGenerator(), VTimeInPicoSec(i), "component"))
+		good.Schedule(MakeEventBase(good.IDGenerator(), VTimeInPicoSec(i), "component"))
+	}
+	goodDone := make(chan error, 1)
+	go func() { goodDone <- good.Run() }()
+	err := runWithDeadline(t, bad.Run)
+	var failure *FailureError
+	if !errors.As(err, &failure) || !reflect.DeepEqual(failure.Cause, cause) ||
+		failure.SimulationID != "bad" || failure.Handler != "component" || failure.Time != 1 || len(failure.Stack) == 0 {
+		t.Fatalf("missing failure context: %+v", err)
+	}
+	if where != "after hook" && after.Load() != 0 {
+		t.Fatal("success hook ran after failure")
+	}
+	if err := runWithDeadline(t, func() error { return <-goodDone }); err != nil {
+		t.Fatal(err)
+	}
+	if goodCount.Load() != 100 || good.CurrentTime() != 100 {
+		t.Fatalf("unaffected simulation differs from control: %d events @ %d", goodCount.Load(), good.CurrentTime())
+	}
+	if bad.Run() == nil {
+		t.Fatal("failed engine restarted")
+	}
+	expectPanic(t, func() { bad.Schedule(MakeEventBase(bad.IDGenerator(), 200, "component")) })
+	expectPanic(t, bad.Continue)
+	t.Logf("%s panic (%T): failed at event 1; independent simulation completed 100 events at time 100", where, cause)
+}
+
+func TestManagedWorkersCancelAndJoin(t *testing.T) {
+	for name, newEngine := range engines() {
+		t.Run(name, func(t *testing.T) {
+			e := newEngine()
+			var joined atomic.Bool
+			started := make(chan struct{})
+			registrar(e).RegisterHandler("component", failureHandler(func(Event) {
+				if err := e.Supervisor().Go("waiting extension", func(ctx context.Context) error {
+					close(started)
+					<-ctx.Done()
+					joined.Store(true)
+					return nil
+				}); err != nil {
+					panic(err)
+				}
+				<-started
+				panic("handler fails with worker active")
+			}))
+			e.Schedule(MakeEventBase(e.IDGenerator(), 1, "component"))
+			if err := runWithDeadline(t, e.Run); err == nil || !joined.Load() {
+				t.Fatalf("worker not joined on failure: %v, joined=%v", err, joined.Load())
+			}
+			if err := e.Supervisor().Go("late", func(context.Context) error { return nil }); err == nil {
+				t.Fatal("late worker admitted")
+			}
+		})
+	}
+}
+
+func TestWorkerCanWakeEmptyEngine(t *testing.T) {
+	for name, newEngine := range engines() {
+		t.Run(name, func(t *testing.T) {
+			e := newEngine()
+			var count atomic.Int32
+			registrar(e).RegisterHandler("component", failureHandler(func(evt Event) {
+				count.Add(1)
+				if evt.Time() == 1 {
+					if err := e.Supervisor().Go("producer", func(context.Context) error {
+						time.Sleep(time.Millisecond)
+						e.Schedule(MakeEventBase(e.IDGenerator(), 2, "component"))
+						return nil
+					}); err != nil {
+						panic(err)
+					}
+				}
+			}))
+			e.Schedule(MakeEventBase(e.IDGenerator(), 1, "component"))
+			if err := runWithDeadline(t, e.Run); err != nil {
+				t.Fatal(err)
+			}
+			if count.Load() != 2 {
+				t.Fatalf("run returned before worker event: %d", count.Load())
+			}
+		})
+	}
+}
+
+func TestCancelWakesPausedEngine(t *testing.T) {
+	for name, newEngine := range engines() {
+		t.Run(name, func(t *testing.T) {
+			e := newEngine()
+			e.Schedule(MakeEventBase(e.IDGenerator(), 1, "unused"))
+			e.Pause()
+			done := make(chan error, 1)
+			go func() { done <- e.Run() }()
+			e.Supervisor().Cancel()
+			err := runWithDeadline(t, func() error { return <-done })
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("cancel lost: %v", err)
+			}
+		})
+	}
+}
+
+func TestParallelSaturatedSchedulingAndHandlerSerialization(t *testing.T) {
+	e := NewParallelEngine()
+	var active atomic.Int32
+	var count atomic.Int32
+	e.RegisterHandler("same", failureHandler(func(evt Event) {
+		if active.Add(1) != 1 {
+			panic("same handler ran concurrently")
+		}
+		defer active.Add(-1)
+		count.Add(1)
+		if evt.Time() == 1 {
+			e.Schedule(MakeEventBase(e.IDGenerator(), 2, "same"))
+		}
+	}))
+	for i := 0; i < 20000; i++ {
+		e.Schedule(MakeEventBase(e.IDGenerator(), 1, "same"))
+	}
+	if err := runWithDeadline(t, e.Run); err != nil {
+		t.Fatal(err)
+	}
+	if count.Load() != 40000 {
+		t.Fatalf("lost scheduled work: %d", count.Load())
+	}
+}
+
+func TestConcurrentWorkerFailuresPreserveFirstCause(t *testing.T) {
+	s := NewSupervisor("workers")
+	sentinel := errors.New("primary")
+	err := runWithDeadline(t, func() error {
+		return s.Execute("setup", func() error {
+			var ready sync.WaitGroup
+			ready.Add(8)
+			start := make(chan struct{})
+			for i := 0; i < 8; i++ {
+				if err := s.Go(fmt.Sprintf("worker %d", i), func(context.Context) error {
+					ready.Done()
+					<-start
+					panic(i)
+				}); err != nil {
+					return err
+				}
+			}
+			ready.Wait()
+			s.Fail("first", sentinel)
+			close(start)
+			return nil
+		})
+	})
+	if !errors.Is(err, sentinel) || len(s.Failures()) != 9 {
+		t.Fatalf("failure history lost: %v, count=%d", err, len(s.Failures()))
+	}
+	if err := s.Close(func() { panic("cleanup") }); !errors.Is(err, sentinel) || len(s.Failures()) != 10 {
+		t.Fatal("cleanup replaced first cause")
+	}
+}
+
+func TestCloseCancelsAndJoinsActiveOperation(t *testing.T) {
+	s := NewSupervisor("active")
+	entered := make(chan struct{})
+	done := make(chan error, 1)
+	go func() { done <- s.Execute("run", func() error { close(entered); <-s.Context().Done(); return nil }) }()
+	<-entered
+	if err := runWithDeadline(t, func() error { return s.Close(func() {}) }); !errors.Is(err, context.Canceled) {
+		t.Fatalf("active termination reported success: %v", err)
+	}
+	if err := runWithDeadline(t, func() error { return <-done }); !errors.Is(err, context.Canceled) {
+		t.Fatalf("running operation lost cancellation: %v", err)
+	}
+}
+
+func TestPauseWaitsForAdmittedHandler(t *testing.T) {
+	for name, newEngine := range engines() {
+		t.Run(name, func(t *testing.T) {
+			e := newEngine()
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			registrar(e).RegisterHandler("blocked", failureHandler(func(Event) { close(entered); <-release }))
+			e.Schedule(MakeEventBase(e.IDGenerator(), 1, "blocked"))
+			done := make(chan error, 1)
+			go func() { done <- e.Run() }()
+			<-entered
+			paused := make(chan struct{})
+			go func() { e.Pause(); close(paused) }()
+			select {
+			case <-paused:
+				t.Error("pause returned while handler still touched model state")
+			case <-time.After(time.Millisecond):
+			}
+			close(release)
+			if err := runWithDeadline(t, func() error { <-paused; e.Continue(); return nil }); err != nil {
+				t.Fatal(err)
+			}
+			if err := runWithDeadline(t, func() error { return <-done }); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestFinishedProducerWakeIsNotLost(t *testing.T) {
+	s := NewSupervisor("test")
+	wake := make(chan struct{}, 1)
+	// The queue was empty, then the last owned producer scheduled and exited.
+	wake <- struct{}{}
+	if !s.waitForWork(wake) {
+		t.Fatal("finished producer's final event would remain unprocessed")
+	}
+	if s.waitForWork(wake) {
+		t.Fatal("no remaining work")
+	}
+}

--- a/timing/id_fixture_test.go
+++ b/timing/id_fixture_test.go
@@ -1,0 +1,3 @@
+package timing
+
+var testIDs = NewIDGenerator()

--- a/timing/idgenerator.go
+++ b/timing/idgenerator.go
@@ -1,124 +1,69 @@
 package timing
 
 import (
-	"log"
 	"sync"
 	"sync/atomic"
 )
 
-var idGeneratorMutex sync.Mutex
-var idGeneratorInstantiated bool
-var idGenerator IDGenerator
-
-// IDGenerator can generate IDs.
+// IDGenerator is owned by an engine. Share it with that engine's components and
+// message producers; never share it between independently restorable simulations.
 type IDGenerator interface {
-	// Generate generates an ID.
 	Generate() uint64
+	// Track, Lookup, and Forget maintain owned ID associations (for example,
+	// tracing tasks). They must be safe for concurrent use with Generate.
+	Track(namespace string, key uint64) uint64
+	Lookup(namespace string, key uint64) (uint64, bool)
+	Forget(namespace string, key uint64)
 }
 
-// UseSequentialIDGenerator configures the ID generator to generate IDs
-// sequentially.
-func UseSequentialIDGenerator() {
-	if idGeneratorInstantiated {
-		log.Panic("cannot change id generator type after using it")
-	}
-
-	idGeneratorMutex.Lock()
-
-	if idGeneratorInstantiated {
-		log.Panic("cannot change id generator type after using it")
-	}
-
-	idGenerator = &sequentialIDGenerator{}
-	idGeneratorInstantiated = true
-
-	idGeneratorMutex.Unlock()
-}
-
-// UseParallelIDGenerator configures the ID generator to generate IDs in
-// parallel. The IDs generated will not be deterministic anymore.
-func UseParallelIDGenerator() {
-	if idGeneratorInstantiated {
-		log.Panic("cannot change id generator type after using it")
-	}
-
-	idGeneratorMutex.Lock()
-
-	if idGeneratorInstantiated {
-		log.Panic("cannot change id generator type after using it")
-	}
-
-	idGenerator = &parallelIDGenerator{}
-	idGeneratorInstantiated = true
-
-	idGeneratorMutex.Unlock()
-}
-
-// GetIDGenerator returns the ID generator used in the current simulation.
-func GetIDGenerator() IDGenerator {
-	if idGeneratorInstantiated {
-		return idGenerator
-	}
-
-	idGeneratorMutex.Lock()
-
-	if idGeneratorInstantiated {
-		idGeneratorMutex.Unlock()
-		return idGenerator
-	}
-
-	idGenerator = &sequentialIDGenerator{}
-	idGeneratorInstantiated = true
-
-	idGeneratorMutex.Unlock()
-
-	return idGenerator
-}
+// NewIDGenerator constructs an independent, checkpointable sequence.
+func NewIDGenerator() *sequentialIDGenerator { return &sequentialIDGenerator{} }
 
 type sequentialIDGenerator struct {
-	nextID uint64
+	nextID     uint64
+	trackingMu sync.Mutex
+	tracking   map[string]map[uint64]uint64
 }
 
-func (g *sequentialIDGenerator) Generate() uint64 {
-	return atomic.AddUint64(&g.nextID, 1)
+func (g *sequentialIDGenerator) Generate() uint64 { return atomic.AddUint64(&g.nextID, 1) }
+func (g *sequentialIDGenerator) Name() string     { return "IDGenerator" }
+func (g *sequentialIDGenerator) NextID() uint64   { return atomic.LoadUint64(&g.nextID) }
+
+// Track associates a message with an owned tracing task, creating it if absent.
+func (g *sequentialIDGenerator) Track(domain string, msg uint64) uint64 {
+	g.trackingMu.Lock()
+	defer g.trackingMu.Unlock()
+	if g.tracking == nil {
+		g.tracking = make(map[string]map[uint64]uint64)
+	}
+	if g.tracking[domain] == nil {
+		g.tracking[domain] = make(map[uint64]uint64)
+	}
+	if id, ok := g.tracking[domain][msg]; ok {
+		return id
+	}
+	id := g.Generate()
+	g.tracking[domain][msg] = id
+	return id
+}
+func (g *sequentialIDGenerator) Lookup(domain string, msg uint64) (uint64, bool) {
+	g.trackingMu.Lock()
+	defer g.trackingMu.Unlock()
+	id, ok := g.tracking[domain][msg]
+	return id, ok
+}
+func (g *sequentialIDGenerator) Forget(domain string, msg uint64) {
+	g.trackingMu.Lock()
+	defer g.trackingMu.Unlock()
+	delete(g.tracking[domain], msg)
+	if len(g.tracking[domain]) == 0 {
+		delete(g.tracking, domain)
+	}
 }
 
-// Name returns the name of the ID generator. It is registered as a simulation
-// entity so its counter is part of the state snapshot.
-func (g *sequentialIDGenerator) Name() string {
-	return "IDGenerator"
-}
+// IDSource exposes the sequence used for event, message, and tracing IDs.
+type IDSource interface{ IDGenerator() IDGenerator }
 
-// GetIDGeneratorNextID returns the current nextID from the sequential ID
-// generator. It panics if the ID generator is not a sequentialIDGenerator.
-func GetIDGeneratorNextID() uint64 {
-	gen := idGenerator.(*sequentialIDGenerator)
-	return atomic.LoadUint64(&gen.nextID)
-}
-
-// SetIDGeneratorNextID sets the nextID on the sequential ID generator.
-// It panics if the ID generator is not a sequentialIDGenerator.
-func SetIDGeneratorNextID(id uint64) {
-	gen := idGenerator.(*sequentialIDGenerator)
-	atomic.StoreUint64(&gen.nextID, id)
-}
-
-// ResetIDGenerator resets the ID generator so a new one can be created.
-func ResetIDGenerator() {
-	idGeneratorInstantiated = false
-	idGenerator = nil
-}
-
-type parallelIDGenerator struct {
-	nextID uint64
-}
-
-func (g *parallelIDGenerator) Generate() uint64 {
-	return atomic.AddUint64(&g.nextID, 1)
-}
-
-// Name returns the name of the ID generator. It is registered as a simulation
-// entity so its counter is part of the state snapshot.
-func (g *parallelIDGenerator) Name() string {
-	return "IDGenerator"
-}
+// IDsFor obtains an explicitly supplied owner's sequence. Custom event
+// schedulers must implement IDSource when used to construct Akita components.
+func IDsFor(owner any) IDGenerator { return owner.(IDSource).IDGenerator() }

--- a/timing/idgenerator_checkpoint.go
+++ b/timing/idgenerator_checkpoint.go
@@ -10,15 +10,19 @@ import (
 // idGeneratorCheckpoint is the serialized form of the ID generator: its kind and
 // next counter value.
 type idGeneratorCheckpoint struct {
-	Kind   string `json:"kind"`
-	NextID uint64 `json:"next_id"`
+	Kind     string                       `json:"kind"`
+	NextID   uint64                       `json:"next_id"`
+	Tracking map[string]map[uint64]uint64 `json:"tracking,omitempty"`
 }
 
 // SaveCheckpoint writes the sequential ID generator's kind and next counter.
 func (g *sequentialIDGenerator) SaveCheckpoint(w io.Writer) error {
+	g.trackingMu.Lock()
+	defer g.trackingMu.Unlock()
 	dto := idGeneratorCheckpoint{
-		Kind:   "sequential",
-		NextID: atomic.LoadUint64(&g.nextID),
+		Kind:     "sequential",
+		Tracking: g.tracking,
+		NextID:   atomic.LoadUint64(&g.nextID),
 	}
 	return json.NewEncoder(w).Encode(dto)
 }
@@ -34,17 +38,16 @@ func (g *sequentialIDGenerator) LoadCheckpoint(r io.Reader) error {
 			"timing: ID generator kind mismatch: checkpoint %q, rebuilt sequential",
 			dto.Kind)
 	}
+	for _, tasks := range dto.Tracking {
+		for msg, id := range tasks {
+			if msg == 0 || id == 0 || id > dto.NextID {
+				return fmt.Errorf("timing: invalid tracked ID")
+			}
+		}
+	}
+	g.trackingMu.Lock()
+	defer g.trackingMu.Unlock()
+	g.tracking = dto.Tracking
 	atomic.StoreUint64(&g.nextID, dto.NextID)
 	return nil
-}
-
-// SaveCheckpoint rejects checkpointing the parallel ID generator: its IDs are not
-// deterministic, so a restored counter would not reproduce the same IDs.
-func (g *parallelIDGenerator) SaveCheckpoint(_ io.Writer) error {
-	return fmt.Errorf("timing: parallel ID generator is not checkpointable")
-}
-
-// LoadCheckpoint rejects loading into the parallel ID generator.
-func (g *parallelIDGenerator) LoadCheckpoint(_ io.Reader) error {
-	return fmt.Errorf("timing: parallel ID generator is not checkpointable")
 }

--- a/timing/idgenerator_checkpoint_test.go
+++ b/timing/idgenerator_checkpoint_test.go
@@ -2,8 +2,6 @@ package timing
 
 import (
 	"bytes"
-	"io"
-	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -31,16 +29,5 @@ func TestSequentialIDGeneratorCheckpointRoundTrip(t *testing.T) {
 	// The next generated ID continues from the restored counter.
 	if id := dst.Generate(); id != 101 {
 		t.Fatalf("next ID = %d, want 101", id)
-	}
-}
-
-func TestParallelIDGeneratorNotCheckpointable(t *testing.T) {
-	g := &parallelIDGenerator{}
-	if err := g.SaveCheckpoint(io.Discard); err == nil ||
-		!strings.Contains(err.Error(), "not checkpointable") {
-		t.Fatalf("expected not-checkpointable error, got %v", err)
-	}
-	if err := g.LoadCheckpoint(strings.NewReader("{}")); err == nil {
-		t.Fatalf("expected not-checkpointable error on load")
 	}
 }

--- a/timing/parallelengine.go
+++ b/timing/parallelengine.go
@@ -1,287 +1,144 @@
 package timing
 
 import (
-	"log"
-	"math"
-	"reflect"
-	"runtime"
+	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/sarchlab/akita/v5/hooking"
 )
 
-// A ParallelEngine is an event engine that is capable for scheduling event
-// in a parallel fashion.
+// ParallelEngine dispatches different handlers concurrently at the earliest
+// virtual time. Events for one handler run in queue order, never concurrently.
+// Scheduling uses short critical sections; workers never borrow dispatcher queues.
 type ParallelEngine struct {
 	hooking.HookableBase
-
-	pauseLock              sync.Mutex
-	nowLock                sync.RWMutex
-	now                    VTimeInPicoSec
-	runningSecondaryEvents bool
-
-	eventChan    chan Event
-	waitGroup    sync.WaitGroup
-	maxGoRoutine int
-
-	queues             []EventQueue
-	queueChan          chan EventQueue
-	secondaryQueues    []EventQueue
-	secondaryQueueChan chan EventQueue
-
-	registry map[string]Handler
+	mu             sync.Mutex
+	now            VTimeInPicoSec
+	queue          *unsafeEventQueue
+	secondaryQueue *unsafeEventQueue
+	registry       map[string]Handler
+	supervisor     *Supervisor
+	ids            IDGenerator
+	wake           chan struct{}
 }
 
-// Name returns the name of the engine. The engine is registered as a simulation
-// entity so its event-queue and time state are part of the state snapshot.
-func (e *ParallelEngine) Name() string {
-	return "Engine"
-}
-
-// NewParallelEngine creates a ParallelEngine.
 func NewParallelEngine() *ParallelEngine {
-	e := new(ParallelEngine)
-
-	e.eventChan = make(chan Event, 10000)
-
-	e.maxGoRoutine = runtime.GOMAXPROCS(0)
-	numQueues := runtime.GOMAXPROCS(0)
-
-	e.registry = make(map[string]Handler)
-
-	// e.spawnWorkers()
-	e.queues = make([]EventQueue, 0, numQueues)
-	e.queueChan = make(chan EventQueue, numQueues)
-	e.secondaryQueues = make([]EventQueue, 0, numQueues)
-	e.secondaryQueueChan = make(chan EventQueue, numQueues)
-
-	for i := 0; i < numQueues; i++ {
-		queue := NewEventQueue()
-		e.queueChan <- queue
-
-		e.queues = append(e.queues, queue)
-
-		secondaryQueue := NewEventQueue()
-		e.secondaryQueueChan <- secondaryQueue
-
-		e.secondaryQueues = append(e.secondaryQueues, secondaryQueue)
+	return &ParallelEngine{
+		queue: newUnsafeEventQueue(), secondaryQueue: newUnsafeEventQueue(),
+		registry: make(map[string]Handler), supervisor: NewSupervisor("Engine"),
+		ids: NewIDGenerator(), wake: make(chan struct{}, 1),
 	}
-
-	return e
+}
+func (e *ParallelEngine) Name() string             { return "Engine" }
+func (e *ParallelEngine) Supervisor() *Supervisor  { return e.supervisor }
+func (e *ParallelEngine) IDGenerator() IDGenerator { return e.ids }
+func (e *ParallelEngine) CurrentTime() VTimeInPicoSec {
+	return VTimeInPicoSec(atomic.LoadUint64((*uint64)(&e.now)))
 }
 
-// RegisterHandler registers a handler with the given name.
-func (e *ParallelEngine) RegisterHandler(name string, handler Handler) {
-	e.registry[name] = handler
+func (e *ParallelEngine) RegisterHandler(name string, h Handler) {
+	e.supervisor.Check()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.registry[name] = h
 }
-
-func (e *ParallelEngine) readNow() VTimeInPicoSec {
-	var now VTimeInPicoSec
-
-	e.nowLock.RLock()
-	now = e.now
-	e.nowLock.RUnlock()
-
-	return now
-}
-
-func (e *ParallelEngine) writeNow(t VTimeInPicoSec) {
-	e.nowLock.Lock()
-	e.now = t
-	e.nowLock.Unlock()
-}
-
-// Schedule registers an event to happen in the future.
 func (e *ParallelEngine) Schedule(evt Event) {
-	now := e.readNow()
-	if evt.Time() < now {
-		log.Panicf(
-			"cannot schedule event in the past, evt %s @ %d, now %d",
-			reflect.TypeOf(evt), evt.Time(), now)
+	e.supervisor.Check()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	defer func() {
+		select {
+		case e.wake <- struct{}{}:
+		default:
+		}
+	}()
+	if evt.Time() < e.now {
+		panic("cannot schedule event in the past")
 	}
-
 	if evt.IsSecondary() {
-		queue := <-e.secondaryQueueChan
-		queue.Push(evt)
-
-		e.secondaryQueueChan <- queue
-
-		return
+		e.secondaryQueue.Push(evt)
+	} else {
+		e.queue.Push(evt)
 	}
-
-	queue := <-e.queueChan
-	queue.Push(evt)
-
-	e.queueChan <- queue
 }
-
-// Run processes all the events scheduled in the ParallelEngine.
 func (e *ParallelEngine) Run() error {
-	for {
-		if !e.hasMoreEvents() {
-			return nil
-		}
-
-		e.pauseLock.Lock()
-		e.determineWhatToRun()
-		e.runRound()
-
-		e.pauseLock.Unlock()
-	}
-}
-
-func (e *ParallelEngine) determineWhatToRun() {
-	primaryTime := e.earliestTimeInQueueGroup(e.queues)
-	secondaryTime := e.earliestTimeInQueueGroup(e.secondaryQueues)
-
-	if primaryTime <= secondaryTime {
-		e.runningSecondaryEvents = false
-		e.writeNow(primaryTime)
-
-		return
-	}
-
-	e.runningSecondaryEvents = true
-	e.writeNow(secondaryTime)
-}
-
-func (e *ParallelEngine) earliestTimeInQueueGroup(
-	queues []EventQueue,
-) VTimeInPicoSec {
-	earliestTime := VTimeInPicoSec(math.MaxUint64)
-
-	for _, q := range queues {
-		if q.Len() == 0 {
-			continue
-		}
-
-		t := q.Peek().Time()
-		if t < earliestTime {
-			earliestTime = t
-		}
-	}
-
-	return earliestTime
-}
-
-func (e *ParallelEngine) runRound() {
-	queues := e.queues
-	queueChan := e.queueChan
-
-	if e.runningSecondaryEvents {
-		queues = e.secondaryQueues
-		queueChan = e.secondaryQueueChan
-	}
-
-	e.emptyQueueChan(queues, queueChan)
-	e.runEventsUntilConflict(queues, queueChan)
-	e.waitGroup.Wait()
-}
-
-func (e *ParallelEngine) emptyQueueChan(
-	queues []EventQueue,
-	queueChan chan EventQueue,
-) {
-	for range queues {
-		<-queueChan
-	}
-}
-
-func (e *ParallelEngine) hasMoreEvents() bool {
-	if e.hasMorePrimaryEvents() || e.hasMoreSecondaryEvents() {
-		return true
-	}
-
-	return false
-}
-
-func (e *ParallelEngine) hasMorePrimaryEvents() bool {
-	for _, q := range e.queues {
-		if q.Len() > 0 {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (e *ParallelEngine) hasMoreSecondaryEvents() bool {
-	for _, q := range e.secondaryQueues {
-		if q.Len() > 0 {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (e *ParallelEngine) runEventsUntilConflict(
-	queues []EventQueue,
-	queueChan chan EventQueue,
-) {
-	now := e.readNow()
-
-	for _, queue := range queues {
-		for queue.Len() > 0 {
-			evt := queue.Peek()
-			if evt.Time() == now {
-				queue.Pop()
-				e.runEventWithTempWorker(evt)
-			} else if evt.Time() < now {
-				log.Panicf(
-					"cannot run event in the past, evt %s @ %d, now %d",
-					reflect.TypeOf(evt), evt.Time(), now)
-			} else {
+	return e.supervisor.Execute("run", func() error {
+		for e.supervisor.awaitResume() {
+			groups := e.nextRound()
+			if len(groups) == 0 {
+				if e.supervisor.waitForWork(e.wake) {
+					continue
+				}
 				break
 			}
+			var round sync.WaitGroup
+			for _, events := range groups {
+				round.Add(1)
+				err := e.supervisor.Go("event worker", func(context.Context) error {
+					defer round.Done()
+					for _, evt := range events {
+						if e.supervisor.stopped.Load() {
+							break
+						}
+						e.supervisor.Protect("event", evt, func() error { e.dispatch(evt); return nil })
+					}
+					return nil
+				})
+				if err != nil {
+					round.Done()
+					break
+				}
+			}
+			round.Wait()
 		}
-
-		queueChan <- queue
+		return nil
+	})
+}
+func (e *ParallelEngine) nextRound() [][]Event {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	q := e.queue
+	if q.Len() == 0 || (e.secondaryQueue.Len() > 0 && e.secondaryQueue.Peek().Time() < q.Peek().Time()) {
+		q = e.secondaryQueue
+	}
+	if q.Len() == 0 {
+		return nil
+	}
+	atomic.StoreUint64((*uint64)(&e.now), uint64(q.Peek().Time()))
+	var groups [][]Event
+	indices := make(map[string]int)
+	for q.Len() > 0 && q.Peek().Time() == e.now {
+		evt := q.Pop()
+		i, ok := indices[evt.HandlerID()]
+		if !ok {
+			i = len(groups)
+			indices[evt.HandlerID()] = i
+			groups = append(groups, nil)
+		}
+		groups[i] = append(groups[i], evt)
+	}
+	return groups
+}
+func (e *ParallelEngine) dispatch(evt Event) {
+	if !e.supervisor.beginDispatch() {
+		return
+	}
+	defer e.supervisor.endDispatch()
+	ctx := hooking.HookCtx{Domain: e, Pos: HookPosBeforeEvent, Item: evt}
+	e.InvokeHook(ctx)
+	if e.supervisor.stopped.Load() {
+		return
+	}
+	name := evt.HandlerID()
+	e.mu.Lock()
+	h := e.registry[name]
+	e.mu.Unlock()
+	h.Handle(evt)
+	if !e.supervisor.stopped.Load() {
+		ctx.Pos = HookPosAfterEvent
+		e.InvokeHook(ctx)
 	}
 }
-
-func (e *ParallelEngine) runEventWithTempWorker(evt Event) {
-	e.waitGroup.Add(1)
-
-	go e.tempWorkerRun(evt)
-}
-
-func (e *ParallelEngine) tempWorkerRun(evt Event) {
-	now := e.readNow()
-
-	if evt.Time() < now {
-		log.Panic("running event in the past")
-	}
-
-	hookCtx := hooking.HookCtx{
-		Domain: e,
-		Pos:    HookPosBeforeEvent,
-		Item:   evt,
-	}
-	e.InvokeHook(hookCtx)
-
-	handler := e.registry[evt.HandlerID()]
-	_ = handler.Handle(evt)
-
-	hookCtx.Pos = HookPosAfterEvent
-	e.InvokeHook(hookCtx)
-
-	e.waitGroup.Done()
-}
-
-// Pause will prevent the engine to move forward. For events that are scheduled
-// at the same time, they may still be triggered.
-func (e *ParallelEngine) Pause() {
-	e.pauseLock.Lock()
-}
-
-// Continue allows the engine to continue to make progress.
-func (e *ParallelEngine) Continue() {
-	e.pauseLock.Unlock()
-}
-
-// CurrentTime returns the current time at which the engine is at.
-// Specifically, the run time of the current event.
-func (e *ParallelEngine) CurrentTime() VTimeInPicoSec {
-	return e.readNow()
-}
+func (e *ParallelEngine) Pause()    { e.supervisor.Pause() }
+func (e *ParallelEngine) Continue() { e.supervisor.Continue() }

--- a/timing/serialengine.go
+++ b/timing/serialengine.go
@@ -8,9 +8,10 @@ import (
 )
 
 // A SerialEngine runs events one after another on the goroutine calling Run.
-// During execution, only that goroutine may schedule events or mutate engine
-// state. External callers may Pause/Continue, read CurrentTime, or inspect the
-// supervisor. Other access requires stopped execution and host coordination.
+// While dispatch is running, only that goroutine may schedule events or mutate
+// engine state. External callers may Pause/Continue, read CurrentTime, or inspect the
+// supervisor. Other access requires a completed run or an acknowledged Pause,
+// with host coordination preventing concurrent access or resume.
 type SerialEngine struct {
 	hooking.HookableBase
 
@@ -51,8 +52,9 @@ func (e *SerialEngine) RegisterHandler(name string, handler Handler) {
 	e.registry[name] = handler
 }
 
-// Schedule registers an event to happen in the future. During a run, only
-// callbacks on the run goroutine may call Schedule; background producers cannot.
+// Schedule registers an event to happen in the future. While dispatch is running,
+// only callbacks on the run goroutine may call Schedule. External scheduling
+// requires a completed run or an acknowledged Pause, with host coordination.
 func (e *SerialEngine) Schedule(evt Event) {
 	e.supervisor.Check()
 	if evt.Time() < e.time {

--- a/timing/serialengine.go
+++ b/timing/serialengine.go
@@ -2,13 +2,15 @@ package timing
 
 import (
 	"log"
-	"sync"
 	"sync/atomic"
 
 	"github.com/sarchlab/akita/v5/hooking"
 )
 
-// A SerialEngine is an Engine that always run events one after another.
+// A SerialEngine runs events one after another on the goroutine calling Run.
+// During execution, only that goroutine may schedule events or mutate engine
+// state. External callers may Pause/Continue, read CurrentTime, or inspect the
+// supervisor. Other access requires stopped execution and host coordination.
 type SerialEngine struct {
 	hooking.HookableBase
 
@@ -16,12 +18,10 @@ type SerialEngine struct {
 	queue          *unsafeEventQueue
 	secondaryQueue *unsafeEventQueue
 
-	mu         sync.Mutex
 	supervisor *Supervisor
 	ids        IDGenerator
 
 	registry map[string]Handler
-	wake     chan struct{}
 	restored bool
 }
 
@@ -33,8 +33,8 @@ func NewSerialEngine() *SerialEngine {
 	e.secondaryQueue = newUnsafeEventQueue()
 	e.registry = make(map[string]Handler)
 	e.supervisor = NewSupervisor("Engine")
+	e.supervisor.serial = true
 	e.ids = NewIDGenerator()
-	e.wake = make(chan struct{}, 1)
 
 	return e
 }
@@ -48,22 +48,13 @@ func (e *SerialEngine) Name() string {
 // RegisterHandler registers a handler with the given name.
 func (e *SerialEngine) RegisterHandler(name string, handler Handler) {
 	e.supervisor.Check()
-	e.mu.Lock()
-	defer e.mu.Unlock()
 	e.registry[name] = handler
 }
 
-// Schedule registers an event to happen in the future.
+// Schedule registers an event to happen in the future. During a run, only
+// callbacks on the run goroutine may call Schedule; background producers cannot.
 func (e *SerialEngine) Schedule(evt Event) {
 	e.supervisor.Check()
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	defer func() {
-		select {
-		case e.wake <- struct{}{}:
-		default:
-		}
-	}()
 	if evt.Time() < e.time {
 		log.Panic("scheduling an event earlier than current time")
 	}
@@ -88,9 +79,6 @@ func (e *SerialEngine) run(limit *VTimeInPicoSec) error {
 		hasHooks := e.NumHooks() > 0
 		for e.supervisor.awaitResume() {
 			if e.dispatchNext(hasHooks, limit) {
-				if e.supervisor.waitForWork(e.wake) {
-					continue
-				}
 				break
 			}
 		}
@@ -98,13 +86,9 @@ func (e *SerialEngine) run(limit *VTimeInPicoSec) error {
 	})
 }
 
-// dispatchNext keeps the queue critical section separate from model callbacks.
+// dispatchNext accesses the queue and model on the same goroutine.
 // A recovery is installed before calling even user-defined event accessors.
 func (e *SerialEngine) dispatchNext(hasHooks bool, limit *VTimeInPicoSec) (done bool) {
-	if !e.supervisor.beginDispatch() {
-		return true
-	}
-	defer e.supervisor.endDispatch()
 	var evt Event
 	defer func() {
 		if p := recover(); p != nil {
@@ -132,8 +116,6 @@ func (e *SerialEngine) dispatchNext(hasHooks bool, limit *VTimeInPicoSec) (done 
 }
 
 func (e *SerialEngine) prepareNext(limit *VTimeInPicoSec) (Event, Handler, bool) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
 	if e.noMoreEvent() || (limit != nil && e.nextEventTime() > *limit) {
 		return nil, nil, true
 	}
@@ -198,8 +180,6 @@ func (e *SerialEngine) CurrentTime() VTimeInPicoSec {
 }
 func (e *SerialEngine) SetCurrentTime(t VTimeInPicoSec) {
 	e.supervisor.Check()
-	e.mu.Lock()
-	defer e.mu.Unlock()
 	atomic.StoreUint64((*uint64)(&e.time), uint64(t))
 }
 func (e *SerialEngine) Supervisor() *Supervisor  { return e.supervisor }

--- a/timing/serialengine.go
+++ b/timing/serialengine.go
@@ -2,7 +2,6 @@ package timing
 
 import (
 	"log"
-	"reflect"
 	"sync"
 	"sync/atomic"
 
@@ -17,13 +16,13 @@ type SerialEngine struct {
 	queue          *unsafeEventQueue
 	secondaryQueue *unsafeEventQueue
 
-	paused    int32 // atomic: 0 = running, 1 = paused
-	pauseMu   sync.Mutex
-	pauseCond *sync.Cond
-
-	singleRunLock sync.Mutex
+	mu         sync.Mutex
+	supervisor *Supervisor
+	ids        IDGenerator
 
 	registry map[string]Handler
+	wake     chan struct{}
+	restored bool
 }
 
 // NewSerialEngine creates a SerialEngine.
@@ -33,7 +32,9 @@ func NewSerialEngine() *SerialEngine {
 	e.queue = newUnsafeEventQueue()
 	e.secondaryQueue = newUnsafeEventQueue()
 	e.registry = make(map[string]Handler)
-	e.pauseCond = sync.NewCond(&e.pauseMu)
+	e.supervisor = NewSupervisor("Engine")
+	e.ids = NewIDGenerator()
+	e.wake = make(chan struct{}, 1)
 
 	return e
 }
@@ -46,11 +47,23 @@ func (e *SerialEngine) Name() string {
 
 // RegisterHandler registers a handler with the given name.
 func (e *SerialEngine) RegisterHandler(name string, handler Handler) {
+	e.supervisor.Check()
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.registry[name] = handler
 }
 
 // Schedule registers an event to happen in the future.
 func (e *SerialEngine) Schedule(evt Event) {
+	e.supervisor.Check()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	defer func() {
+		select {
+		case e.wake <- struct{}{}:
+		default:
+		}
+	}()
 	if evt.Time() < e.time {
 		log.Panic("scheduling an event earlier than current time")
 	}
@@ -65,84 +78,71 @@ func (e *SerialEngine) Schedule(evt Event) {
 }
 
 // Run processes all the events scheduled in the SerialEngine.
-func (e *SerialEngine) Run() error {
-	e.singleRunLock.Lock()
-	defer e.singleRunLock.Unlock()
+func (e *SerialEngine) Run() error { return e.run(nil) }
 
-	hasHooks := e.NumHooks() > 0
+// RunUntil processes events at or before t, retaining later events for another run.
+func (e *SerialEngine) RunUntil(t VTimeInPicoSec) error { return e.run(&t) }
 
-	for {
-		if e.noMoreEvent() {
-			return nil
+func (e *SerialEngine) run(limit *VTimeInPicoSec) error {
+	return e.supervisor.Execute("run", func() error {
+		hasHooks := e.NumHooks() > 0
+		for e.supervisor.awaitResume() {
+			if e.dispatchNext(hasHooks, limit) {
+				if e.supervisor.waitForWork(e.wake) {
+					continue
+				}
+				break
+			}
 		}
-
-		// Lightweight pause check: atomic load is ~1ns when not paused.
-		if atomic.LoadInt32(&e.paused) != 0 {
-			e.waitForResume()
-		}
-
-		e.dispatchNext(hasHooks)
-	}
+		return nil
+	})
 }
 
-// RunUntil runs events in time order until the next event's time would exceed t,
-// or the queue empties. Events at times <= t scheduled while running (including
-// newly scheduled ones) are processed; the engine stops with its time at the
-// last processed event and all later events still queued. This is a
-// deterministic mid-run boundary — unlike Pause, which stops at a
-// non-reproducible point — used to take a mid-transaction checkpoint.
-func (e *SerialEngine) RunUntil(t VTimeInPicoSec) error {
-	e.singleRunLock.Lock()
-	defer e.singleRunLock.Unlock()
-
-	hasHooks := e.NumHooks() > 0
-
-	for {
-		if e.noMoreEvent() {
-			return nil
-		}
-		if e.nextEventTime() > t {
-			return nil
-		}
-
-		if atomic.LoadInt32(&e.paused) != 0 {
-			e.waitForResume()
-		}
-
-		e.dispatchNext(hasHooks)
+// dispatchNext keeps the queue critical section separate from model callbacks.
+// A recovery is installed before calling even user-defined event accessors.
+func (e *SerialEngine) dispatchNext(hasHooks bool, limit *VTimeInPicoSec) (done bool) {
+	if !e.supervisor.beginDispatch() {
+		return true
 	}
-}
-
-// dispatchNext pops the earliest event and runs it, invoking hooks when present.
-func (e *SerialEngine) dispatchNext(hasHooks bool) {
-	evt := e.nextEvent()
-
-	if evt.Time() < e.time {
-		log.Panicf(
-			"cannot run event in the past, evt %s @ %d, now %d",
-			reflect.TypeOf(evt), evt.Time(), e.time,
-		)
+	defer e.supervisor.endDispatch()
+	var evt Event
+	defer func() {
+		if p := recover(); p != nil {
+			e.supervisor.record("event", evt, p)
+		}
+	}()
+	var handler Handler
+	evt, handler, done = e.prepareNext(limit)
+	if done {
+		return true
 	}
-
-	e.time = evt.Time()
-
+	ctx := hooking.HookCtx{Domain: e, Pos: HookPosBeforeEvent, Item: evt}
 	if hasHooks {
-		hookCtx := hooking.HookCtx{
-			Domain: e,
-			Pos:    HookPosBeforeEvent,
-			Item:   evt,
-		}
-		e.InvokeHook(hookCtx)
-
-		handler := e.registry[evt.HandlerID()]
-		_ = handler.Handle(evt)
-
-		hookCtx.Pos = HookPosAfterEvent
-		e.InvokeHook(hookCtx)
-	} else {
-		handler := e.registry[evt.HandlerID()]
-		_ = handler.Handle(evt)
+		e.InvokeHook(ctx)
 	}
+	if e.supervisor.stopped.Load() {
+		return false
+	}
+	handler.Handle(evt)
+	if hasHooks && !e.supervisor.stopped.Load() {
+		ctx.Pos = HookPosAfterEvent
+		e.InvokeHook(ctx)
+	}
+	return false
+}
+
+func (e *SerialEngine) prepareNext(limit *VTimeInPicoSec) (Event, Handler, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.noMoreEvent() || (limit != nil && e.nextEventTime() > *limit) {
+		return nil, nil, true
+	}
+	evt := e.nextEvent()
+	if evt.Time() < e.time {
+		panic("cannot run event in the past")
+	}
+	atomic.StoreUint64((*uint64)(&e.time), uint64(evt.Time()))
+	return evt, e.registry[evt.HandlerID()], false
 }
 
 // nextEventTime returns the time of the earliest queued event. It must not be
@@ -162,15 +162,6 @@ func (e *SerialEngine) nextEventTime() VTimeInPicoSec {
 	}
 
 	return secondary
-}
-
-// waitForResume blocks until the engine is unpaused.
-func (e *SerialEngine) waitForResume() {
-	e.pauseMu.Lock()
-	for atomic.LoadInt32(&e.paused) != 0 {
-		e.pauseCond.Wait()
-	}
-	e.pauseMu.Unlock()
 }
 
 func (e *SerialEngine) noMoreEvent() bool {
@@ -199,30 +190,17 @@ func (e *SerialEngine) nextEvent() Event {
 	return secondaryEvt
 }
 
-// Pause prevents the SerialEngine from triggering more events.
-func (e *SerialEngine) Pause() {
-	e.pauseMu.Lock()
-	defer e.pauseMu.Unlock()
-
-	atomic.StoreInt32(&e.paused, 1)
-}
-
-// Continue allows the SerialEngine to trigger more events.
-func (e *SerialEngine) Continue() {
-	e.pauseMu.Lock()
-	defer e.pauseMu.Unlock()
-
-	atomic.StoreInt32(&e.paused, 0)
-	e.pauseCond.Broadcast()
-}
-
-// CurrentTime returns the current time at which the engine is at.
-// Specifically, the run time of the current event.
+// Pause prevents subsequent event dispatch; an already admitted event may finish.
+func (e *SerialEngine) Pause()    { e.supervisor.Pause() }
+func (e *SerialEngine) Continue() { e.supervisor.Continue() }
 func (e *SerialEngine) CurrentTime() VTimeInPicoSec {
-	return e.time
+	return VTimeInPicoSec(atomic.LoadUint64((*uint64)(&e.time)))
 }
-
-// SetCurrentTime sets the current time of the engine.
 func (e *SerialEngine) SetCurrentTime(t VTimeInPicoSec) {
-	e.time = t
+	e.supervisor.Check()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	atomic.StoreUint64((*uint64)(&e.time), uint64(t))
 }
+func (e *SerialEngine) Supervisor() *Supervisor  { return e.supervisor }
+func (e *SerialEngine) IDGenerator() IDGenerator { return e.ids }

--- a/timing/serialengine_checkpoint.go
+++ b/timing/serialengine_checkpoint.go
@@ -51,6 +51,7 @@ func (e *SerialEngine) LoadCheckpoint(r io.Reader) (err error) {
 		}
 		if err != nil {
 			e.supervisor.Fail("restore engine", err)
+			err = e.supervisor.Err()
 		}
 	}()
 	if !e.supervisor.Fresh() {

--- a/timing/serialengine_checkpoint.go
+++ b/timing/serialengine_checkpoint.go
@@ -17,12 +17,11 @@ type serialEngineCheckpoint struct {
 }
 
 // SaveCheckpoint writes the engine's current time and queued events.
+// Execution and all engine mutations must be stopped until it returns.
 func (e *SerialEngine) SaveCheckpoint(w io.Writer) error {
 	if err := e.supervisor.Err(); err != nil {
 		return err
 	}
-	e.mu.Lock()
-	defer e.mu.Unlock()
 	primary, err := eventCodec.EncodeSlice(e.queue.snapshot())
 	if err != nil {
 		return err
@@ -57,8 +56,6 @@ func (e *SerialEngine) LoadCheckpoint(r io.Reader) (err error) {
 	if !e.supervisor.Fresh() {
 		return fmt.Errorf("timing: restore requires a fresh engine")
 	}
-	e.mu.Lock()
-	defer e.mu.Unlock()
 
 	if e.restored {
 		return fmt.Errorf("timing: engine has already attempted a restore")

--- a/timing/serialengine_checkpoint.go
+++ b/timing/serialengine_checkpoint.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sync/atomic"
 )
 
 // serialEngineCheckpoint is the serialized form of the engine: its current time
@@ -17,6 +18,11 @@ type serialEngineCheckpoint struct {
 
 // SaveCheckpoint writes the engine's current time and queued events.
 func (e *SerialEngine) SaveCheckpoint(w io.Writer) error {
+	if err := e.supervisor.Err(); err != nil {
+		return err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	primary, err := eventCodec.EncodeSlice(e.queue.snapshot())
 	if err != nil {
 		return err
@@ -37,7 +43,26 @@ func (e *SerialEngine) SaveCheckpoint(w io.Writer) error {
 // rebuilt engine, whose queues must already be empty. Events are restored in
 // pop order so the (time, sequence) ordering is reproduced, and each event's
 // handler must already be registered.
-func (e *SerialEngine) LoadCheckpoint(r io.Reader) error {
+func (e *SerialEngine) LoadCheckpoint(r io.Reader) (err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			e.supervisor.Fail("restore engine", p)
+			err = e.supervisor.Err()
+		}
+		if err != nil {
+			e.supervisor.Fail("restore engine", err)
+		}
+	}()
+	if !e.supervisor.Fresh() {
+		return fmt.Errorf("timing: restore requires a fresh engine")
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.restored {
+		return fmt.Errorf("timing: engine has already attempted a restore")
+	}
+	e.restored = true
 	if e.queue.Len() != 0 || e.secondaryQueue.Len() != 0 {
 		return fmt.Errorf(
 			"timing: cannot load a checkpoint into a non-empty serial engine queue")
@@ -57,9 +82,19 @@ func (e *SerialEngine) LoadCheckpoint(r io.Reader) error {
 		return err
 	}
 
+	for _, evt := range primary {
+		if evt.IsSecondary() || evt.Time() < dto.Time {
+			return fmt.Errorf("timing: invalid primary checkpoint event")
+		}
+	}
+	for _, evt := range secondary {
+		if !evt.IsSecondary() || evt.Time() < dto.Time {
+			return fmt.Errorf("timing: invalid secondary checkpoint event")
+		}
+	}
 	e.queue.restore(primary)
 	e.secondaryQueue.restore(secondary)
-	e.time = dto.Time
+	atomic.StoreUint64((*uint64)(&e.time), uint64(dto.Time))
 
 	return nil
 }

--- a/timing/serialengine_checkpoint_test.go
+++ b/timing/serialengine_checkpoint_test.go
@@ -2,6 +2,8 @@ package timing
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -18,6 +20,33 @@ type idRecordingHandler struct {
 func (h *idRecordingHandler) Handle(e Event) {
 	h.ids = append(h.ids, e.(queueTestEvent).ID)
 	return
+}
+
+func TestFailedEngineRestoreIsRecordedOnceAcrossBoundaries(t *testing.T) {
+	e := NewSerialEngine()
+	err := e.Supervisor().Execute("restore checkpoint", func() error {
+		err := e.LoadCheckpoint(bytes.NewBufferString("invalid JSON"))
+		if err == nil {
+			return nil
+		}
+		return fmt.Errorf("load entity: %w", err)
+	})
+	if err == nil || len(e.Supervisor().Failures()) != 1 {
+		t.Fatalf("restore failure recorded incorrectly: err=%v failures=%d", err, len(e.Supervisor().Failures()))
+	}
+	if e.Run() == nil {
+		t.Fatal("failed restore engine was reusable")
+	}
+	cleanup := errors.New("cleanup failed too")
+	e.Supervisor().Fail("cleanup", errors.Join(err, cleanup))
+	if failures := e.Supervisor().Failures(); len(failures) != 2 || !errors.Is(failures[1], cleanup) {
+		t.Fatal("joined secondary failure was discarded")
+	}
+	other := NewSupervisor("other")
+	other.Fail("shared host operation", err)
+	if len(other.Failures()) != 1 || other.Err() == nil {
+		t.Fatal("failure originating in another supervisor was discarded")
+	}
 }
 
 func TestSerialEngineQueueRoundTrip(t *testing.T) {

--- a/timing/serialengine_checkpoint_test.go
+++ b/timing/serialengine_checkpoint_test.go
@@ -15,9 +15,9 @@ type idRecordingHandler struct {
 	ids []uint64
 }
 
-func (h *idRecordingHandler) Handle(e Event) error {
+func (h *idRecordingHandler) Handle(e Event) {
 	h.ids = append(h.ids, e.(queueTestEvent).ID)
-	return nil
+	return
 }
 
 func TestSerialEngineQueueRoundTrip(t *testing.T) {

--- a/timing/serialengine_pause_test.go
+++ b/timing/serialengine_pause_test.go
@@ -1,0 +1,89 @@
+package timing
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/sarchlab/akita/v5/hooking"
+)
+
+func TestSerialPauseAcknowledgesCompletedCallbacks(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		e := NewSerialEngine()
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		count, afterHooks := 0, 0
+		e.RegisterHandler("model", failureHandler(func(evt Event) {
+			entered <- struct{}{}
+			<-release
+			count++
+			if evt.Time() < 4 {
+				e.Schedule(MakeEventBase(e.IDGenerator(), evt.Time()+1, "model"))
+			}
+		}))
+		hook := failureHook(func(ctx hooking.HookCtx) {
+			if ctx.Pos == HookPosAfterEvent {
+				afterHooks++
+			}
+		})
+		e.AcceptHook(&hook)
+		e.Schedule(MakeEventBase(e.IDGenerator(), 1, "model"))
+		done := make(chan error, 1)
+		go func() { done <- e.Run() }()
+		for want := 1; want <= 4; want++ {
+			<-entered
+			paused := make(chan struct{})
+			go func() { e.Pause(); close(paused) }()
+			synctest.Wait()
+			select {
+			case <-paused:
+				t.Fatal("Pause returned before the callback finished")
+			default:
+			}
+			release <- struct{}{}
+			<-paused
+			// Deliberately read ordinary model fields: the acknowledgment must
+			// synchronize both the handler and its after-event hook with inspection.
+			if count != want || afterHooks != want || e.CurrentTime() != VTimeInPicoSec(want) {
+				t.Fatalf("incomplete paused state: events=%d hooks=%d time=%d", count, afterHooks, e.CurrentTime())
+			}
+			select {
+			case <-entered:
+				t.Fatal("next callback entered while paused")
+			default:
+			}
+			e.Continue()
+		}
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("four pauses observed completed handlers and hooks; all four events finished after resume")
+	})
+}
+
+func TestSerialPauseBeforeAndBetweenRuns(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		e := NewSerialEngine()
+		count := 0
+		e.RegisterHandler("model", failureHandler(func(Event) { count++ }))
+		for i := 1; i <= 3; i++ {
+			e.Schedule(MakeEventBase(e.IDGenerator(), VTimeInPicoSec(i), "model"))
+			e.Pause()
+			done := make(chan error, 1)
+			go func() { done <- e.RunUntil(VTimeInPicoSec(i)) }()
+			synctest.Wait()
+			if count != i-1 {
+				t.Fatal("run dispatched despite an existing pause")
+			}
+			// A second caller must observe the same acknowledged pause.
+			e.Pause()
+			e.Continue()
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			if count != i {
+				t.Fatalf("resume did not finish run %d: %d events", i, count)
+			}
+		}
+	})
+}

--- a/timing/serialengine_rununtil_test.go
+++ b/timing/serialengine_rununtil_test.go
@@ -59,7 +59,7 @@ type rescheduleHandler struct {
 	until  VTimeInPicoSec
 }
 
-func (h *rescheduleHandler) Handle(e Event) error {
+func (h *rescheduleHandler) Handle(e Event) {
 	now := e.Time()
 	h.fired = append(h.fired, now)
 
@@ -71,7 +71,7 @@ func (h *rescheduleHandler) Handle(e Event) error {
 		h.engine.Schedule(ev)
 	}
 
-	return nil
+	return
 }
 
 func TestRunUntilProcessesEventsScheduledWithinBoundary(t *testing.T) {

--- a/timing/supervisor.go
+++ b/timing/supervisor.go
@@ -1,0 +1,341 @@
+package timing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+)
+
+// FailureError describes the first failure of one simulation. Cause preserves the
+// original panic value; Stack records where it was caught. A failed instance
+// cannot be resumed. Diagnosis must not inspect mutable component state.
+type FailureError struct {
+	SimulationID string
+	Operation    string
+	Handler      string
+	EventType    string
+	Time         VTimeInPicoSec
+	Cause        any
+	Stack        []byte
+}
+
+func (f *FailureError) Error() string {
+	return fmt.Sprintf("simulation %q failed during %s (handler %q, event %s, time %d): %v",
+		f.SimulationID, f.Operation, f.Handler, f.EventType, f.Time, f.Cause)
+}
+
+func (f *FailureError) Unwrap() error {
+	err, _ := f.Cause.(error)
+	return err
+}
+
+// Supervisor owns a simulation's failure boundary and cooperative workers.
+// Use Execute for setup and external mutations, and Go for extension workers.
+// Callbacks must not recursively call Execute, Run, or Close. Workers must
+// finish or respond to Context cancellation; arbitrary goroutines cannot be killed.
+type Supervisor struct {
+	opMu          sync.Mutex
+	dispatchMu    sync.RWMutex
+	stopped       atomic.Bool
+	pauseSignal   atomic.Pointer[chan struct{}]
+	mu            sync.Mutex
+	id            string
+	ctx           context.Context //nolint:containedctx // Owns the simulation lifetime, rather than a request context.
+	cancel        context.CancelFunc
+	failures      []*FailureError
+	active        bool
+	accepting     bool
+	closing       bool
+	closed        bool
+	executed      bool
+	workers       sync.WaitGroup
+	workerCount   int
+	workerChanged chan struct{}
+	resume        chan struct{}
+}
+
+func NewSupervisor(id string) *Supervisor {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Supervisor{id: id, ctx: ctx, cancel: cancel, workerChanged: make(chan struct{}, 1)}
+}
+
+func (s *Supervisor) Context() context.Context { return s.ctx }
+
+// SetID assigns diagnostic identity during setup, before starting workers.
+func (s *Supervisor) SetID(id string) { s.mu.Lock(); defer s.mu.Unlock(); s.id = id }
+
+// Err returns the first failure, or nil. The returned diagnostic is a copy.
+func (s *Supervisor) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.failures) == 0 {
+		return nil
+	}
+	return cloneFailure(s.failures[0])
+}
+
+func cloneFailure(f *FailureError) *FailureError {
+	c := *f
+	c.Stack = append([]byte(nil), f.Stack...)
+	return &c
+}
+
+// Failures returns independent snapshots, preserving secondary cleanup failures.
+func (s *Supervisor) Failures() []*FailureError {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*FailureError, len(s.failures))
+	for i, f := range s.failures {
+		out[i] = cloneFailure(f)
+	}
+	return out
+}
+
+// Fail records an operational failure and cancels only this simulation.
+func (s *Supervisor) Fail(operation string, cause any) { s.record(operation, nil, cause) }
+
+func (s *Supervisor) record(operation string, evt Event, cause any) {
+	f := &FailureError{Operation: operation, Cause: cause, Stack: debug.Stack()}
+	if evt != nil {
+		annotateFailure(f, evt)
+	}
+	s.mu.Lock()
+	f.SimulationID = s.id
+	s.failures = append(s.failures, f)
+	s.stopped.Store(true)
+	s.cancel()
+	s.mu.Unlock()
+}
+
+// Check rejects operations on failed or closed instances by panicking. Managed
+// callbacks contain this panic; callers outside a boundary own their recovery.
+func (s *Supervisor) Check() {
+	if !s.stopped.Load() {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.failures) > 0 {
+		panic(cloneFailure(s.failures[0]))
+	}
+	if s.closed || s.closing {
+		panic("simulation is closed")
+	}
+}
+
+// Protect contains a callback on the current goroutine. Worker ownership and
+// operation serialization belong to Execute/Go, not this low-level boundary.
+func (s *Supervisor) Protect(operation string, evt Event, fn func() error) {
+	defer func() {
+		if p := recover(); p != nil {
+			s.record(operation, evt, p)
+		}
+	}()
+	if err := fn(); err != nil {
+		s.record(operation, evt, err)
+	}
+}
+
+// Execute runs a managed operation and joins every admitted worker, even after
+// panic. Concurrent operations are rejected instead of waiting behind a run.
+func (s *Supervisor) Execute(operation string, fn func() error) error {
+	if !s.opMu.TryLock() {
+		return errors.New("simulation already has an active operation")
+	}
+	defer s.opMu.Unlock()
+	if err := s.begin(operation); err != nil {
+		return err
+	}
+	s.Protect(operation, nil, fn)
+	s.mu.Lock()
+	s.accepting = false
+	s.mu.Unlock()
+	s.workers.Wait()
+	s.mu.Lock()
+	s.active = false
+	s.mu.Unlock()
+	return s.Err()
+}
+
+func (s *Supervisor) begin(operation string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.failures) > 0 {
+		return cloneFailure(s.failures[0])
+	}
+	if s.closed || s.closing {
+		return errors.New("simulation is closed")
+	}
+	s.active = true
+	s.accepting = true
+	if operation == "run" {
+		s.executed = true
+	}
+	return nil
+}
+
+// Go starts a worker during a managed operation. A worker may launch children
+// while admission remains open. Every worker must handle a rejected launch.
+func (s *Supervisor) Go(operation string, fn func(context.Context) error) error {
+	s.mu.Lock()
+	if !s.accepting || s.closed || s.closing || len(s.failures) > 0 {
+		s.mu.Unlock()
+		return errors.New("simulation is not accepting workers")
+	}
+	s.workers.Add(1)
+	s.workerCount++
+	s.mu.Unlock()
+	go func() { defer s.workerDone(); s.Protect(operation, nil, func() error { return fn(s.ctx) }) }()
+	return nil
+}
+
+// Fresh reports whether execution has never begun. Restore is permitted only
+// on a fresh instance; a failed restore is terminal, including preflight failure.
+func (s *Supervisor) Fresh() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.executed && !s.closed && len(s.failures) == 0
+}
+
+// Pause prevents dispatch of subsequent events. Already admitted events finish.
+func (s *Supervisor) Pause() {
+	s.Check()
+	s.mu.Lock()
+	if s.resume == nil {
+		s.resume = make(chan struct{})
+		signal := s.resume
+		s.pauseSignal.Store(&signal)
+	}
+	s.mu.Unlock()
+	// An external pause waits until admitted callbacks have left their state.
+	s.dispatchMu.Lock()
+	s.dispatchMu.Unlock()
+	s.Check()
+}
+
+func (s *Supervisor) Continue() {
+	s.Check()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.resume != nil {
+		close(s.resume)
+		s.resume = nil
+		s.pauseSignal.Store(nil)
+	}
+}
+
+func (s *Supervisor) awaitResume() bool {
+	if signal := s.pauseSignal.Load(); signal != nil {
+		select {
+		case <-*signal:
+		case <-s.ctx.Done():
+			return false
+		}
+	}
+	return !s.stopped.Load()
+}
+
+// Close cancels cooperative work, waits for the active operation, then contains
+// cleanup. Cleanup must only release owned resources, never traverse failed models.
+func (s *Supervisor) Close(cleanup func()) error {
+	s.mu.Lock()
+	if s.active && len(s.failures) == 0 {
+		s.failures = append(s.failures, &FailureError{
+			SimulationID: s.id, Operation: "termination during active operation",
+			Cause: context.Canceled, Stack: debug.Stack(),
+		})
+	}
+	s.closing = true
+	s.stopped.Store(true)
+	s.cancel()
+	s.mu.Unlock()
+	s.opMu.Lock()
+	defer s.opMu.Unlock()
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return s.Err()
+	}
+	s.closed = true
+	s.mu.Unlock()
+	s.Protect("cleanup", nil, func() error { cleanup(); return nil })
+	return s.Err()
+}
+
+func annotateFailure(f *FailureError, evt Event) {
+	// Broken event accessors must not escape while diagnosing the original panic.
+	defer func() { _ = recover() }()
+	f.EventType = fmt.Sprintf("%T", evt)
+	f.Handler = evt.HandlerID()
+	f.Time = evt.Time()
+}
+
+// State is safe to inspect without touching potentially invalid model state.
+func (s *Supervisor) State() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.failures) > 0 {
+		return "failed"
+	}
+	if s.closed || s.closing {
+		return "closed"
+	}
+	if s.active {
+		return "running"
+	}
+	return "ready"
+}
+
+// Cancel terminates cooperative execution and makes failure terminal.
+func (s *Supervisor) Cancel() { s.Fail("cancel", context.Canceled) }
+
+func (s *Supervisor) workerDone() {
+	s.mu.Lock()
+	s.workerCount--
+	s.mu.Unlock()
+	select {
+	case s.workerChanged <- struct{}{}:
+	default:
+	}
+	s.workers.Done()
+}
+
+// waitForWork lets an extension worker schedule more events while the queue is
+// empty, without blocking that worker's event-dependent progress.
+func (s *Supervisor) waitForWork(wake <-chan struct{}) bool {
+	s.mu.Lock()
+	pending := s.workerCount > 0
+	s.mu.Unlock()
+	if !pending {
+		// A producer may have scheduled its final event and exited after the
+		// dispatcher observed an empty queue. Consume that wake before ending.
+		select {
+		case <-wake:
+			return true
+		default:
+			return false
+		}
+	}
+	select {
+	case <-wake:
+	case <-s.workerChanged:
+	case <-s.ctx.Done():
+		return false
+	}
+	return true
+}
+
+func (s *Supervisor) beginDispatch() bool {
+	for s.awaitResume() {
+		s.dispatchMu.RLock()
+		if s.pauseSignal.Load() == nil && !s.stopped.Load() {
+			return true
+		}
+		s.dispatchMu.RUnlock()
+	}
+	return false
+}
+func (s *Supervisor) endDispatch() { s.dispatchMu.RUnlock() }

--- a/timing/supervisor.go
+++ b/timing/supervisor.go
@@ -9,6 +9,9 @@ import (
 	"sync/atomic"
 )
 
+// ErrClosed identifies operations rejected because healthy shutdown has begun.
+var ErrClosed = errors.New("simulation is closed")
+
 // FailureError describes the first failure of one simulation. Cause preserves the
 // original panic value; Stack records where it was caught. A failed instance
 // cannot be resumed. Diagnosis must not inspect mutable component state.
@@ -122,7 +125,7 @@ func (s *Supervisor) Check() {
 		panic(cloneFailure(s.failures[0]))
 	}
 	if s.closed || s.closing {
-		panic("simulation is closed")
+		panic(ErrClosed)
 	}
 }
 
@@ -167,7 +170,7 @@ func (s *Supervisor) begin(operation string) error {
 		return cloneFailure(s.failures[0])
 	}
 	if s.closed || s.closing {
-		return errors.New("simulation is closed")
+		return ErrClosed
 	}
 	s.active = true
 	s.accepting = true

--- a/timing/supervisor.go
+++ b/timing/supervisor.go
@@ -36,6 +36,12 @@ func (f *FailureError) Unwrap() error {
 	return err
 }
 
+type pauseRequest struct {
+	resume  chan struct{}
+	reached chan struct{}
+	once    sync.Once
+}
+
 // Supervisor owns a simulation's failure boundary and cooperative workers.
 // Use Execute for setup and external mutations, and Go for extension workers.
 // Callbacks must not recursively call Execute, Run, or Close. Workers must
@@ -44,7 +50,7 @@ type Supervisor struct {
 	opMu          sync.Mutex
 	dispatchMu    sync.RWMutex
 	stopped       atomic.Bool
-	pauseSignal   atomic.Pointer[chan struct{}]
+	pauseSignal   atomic.Pointer[pauseRequest]
 	mu            sync.Mutex
 	id            string
 	ctx           context.Context //nolint:containedctx // Owns the simulation lifetime, rather than a request context.
@@ -58,7 +64,10 @@ type Supervisor struct {
 	workers       sync.WaitGroup
 	workerCount   int
 	workerChanged chan struct{}
-	resume        chan struct{}
+	// Serial dispatch acknowledges pauses at event boundaries. These fields
+	// are initialized before use (serial) or protected by mu (serialRunDone).
+	serial        bool
+	serialRunDone chan struct{}
 }
 
 func NewSupervisor(id string) *Supervisor {
@@ -182,6 +191,10 @@ func (s *Supervisor) Execute(operation string, fn func() error) error {
 	}
 	s.Protect(operation, nil, fn)
 	s.mu.Lock()
+	if s.serialRunDone != nil {
+		close(s.serialRunDone)
+		s.serialRunDone = nil
+	}
 	s.accepting = false
 	s.mu.Unlock()
 	s.workers.Wait()
@@ -204,6 +217,9 @@ func (s *Supervisor) begin(operation string) error {
 	s.accepting = true
 	if operation == "run" {
 		s.executed = true
+		if s.serial {
+			s.serialRunDone = make(chan struct{})
+		}
 	}
 	return nil
 }
@@ -235,15 +251,27 @@ func (s *Supervisor) Fresh() bool {
 func (s *Supervisor) Pause() {
 	s.Check()
 	s.mu.Lock()
-	if s.resume == nil {
-		s.resume = make(chan struct{})
-		signal := s.resume
-		s.pauseSignal.Store(&signal)
+	request := s.pauseSignal.Load()
+	if request == nil {
+		request = &pauseRequest{resume: make(chan struct{}), reached: make(chan struct{})}
+		s.pauseSignal.Store(request)
 	}
+	done := s.serialRunDone
 	s.mu.Unlock()
-	// An external pause waits until admitted callbacks have left their state.
-	s.dispatchMu.Lock()
-	s.dispatchMu.Unlock()
+	if s.serial {
+		if done != nil {
+			select {
+			case <-request.reached:
+			case <-done:
+			case <-request.resume:
+			case <-s.ctx.Done():
+			}
+		}
+	} else {
+		// Parallel callbacks acknowledge completion by releasing their locks.
+		s.dispatchMu.Lock()
+		s.dispatchMu.Unlock()
+	}
 	s.Check()
 }
 
@@ -251,17 +279,18 @@ func (s *Supervisor) Continue() {
 	s.Check()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.resume != nil {
-		close(s.resume)
-		s.resume = nil
-		s.pauseSignal.Store(nil)
+	if request := s.pauseSignal.Swap(nil); request != nil {
+		close(request.resume)
 	}
 }
 
 func (s *Supervisor) awaitResume() bool {
-	if signal := s.pauseSignal.Load(); signal != nil {
+	if request := s.pauseSignal.Load(); request != nil {
+		if s.serial {
+			request.once.Do(func() { close(request.reached) })
+		}
 		select {
-		case <-*signal:
+		case <-request.resume:
 		case <-s.ctx.Done():
 			return false
 		}

--- a/timing/supervisor.go
+++ b/timing/supervisor.go
@@ -23,6 +23,7 @@ type FailureError struct {
 	Time         VTimeInPicoSec
 	Cause        any
 	Stack        []byte
+	recordedBy   *Supervisor
 }
 
 func (f *FailureError) Error() string {
@@ -101,7 +102,10 @@ func (s *Supervisor) Failures() []*FailureError {
 func (s *Supervisor) Fail(operation string, cause any) { s.record(operation, nil, cause) }
 
 func (s *Supervisor) record(operation string, evt Event, cause any) {
-	f := &FailureError{Operation: operation, Cause: cause, Stack: debug.Stack()}
+	if s.alreadyRecorded(cause) {
+		return
+	}
+	f := &FailureError{Operation: operation, Cause: cause, Stack: debug.Stack(), recordedBy: s}
 	if evt != nil {
 		annotateFailure(f, evt)
 	}
@@ -111,6 +115,30 @@ func (s *Supervisor) record(operation string, evt Event, cause any) {
 	s.stopped.Store(true)
 	s.cancel()
 	s.mu.Unlock()
+}
+
+// A failure returned through nested managed boundaries is one incident. Errors
+// from another owner, and distinct later failures, must still be recorded.
+func (s *Supervisor) alreadyRecorded(cause any) (recorded bool) {
+	// A user-defined Unwrap method must not break the failure boundary.
+	defer func() { _ = recover() }()
+	err, ok := cause.(error)
+	if !ok {
+		return false
+	}
+	for err != nil {
+		if failure, ok := err.(*FailureError); ok {
+			return failure != nil && failure.recordedBy == s
+		}
+		// A joined error can contain an additional failure, so only suppress
+		// ordinary single-cause wrapping of an already-recorded incident.
+		wrapped, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		err = wrapped.Unwrap()
+	}
+	return false
 }
 
 // Check rejects operations on failed or closed instances by panicking. Managed

--- a/timing/timing_test.go
+++ b/timing/timing_test.go
@@ -11,24 +11,22 @@ type recordingHandler struct {
 	labels []string
 }
 
-func (h *recordingHandler) Handle(e Event) error {
+func (h *recordingHandler) Handle(e Event) {
 	h.labels = append(h.labels, e.(testEvent).label)
-	return nil
+	return
 }
 
 func TestSerialEngineRunsEventsInTimeOrder(t *testing.T) {
-	ResetIDGenerator()
-
 	engine := NewSerialEngine()
 	handler := &recordingHandler{}
 	engine.RegisterHandler("handler", handler)
 
 	engine.Schedule(testEvent{
-		EventBase: MakeEventBase(2, "handler"),
+		EventBase: MakeEventBase(testIDs, 2, "handler"),
 		label:     "second",
 	})
 	engine.Schedule(testEvent{
-		EventBase: MakeEventBase(1, "handler"),
+		EventBase: MakeEventBase(testIDs, 1, "handler"),
 		label:     "first",
 	})
 
@@ -42,21 +40,19 @@ func TestSerialEngineRunsEventsInTimeOrder(t *testing.T) {
 }
 
 func TestSerialEngineRunsSecondaryEventsAfterPrimaryEvents(t *testing.T) {
-	ResetIDGenerator()
-
 	engine := NewSerialEngine()
 	handler := &recordingHandler{}
 	engine.RegisterHandler("handler", handler)
 
 	secondary := testEvent{
-		EventBase: MakeEventBase(1, "handler"),
+		EventBase: MakeEventBase(testIDs, 1, "handler"),
 		label:     "secondary",
 	}
 	secondary.Secondary = true
 
 	engine.Schedule(secondary)
 	engine.Schedule(testEvent{
-		EventBase: MakeEventBase(1, "handler"),
+		EventBase: MakeEventBase(testIDs, 1, "handler"),
 		label:     "primary",
 	})
 
@@ -70,14 +66,13 @@ func TestSerialEngineRunsSecondaryEventsAfterPrimaryEvents(t *testing.T) {
 }
 
 func TestIDGeneratorNextID(t *testing.T) {
-	ResetIDGenerator()
-	UseSequentialIDGenerator()
+	testIDs := NewIDGenerator()
 
-	GetIDGenerator().Generate()
-	GetIDGenerator().Generate()
+	testIDs.Generate()
+	testIDs.Generate()
 
-	if got, want := GetIDGeneratorNextID(), uint64(2); got != want {
-		t.Fatalf("GetIDGeneratorNextID() = %d, want %d", got, want)
+	if got, want := testIDs.NextID(), uint64(2); got != want {
+		t.Fatalf("testIDs.NextID() = %d, want %d", got, want)
 	}
 }
 

--- a/tracing/api.go
+++ b/tracing/api.go
@@ -14,6 +14,7 @@ import (
 // domain's clock, but only after confirming the domain has hooks, so the
 // clock is never consulted when tracing is disabled.
 type NamedHookable interface {
+	timing.IDSource
 	naming.Named
 	hooking.Hookable
 	timing.TimeTeller
@@ -127,7 +128,7 @@ func AddTaskTag(domain NamedHookable, tag TaskTag) {
 	}
 
 	if tag.ID == 0 {
-		tag.ID = timing.GetIDGenerator().Generate()
+		tag.ID = timing.IDsFor(domain).Generate()
 	}
 
 	tag.Time = domain.CurrentTime()
@@ -148,7 +149,7 @@ func AddMilestone(domain NamedHookable, m Milestone) {
 	}
 
 	if m.ID == 0 {
-		m.ID = timing.GetIDGenerator().Generate()
+		m.ID = timing.IDsFor(domain).Generate()
 	}
 
 	m.Time = domain.CurrentTime()

--- a/tracing/dbtracer.go
+++ b/tracing/dbtracer.go
@@ -211,7 +211,7 @@ func (t *DBTracer) EndTask(task TaskEnd) {
 		StartTime: float64(originalTask.StartTime),
 		EndTime:   float64(originalTask.EndTime),
 	}
-	t.backend.InsertData(traceTableName, entry)
+	datarecording.MustRecord(t.backend.InsertData(traceTableName, entry))
 
 	// Write milestones to the milestone table. A milestone's location is
 	// the task's location, recovered by readers via the TaskID join.
@@ -223,7 +223,7 @@ func (t *DBTracer) EndTask(task TaskEnd) {
 			Kind:   string(m.Kind),
 			What:   m.What,
 		}
-		t.backend.InsertData(milestoneTableName, milestoneEntry)
+		datarecording.MustRecord(t.backend.InsertData(milestoneTableName, milestoneEntry))
 	}
 
 	// Write tags to the tag table.
@@ -234,7 +234,7 @@ func (t *DBTracer) EndTask(task TaskEnd) {
 			Time:   float64(tag.Time),
 			What:   tag.What,
 		}
-		t.backend.InsertData(tagTableName, tagEntry)
+		datarecording.MustRecord(t.backend.InsertData(tagTableName, tagEntry))
 	}
 }
 
@@ -267,7 +267,7 @@ func (t *DBTracer) Terminate() {
 	defer t.mu.Unlock()
 
 	t.tracingTasks = nil
-	t.backend.Flush()
+	datarecording.MustRecord(t.backend.Flush())
 }
 
 func captureBacktrace() string {
@@ -304,12 +304,12 @@ func (t *DBTracer) StopTracing() {
 		StartTime: float64(t.tracingStartTime),
 		EndTime:   float64(endTime),
 	}
-	t.backend.InsertData(segmentTableName, segment)
+	datarecording.MustRecord(t.backend.InsertData(segmentTableName, segment))
 
 	t.isTracing = false
 
 	// Flush to ensure all data is written to database immediately
-	t.backend.Flush()
+	datarecording.MustRecord(t.backend.Flush())
 }
 
 // NewDBTracer creates a new DBTracer.
@@ -317,10 +317,10 @@ func NewDBTracer(
 	timeTeller timing.TimeTeller,
 	dataRecorder datarecording.DataRecorder,
 ) *DBTracer {
-	dataRecorder.CreateTable(traceTableName, taskTableEntry{})
-	dataRecorder.CreateTable(milestoneTableName, milestoneTableEntry{})
-	dataRecorder.CreateTable(tagTableName, tagTableEntry{})
-	dataRecorder.CreateTable(segmentTableName, segmentTableEntry{})
+	datarecording.MustRecord(dataRecorder.CreateTable(traceTableName, taskTableEntry{}))
+	datarecording.MustRecord(dataRecorder.CreateTable(milestoneTableName, milestoneTableEntry{}))
+	datarecording.MustRecord(dataRecorder.CreateTable(tagTableName, tagTableEntry{}))
+	datarecording.MustRecord(dataRecorder.CreateTable(segmentTableName, segmentTableEntry{}))
 
 	t := &DBTracer{
 		timeTeller:   timeTeller,

--- a/tracing/dbtracer_roundtrip_test.go
+++ b/tracing/dbtracer_roundtrip_test.go
@@ -14,6 +14,7 @@ import (
 // roundTripDomain is a minimal NamedHookable used to drive the DBTracer through
 // a real emit -> persist cycle.
 type roundTripDomain struct {
+	ids timing.IDGenerator
 	*hooking.HookableBase
 	name string
 	now  timing.VTimeInPicoSec
@@ -50,7 +51,10 @@ func writeRoundTripTrace(t *testing.T) string {
 	os.Remove(dbFile)
 	t.Cleanup(func() { os.Remove(dbFile) })
 
-	recorder := datarecording.NewDataRecorder(dbName)
+	recorder, err := datarecording.NewDataRecorder(dbName)
+	if err != nil {
+		panic(err)
+	}
 	domain := &roundTripDomain{
 		HookableBase: hooking.NewHookableBase(),
 		name:         "GPU[0].L1Cache",
@@ -125,4 +129,11 @@ func assertDictionaryAndChildren(t *testing.T, db *sql.DB) {
 	if tagWhat != "read-hit" {
 		t.Fatalf("tag What = %q, want read-hit", tagWhat)
 	}
+}
+
+func (d *roundTripDomain) IDGenerator() timing.IDGenerator {
+	if d.ids == nil {
+		d.ids = timing.NewIDGenerator()
+	}
+	return d.ids
 }

--- a/tracing/dbtracer_test.go
+++ b/tracing/dbtracer_test.go
@@ -35,7 +35,13 @@ var _ = Describe("DBTracer Milestone Deduplication", func() {
 		timeTeller = &testTimeTeller{}
 		dbPath = "test_trace_milestone"
 		os.Remove(dbPath + ".sqlite3")
-		dataRecorder = datarecording.NewDataRecorder(dbPath)
+		{
+			var err error
+			dataRecorder, err = datarecording.NewDataRecorder(dbPath)
+			if err != nil {
+				panic(err)
+			}
+		}
 		tracer = NewDBTracer(timeTeller, dataRecorder)
 	})
 

--- a/tracing/example_tracer_test.go
+++ b/tracing/example_tracer_test.go
@@ -18,6 +18,7 @@ func (t *SampleTimeTeller) CurrentTime() timing.VTimeInPicoSec {
 }
 
 type SampleDomain struct {
+	ids timing.IDGenerator
 	*hooking.HookableBase
 
 	timeTeller timing.TimeTeller
@@ -96,4 +97,11 @@ func ExampleTracer() {
 	// 25
 	// 20
 	// 12
+}
+
+func (d *SampleDomain) IDGenerator() timing.IDGenerator {
+	if d.ids == nil {
+		d.ids = timing.NewIDGenerator()
+	}
+	return d.ids
 }

--- a/tracing/incomingbuffertracer_test.go
+++ b/tracing/incomingbuffertracer_test.go
@@ -14,6 +14,7 @@ import (
 // tasks on it). InvokeHook is provided by the embedded HookableBase, which is
 // how CollectTrace forwards events to a tracer.
 type ibFakeComp struct {
+	ids timing.IDGenerator
 	hooking.HookableBase
 	name string
 	time timing.VTimeInPicoSec
@@ -139,3 +140,10 @@ var _ = Describe("Incoming buffer tracer", func() {
 		Expect(tracer.milestones).To(BeEmpty())
 	})
 })
+
+func (d *ibFakeComp) IDGenerator() timing.IDGenerator {
+	if d.ids == nil {
+		d.ids = timing.NewIDGenerator()
+	}
+	return d.ids
+}

--- a/tracing/outgoingbuffertracer_test.go
+++ b/tracing/outgoingbuffertracer_test.go
@@ -14,6 +14,7 @@ import (
 // tasks on it). InvokeHook is provided by the embedded HookableBase, which is
 // how CollectTrace forwards events to a tracer.
 type obFakeComp struct {
+	ids timing.IDGenerator
 	hooking.HookableBase
 	name string
 	time timing.VTimeInPicoSec
@@ -51,7 +52,7 @@ type obFakeConn struct {
 	hooking.HookableBase
 }
 
-func (c *obFakeConn) Name() string                  { return "Conn" }
+func (c *obFakeConn) Name() string                   { return "Conn" }
 func (c *obFakeConn) PlugIn(messaging.Port)          {}
 func (c *obFakeConn) Unplug(messaging.Port)          {}
 func (c *obFakeConn) NotifyAvailable(messaging.Port) {}
@@ -153,3 +154,10 @@ var _ = Describe("Outgoing buffer tracer", func() {
 		Expect(tracer.milestones).To(BeEmpty())
 	})
 })
+
+func (d *obFakeComp) IDGenerator() timing.IDGenerator {
+	if d.ids == nil {
+		d.ids = timing.NewIDGenerator()
+	}
+	return d.ids
+}

--- a/tracing/registry.go
+++ b/tracing/registry.go
@@ -1,154 +1,34 @@
 package tracing
 
 import (
-	"sync"
-
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/timing"
 )
 
-// The receiver task ID registry maps (domain, message-ID) to the local task ID
-// that the receiver uses to track its handling of that message. This lets a
-// receiver derive a stable task ID for an incoming message without mutating
-// the message itself.
-
-type receiverTaskKey struct {
-	domain string
-	msgID  uint64
-}
-
-var (
-	receiverTaskIDs   = make(map[receiverTaskKey]uint64)
-	receiverTaskIDsMu sync.Mutex
-)
-
+// Tracking belongs to the simulation's ID sequence, so identical component
+// names and message IDs in two simulations cannot share task identities.
+func registry(domain NamedHookable) timing.IDGenerator { return timing.IDsFor(domain) }
 func lookupOrCreateReceiverTaskID(msg messaging.Msg, domain NamedHookable) uint64 {
-	key := receiverTaskKey{domain: domain.Name(), msgID: msg.Meta().ID}
-
-	receiverTaskIDsMu.Lock()
-	defer receiverTaskIDsMu.Unlock()
-
-	if id, ok := receiverTaskIDs[key]; ok {
-		return id
-	}
-
-	id := timing.GetIDGenerator().Generate()
-	receiverTaskIDs[key] = id
-
-	return id
+	return registry(domain).Track(domain.Name()+"/receiver", msg.Meta().ID)
 }
-
-// receiverTaskIDByMsgID returns the receiver-side task ID registered for the
-// message ID at the domain, and whether one exists. Unlike
-// lookupOrCreateReceiverTaskID it never creates an entry, so a reset path can
-// resolve an in-flight task's ID to end it without resurrecting an entry that
-// was already forgotten.
-func receiverTaskIDByMsgID(
-	msgID uint64, domain NamedHookable,
-) (uint64, bool) {
-	key := receiverTaskKey{domain: domain.Name(), msgID: msgID}
-
-	receiverTaskIDsMu.Lock()
-	defer receiverTaskIDsMu.Unlock()
-
-	id, ok := receiverTaskIDs[key]
-
-	return id, ok
+func receiverTaskIDByMsgID(msgID uint64, domain NamedHookable) (uint64, bool) {
+	return registry(domain).Lookup(domain.Name()+"/receiver", msgID)
 }
-
 func forgetReceiverTaskID(msg messaging.Msg, domain NamedHookable) {
 	forgetReceiverTaskIDByMsgID(msg.Meta().ID, domain)
 }
-
 func forgetReceiverTaskIDByMsgID(msgID uint64, domain NamedHookable) {
-	key := receiverTaskKey{domain: domain.Name(), msgID: msgID}
-
-	receiverTaskIDsMu.Lock()
-	delete(receiverTaskIDs, key)
-	receiverTaskIDsMu.Unlock()
+	registry(domain).Forget(domain.Name()+"/receiver", msgID)
 }
-
-// The incoming-buffer task ID registry maps (domain, message-ID) to the task ID
-// of the buffer task that tracks a message's residency in a port's incoming
-// buffer (from delivery until it is retrieved). The port hook that opens the
-// task and the component that hangs admission milestones on it both derive the
-// same ID from the message, without mutating the message.
-
-type incomingBufferTaskKey struct {
-	domain string
-	msgID  uint64
+func lookupOrCreateIncomingBufferTaskID(msg messaging.Msg, domain NamedHookable) uint64 {
+	return registry(domain).Track(domain.Name()+"/incoming", msg.Meta().ID)
 }
-
-var (
-	incomingBufferTaskIDs   = make(map[incomingBufferTaskKey]uint64)
-	incomingBufferTaskIDsMu sync.Mutex
-)
-
-func lookupOrCreateIncomingBufferTaskID(
-	msg messaging.Msg, domain NamedHookable,
-) uint64 {
-	key := incomingBufferTaskKey{domain: domain.Name(), msgID: msg.Meta().ID}
-
-	incomingBufferTaskIDsMu.Lock()
-	defer incomingBufferTaskIDsMu.Unlock()
-
-	if id, ok := incomingBufferTaskIDs[key]; ok {
-		return id
-	}
-
-	id := timing.GetIDGenerator().Generate()
-	incomingBufferTaskIDs[key] = id
-
-	return id
-}
-
 func forgetIncomingBufferTaskIDByMsgID(msgID uint64, domain NamedHookable) {
-	key := incomingBufferTaskKey{domain: domain.Name(), msgID: msgID}
-
-	incomingBufferTaskIDsMu.Lock()
-	delete(incomingBufferTaskIDs, key)
-	incomingBufferTaskIDsMu.Unlock()
+	registry(domain).Forget(domain.Name()+"/incoming", msgID)
 }
-
-// The outgoing-buffer task ID registry maps (domain, message-ID) to the task ID
-// of the buffer task that tracks a message's residency in a port's outgoing
-// buffer (from send until the connection drains it). It is kept separate from
-// the incoming-buffer registry so that a message which is both received and
-// re-sent by the same component (same domain name, same message ID) gets a
-// distinct task on each side.
-
-type outgoingBufferTaskKey struct {
-	domain string
-	msgID  uint64
+func lookupOrCreateOutgoingBufferTaskID(msg messaging.Msg, domain NamedHookable) uint64 {
+	return registry(domain).Track(domain.Name()+"/outgoing", msg.Meta().ID)
 }
-
-var (
-	outgoingBufferTaskIDs   = make(map[outgoingBufferTaskKey]uint64)
-	outgoingBufferTaskIDsMu sync.Mutex
-)
-
-func lookupOrCreateOutgoingBufferTaskID(
-	msg messaging.Msg, domain NamedHookable,
-) uint64 {
-	key := outgoingBufferTaskKey{domain: domain.Name(), msgID: msg.Meta().ID}
-
-	outgoingBufferTaskIDsMu.Lock()
-	defer outgoingBufferTaskIDsMu.Unlock()
-
-	if id, ok := outgoingBufferTaskIDs[key]; ok {
-		return id
-	}
-
-	id := timing.GetIDGenerator().Generate()
-	outgoingBufferTaskIDs[key] = id
-
-	return id
-}
-
 func forgetOutgoingBufferTaskIDByMsgID(msgID uint64, domain NamedHookable) {
-	key := outgoingBufferTaskKey{domain: domain.Name(), msgID: msgID}
-
-	outgoingBufferTaskIDsMu.Lock()
-	delete(outgoingBufferTaskIDs, key)
-	outgoingBufferTaskIDsMu.Unlock()
+	registry(domain).Forget(domain.Name()+"/outgoing", msgID)
 }


### PR DESCRIPTION
An ordinary Go panic in an Akita simulation can currently terminate its host, and the engines ignore handler errors. This change makes each simulation own a failure boundary: a failed run returns contextual diagnostics, cancels and joins its workers, and becomes terminal while other simulations keep running.

Implements #478 for v5 beta: storage precondition violations panic, optional tooling degrades with explicit diagnostics, and restore is permitted only into fresh instances.

- Add managed setup, execution, worker, cancellation, and cleanup boundaries for serial and parallel engines. Preserve the first cause and stack plus later failures; reject reuse after failure. Parallel dispatch serializes events for the same handler and avoids borrowed-queue deadlocks.
- Keep serial dispatch and scheduling on the run goroutine without a queue mutex or per-event dispatch lock. External pause is acknowledged at an event boundary; monitor-triggered scheduling pauses first. Background tooling cannot schedule into a running serial engine. Parallel engine concurrency remains separate.
- Remove `Handler.Handle` and storage read/write error results. Keep errors at setup/run, external I/O, validation, checkpoint, and finalization boundaries. Migrate callers, generated interfaces, examples, and tutorials.
- Own ID sequences and tracing associations per engine. Restore into a fresh target once; discard failed targets. Validate serialized containers, event references, and storage ranges; stage both port buffers before assignment.
- Return recorder/query errors, retain failed batches, release recording handles explicitly, and reject shared output paths. Optional monitor/source operational failures produce diagnostics. Requested recording failures invalidate the simulation; successful finalization publishes an atomic `.complete` marker after database close.
- Contain monitor callbacks, join admitted monitor work, propagate reader/provider errors, and restrict provider capability fallback to explicit unsupported-tool responses.

The API, migration, output-validity, and cooperative-isolation contracts are documented in `simulation/ERROR_HANDLING.md`. Ordinary Go panics are contained; fatal runtime failures and unmanaged or noncooperative goroutines require host-level isolation. Callbacks cannot recursively run, pause, or terminate their owning operation.

Validation of the serial-engine revision (`da6e2fe6a3419ac17af8656fe936dbf562a52711`): all 41 local Ginkgo suites, zero lint issues, and race checks for timing, simulation, and monitoring passed. Pause regressions verify completed handlers and after-event hooks before inspection, no dispatch until resume, and pause before/between runs. A reproduced monitor-tick regression now waits for the active callback, returns HTTP 200, and completes the scheduled event. All six CI checks passed on this exact SHA, including all 57 memory workloads and nine network scenarios. Claude Code approved this SHA with `ready_to_merge: true` and no merge blockers in one fresh pass for this revision (five total PR review rounds). Codex independently finds no blocker. Three explicitly nonblocking follow-ups are recorded in the dev-loop summary: healthy-worker completion guidance, request cancellation while inspecting a nonreturning callback, and invalid-event-time diagnostic detail. These do not expand this mutex-removal revision.

The broader PR includes generation/build/tests and regression coverage for hooks, handlers, workers, cleanup, cancellation, queue saturation, output errors, failed restore, invalid JSON, SQL failures, and provider fallback.

Observable acceptance (`go run ./examples/failureisolation`):
```json
{"completed_events":3,"failed_events":1,"failed_state":"failed","failure_contained":true,"unaffected_state":"closed"}
```

Malformed monitor pagination returns HTTP 400 while allowing the simulation to run and produce complete output. Filename encoding keeps SQLite connection options out of literal output paths, and reader tests verify that read-only access stays read-only.

The HTTP shutdown acceptance also verifies that a healthy overlapping inspection leaves the simulation closed with `.complete`, while an injected inspection panic leaves it failed without `.complete`.

Dispatch microbenchmark (Apple M5 Max / Go 1.27): five sequential 1-second samples per version of the same 10,000-event scheduling loop. Median ns/event: original base **23.23**, prior PR head `d797f4d1` **38.47**, current head **28.28**. Removing the serial locks/wake path reduces this benchmark's time by about **26.5%** versus the prior PR head; current time is about **5.05 ns/event (21.7%)** above the original base. The event allocation remains 48 B/event; pause coordination adds one 112-byte channel allocation per `Run` (one per 10,000 events in this benchmark). These measurements do not establish a full-model slowdown.

Closes #478.
