### PR TITLE
Clarify core error and panic contracts

### DIFF
--- a/doc/tutorial/events/01_first_program.md
+++ b/doc/tutorial/events/01_first_program.md
@@ -36,15 +36,15 @@ implements a single method:
 ```go
 type EventPrinter struct{}
 
-func (e *EventPrinter) Handle(event timing.Event) error {
+func (e *EventPrinter) Handle(event timing.Event) {
     fmt.Printf("Event: %d\n", event.Time())
-    return nil
 }
 ```
 
 When the engine fires an event, it looks up the registered handler by name
-and calls `Handle(event)`. Anything the handler returns as an error stops
-the simulation.
+and calls `Handle(event)`. A violated model invariant may panic. The engine
+contains that panic and returns a `*timing.PanicError` from `Run` or `RunUntil`;
+discard the failed engine and its model state. Check the returned error.
 
 ### 2. Building the simulation
 

--- a/doc/tutorial/events/02_many_events.md
+++ b/doc/tutorial/events/02_many_events.md
@@ -55,7 +55,7 @@ type handler struct {
     count int
 }
 
-func (h *handler) Handle(e timing.Event) error {
+func (h *handler) Handle(e timing.Event) {
     h.count += 1
 
     evt := e.(splitEvent)
@@ -64,8 +64,6 @@ func (h *handler) Handle(e timing.Event) error {
 
     h.scheduleNextSplitEvent(evt.Time(), evt.id)
     h.scheduleNextSplitEvent(evt.Time(), h.count)
-
-    return nil
 }
 ```
 

--- a/examples/01_print_event/main.go
+++ b/examples/01_print_event/main.go
@@ -10,10 +10,8 @@ import (
 type EventPrinter struct {
 }
 
-func (e *EventPrinter) Handle(event timing.Event) error {
+func (e *EventPrinter) Handle(event timing.Event) {
 	fmt.Printf("Event: %d\n", event.Time())
-
-	return nil
 }
 
 func main() {

--- a/examples/02_cell_split/main.go
+++ b/examples/02_cell_split/main.go
@@ -35,7 +35,7 @@ type handler struct {
 	count int
 }
 
-func (h *handler) Handle(e timing.Event) error {
+func (h *handler) Handle(e timing.Event) {
 	h.count += 1
 
 	evt := e.(splitEvent)
@@ -44,8 +44,6 @@ func (h *handler) Handle(e timing.Event) error {
 
 	h.scheduleNextSplitEvent(evt.Time(), evt.id)
 	h.scheduleNextSplitEvent(evt.Time(), h.count) // h.count is the new cell
-
-	return nil
 }
 
 func (h *handler) scheduleNextSplitEvent(now timing.VTimeInPicoSec, id int) {

--- a/examples/ping/example_test.go
+++ b/examples/ping/example_test.go
@@ -40,7 +40,9 @@ func Example_pingWithEvents() {
 	SchedulePing(agentA, 1, agentB.GetPortByName("Out").AsRemote())
 	SchedulePing(agentA, 3, agentB.GetPortByName("Out").AsRemote())
 
-	engine.Run()
+	if err := engine.Run(); err != nil {
+		panic(err)
+	}
 	// Output:
 	// Ping 0, 2000000000999 ps
 	// Ping 1, 2000000000997 ps

--- a/mem/README.md
+++ b/mem/README.md
@@ -48,8 +48,10 @@ storage := mem.NewStorage(4 * mem.GB)
 storage.Write(0x1000, []byte{0xDE, 0xAD})
 
 // Read data
-data, err := storage.Read(0x1000, 2)
+data := storage.Read(0x1000, 2)
 ```
+
+Empty, overflowing, or out-of-capacity ranges panic before allocation or mutation.
 
 A `Storage` can be registered with the simulation as shared state via
 `NewStorageResource(name, storage)`, making its contents reachable by name

--- a/mem/cache/writeback/bankstage.go
+++ b/mem/cache/writeback/bankstage.go
@@ -202,11 +202,8 @@ func (s *bankStage) finalizeReadHit(transIdx int, trans *transactionState) bool 
 	_, offset := getCacheLineID(addr, spec.Log2BlockSize)
 	nextBlock := &next.DirectoryState.Sets[trans.BlockSetID].Blocks[trans.BlockWayID]
 
-	data, err := s.cache.storage.Read(
+	data := s.cache.storage.Read(
 		nextBlock.CacheAddress+offset, trans.ReadAccessByteSize)
-	if err != nil {
-		panic(err)
-	}
 
 	trans.Removed = true
 
@@ -274,11 +271,8 @@ func (s *bankStage) writeData(
 	offset uint64,
 	log2BlockSize uint64,
 ) []bool {
-	data, err := s.cache.storage.Read(
+	data := s.cache.storage.Read(
 		block.CacheAddress, 1<<log2BlockSize)
-	if err != nil {
-		panic(err)
-	}
 
 	dirtyMask := block.DirtyMask
 	if dirtyMask == nil {
@@ -293,10 +287,7 @@ func (s *bankStage) writeData(
 		}
 	}
 
-	err = s.cache.storage.Write(block.CacheAddress, data)
-	if err != nil {
-		panic(err)
-	}
+	s.cache.storage.Write(block.CacheAddress, data)
 
 	return dirtyMask
 }
@@ -316,10 +307,7 @@ func (s *bankStage) finalizeBankWriteFetched(
 
 	mshrBuf.PushTyped(transIdx)
 
-	err := s.cache.storage.Write(nextBlock.CacheAddress, trans.MSHRData)
-	if err != nil {
-		panic(err)
-	}
+	s.cache.storage.Write(nextBlock.CacheAddress, trans.MSHRData)
 	nextBlock.IsLocked = false
 	nextBlock.IsValid = true
 
@@ -342,11 +330,8 @@ func (s *bankStage) finalizeBankEviction(
 		return false
 	}
 
-	data, err := s.cache.storage.Read(
+	data := s.cache.storage.Read(
 		trans.VictimCacheAddress, 1<<spec.Log2BlockSize)
-	if err != nil {
-		panic(err)
-	}
 
 	trans.EvictingData = data
 

--- a/mem/cache/writeback/bankstage_test.go
+++ b/mem/cache/writeback/bankstage_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Bank Stage", func() {
 			ret := bs.Tick()
 
 			Expect(ret).To(BeTrue())
-			data, _ := storage.Read(0x44, 4)
+			data := storage.Read(0x44, 4)
 			Expect(data).To(Equal([]byte{5, 6, 7, 8}))
 			next := &m.comp.State
 			block := &next.DirectoryState.Sets[0].Blocks[0]
@@ -252,7 +252,7 @@ var _ = Describe("Bank Stage", func() {
 
 			Expect(ret).To(BeTrue())
 			next := &m.comp.State
-			writtenData, _ := storage.Read(0x40, 64)
+			writtenData := storage.Read(0x40, 64)
 			Expect(writtenData).To(Equal(next.Transactions[0].MSHRData))
 			block := &next.DirectoryState.Sets[0].Blocks[0]
 			Expect(block.IsLocked).To(BeFalse())

--- a/mem/cache/writeback/control_behavior_test.go
+++ b/mem/cache/writeback/control_behavior_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Write-Back Cache control behavior", func() {
 		for i := range data {
 			data[i] = fill
 		}
-		Expect(storage.Write(block.CacheAddress, data)).To(Succeed())
+		storage.Write(block.CacheAddress, data)
 
 		return setID
 	}

--- a/mem/cache/writeback/milestone_test.go
+++ b/mem/cache/writeback/milestone_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Write-Back Cache milestones", func() {
 			read.TrafficClass = "memprotocol.ReadReq"
 			topPort.Deliver(read)
 
-			engine.Run()
+			Expect(engine.Run()).To(Succeed())
 
 			rsp := agentPort.RetrieveIncoming()
 			dr := rsp.(memprotocol.DataReadyRsp)
@@ -224,7 +224,7 @@ var _ = Describe("Write-Back Cache milestones", func() {
 			read.TrafficClass = "memprotocol.ReadReq"
 			topPort.Deliver(read)
 
-			engine.Run()
+			Expect(engine.Run()).To(Succeed())
 
 			// Drive the read miss all the way through the downstream fetch
 			// response: the agent must have received the data.

--- a/mem/cache/writeback/writebackcache_test.go
+++ b/mem/cache/writeback/writebackcache_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		read.TrafficClass = "memprotocol.ReadReq"
 		cacheComp.GetPortByName("Top").Deliver(read)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsp := agentPort.RetrieveIncoming()
 		dr := rsp.(memprotocol.DataReadyRsp)
@@ -171,7 +171,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		write.TrafficClass = "memprotocol.WriteReq"
 		cacheComp.GetPortByName("Top").Deliver(write)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsp := agentPort.RetrieveIncoming()
 		Expect(rsp.Meta().RspTo).To(Equal(write.ID))
@@ -179,7 +179,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		// Re-read state after engine run
 		postState := m.comp.State
 		postBlock := &postState.DirectoryState.Sets[setID].Blocks[0]
-		retData, _ := m.storage.Read(postBlock.CacheAddress+0x4, 4)
+		retData := m.storage.Read(postBlock.CacheAddress+0x4, 4)
 		Expect(retData).To(Equal(write.Data))
 		Expect(postBlock.IsValid).To(BeTrue())
 		Expect(postBlock.IsDirty).To(BeTrue())
@@ -207,7 +207,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		read.TrafficClass = "memprotocol.ReadReq"
 		cacheComp.GetPortByName("Top").Deliver(read)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsp := agentPort.RetrieveIncoming()
 		dr := rsp.(memprotocol.DataReadyRsp)
@@ -247,7 +247,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		read2.TrafficClass = "memprotocol.ReadReq"
 		cacheComp.GetPortByName("Top").Deliver(read2)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsps := map[uint64][]byte{}
 		for i := 0; i < 2; i++ {
@@ -291,7 +291,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		read.TrafficClass = "memprotocol.ReadReq"
 		cacheComp.GetPortByName("Top").Deliver(read)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsps := map[uint64]messaging.Msg{}
 		for i := 0; i < 2; i++ {
@@ -338,7 +338,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		read.TrafficClass = "memprotocol.ReadReq"
 		cacheComp.GetPortByName("Top").Deliver(read)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsp := agentPort.RetrieveIncoming()
 		dr := rsp.(memprotocol.DataReadyRsp)
@@ -368,7 +368,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		cacheComp.GetPortByName("Top").Deliver(write2)
 
 		// Let the writes settle so the block is resident and dirty.
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 		Expect(controlAgentPort.RetrieveIncoming()).To(BeNil())
 
 		// Flush is a conditional verb: pause first so it is legal.
@@ -379,7 +379,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		pause.TrafficClass = "memcontrolprotocol.Req"
 		cacheComp.GetPortByName("Control").Deliver(pause)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		pauseRsp := controlAgentPort.RetrieveIncoming()
 		Expect(pauseRsp).NotTo(BeNil())
@@ -393,7 +393,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		flush.TrafficClass = "memcontrolprotocol.Req"
 		cacheComp.GetPortByName("Control").Deliver(flush)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsp := controlAgentPort.RetrieveIncoming()
 		Expect(rsp).NotTo(BeNil())
@@ -401,8 +401,7 @@ var _ = Describe("Write-Back Cache Integration", func() {
 		Expect(rsp.(memcontrolprotocol.Rsp).Success).To(BeTrue())
 
 		// The dirty block's data reached DRAM.
-		flushed, err := dramStorage.Read(0x100000, 4)
-		Expect(err).ToNot(HaveOccurred())
+		flushed := dramStorage.Read(0x100000, 4)
 		Expect(flushed).To(Equal([]byte{1, 2, 3, 4}))
 	})
 })

--- a/mem/cache/writethroughcache/bankstage.go
+++ b/mem/cache/writethroughcache/bankstage.go
@@ -105,11 +105,8 @@ func (s *bankStage) finalizeReadHitTrans(
 	nextBlock := &next.DirectoryState.Sets[trans.BlockSetID].Blocks[trans.BlockWayID]
 	blockSize := uint64(1 << s.cache.comp.Spec().Log2BlockSize)
 
-	data, err := s.cache.storage.Read(
+	data := s.cache.storage.Read(
 		nextBlock.CacheAddress, blockSize)
-	if err != nil {
-		panic(err)
-	}
 
 	nextBlock.ReadCount--
 
@@ -132,10 +129,7 @@ func (s *bankStage) finalizeWriteTrans(
 	nextBlock := &next.DirectoryState.Sets[trans.BlockSetID].Blocks[trans.BlockWayID]
 	blockSize := 1 << s.cache.comp.Spec().Log2BlockSize
 
-	data, err := s.cache.storage.Read(nextBlock.CacheAddress, uint64(blockSize))
-	if err != nil {
-		panic(err)
-	}
+	data := s.cache.storage.Read(nextBlock.CacheAddress, uint64(blockSize))
 
 	offset := trans.WriteAddress - nextBlock.Tag
 
@@ -145,10 +139,7 @@ func (s *bankStage) finalizeWriteTrans(
 		}
 	}
 
-	err = s.cache.storage.Write(nextBlock.CacheAddress, data)
-	if err != nil {
-		panic(err)
-	}
+	s.cache.storage.Write(nextBlock.CacheAddress, data)
 
 	nextBlock.DirtyMask = trans.WriteDirtyMask
 	nextBlock.IsLocked = false
@@ -172,10 +163,7 @@ func (s *bankStage) finalizeWriteFetchedTrans(
 	next := &s.cache.comp.State
 	nextBlock := &next.DirectoryState.Sets[trans.BlockSetID].Blocks[trans.BlockWayID]
 
-	err := s.cache.storage.Write(nextBlock.CacheAddress, trans.Data)
-	if err != nil {
-		panic(err)
-	}
+	s.cache.storage.Write(nextBlock.CacheAddress, trans.Data)
 
 	nextBlock.DirtyMask = trans.WriteFetchedDirtyMask
 	nextBlock.IsLocked = false

--- a/mem/cache/writethroughcache/bankstage_test.go
+++ b/mem/cache/writethroughcache/bankstage_test.go
@@ -219,7 +219,7 @@ var _ = Describe("Bankstage", func() {
 
 			Expect(madeProgress).To(BeTrue())
 			Expect(next.DirectoryState.Sets[blockSetID].Blocks[blockWayID].IsLocked).To(BeFalse())
-			data, _ := storage.Read(0x400, 64)
+			data := storage.Read(0x400, 64)
 			Expect(data).To(Equal([]byte{
 				0, 0, 0, 0, 0, 0, 0, 0,
 				1, 2, 3, 4, 5, 6, 7, 8,
@@ -283,7 +283,7 @@ var _ = Describe("Bankstage", func() {
 			Expect(madeProgress).To(BeTrue())
 			Expect(next.DirectoryState.Sets[blockSetID].Blocks[blockWayID].IsLocked).To(BeFalse())
 			trans := &next.Transactions[0]
-			data, _ := storage.Read(0x400, 64)
+			data := storage.Read(0x400, 64)
 			Expect(data).To(Equal(trans.Data))
 		})
 

--- a/mem/cache/writethroughcache/cache_test.go
+++ b/mem/cache/writethroughcache/cache_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Cache", func() {
 		read.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(read)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsps := drainResponses()
 		Expect(rsps).To(HaveLen(1))
@@ -133,7 +133,7 @@ var _ = Describe("Cache", func() {
 		read2.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(read2)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		// Without coalescing, the MSHR-hit transaction (read2) may be
 		// finalized before the fetcher (read1). Accept responses in
@@ -163,7 +163,7 @@ var _ = Describe("Cache", func() {
 		read1.TrafficBytes = 12
 		read1.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(read1)
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 		t1 := engine.CurrentTime()
 
 		rsps := drainResponses()
@@ -179,7 +179,7 @@ var _ = Describe("Cache", func() {
 		read2.TrafficBytes = 12
 		read2.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(read2)
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 		t2 := engine.CurrentTime()
 
 		rsps = drainResponses()
@@ -200,13 +200,13 @@ var _ = Describe("Cache", func() {
 		write.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(write)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsps := drainResponses()
 		Expect(rsps).To(HaveLen(1))
 		Expect(rsps[0].Meta().RspTo).To(Equal(write.ID))
 
-		data, _ := dramStorage.Read(0x100, 4)
+		data := dramStorage.Read(0x100, 4)
 		Expect(data).To(Equal([]byte{1, 2, 3, 4}))
 	})
 
@@ -229,13 +229,13 @@ var _ = Describe("Cache", func() {
 		write.TrafficBytes = 64 + 12
 		write.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(write)
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsps := drainResponses()
 		Expect(rsps).To(HaveLen(1))
 		Expect(rsps[0].Meta().RspTo).To(Equal(write.ID))
 
-		data, _ := dramStorage.Read(0x100, 4)
+		data := dramStorage.Read(0x100, 4)
 		Expect(data).To(Equal([]byte{1, 2, 3, 4}))
 	})
 

--- a/mem/cache/writethroughcache/milestone_test.go
+++ b/mem/cache/writethroughcache/milestone_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Cache milestones", func() {
 		read.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(read)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsps := drainResponses()
 		Expect(rsps).To(HaveLen(1))
@@ -220,7 +220,7 @@ var _ = Describe("Cache milestones", func() {
 
 		// Run to quiescence: the read miss fetches from the lower memory and the
 		// DataReadyRsp comes back, filling the line and completing the request.
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsps := drainResponses()
 		Expect(rsps).To(HaveLen(1))
@@ -267,7 +267,7 @@ var _ = Describe("Cache milestones", func() {
 		warm.TrafficBytes = 64 + 12
 		warm.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(warm)
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 		Expect(drainResponses()).To(HaveLen(1))
 
 		// Discard the warm write's trace events so the assertions below see only
@@ -285,7 +285,7 @@ var _ = Describe("Cache milestones", func() {
 		hit.TrafficBytes = 4 + 12
 		hit.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(hit)
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 		Expect(drainResponses()).To(HaveLen(1))
 
 		// The req_in is now the cache's single task for the request, so the
@@ -339,7 +339,7 @@ var _ = Describe("Cache milestones", func() {
 		miss.TrafficBytes = 64 + 12
 		miss.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(miss)
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 		Expect(drainResponses()).To(HaveLen(1))
 
 		reqInStart, ok := rec.firstStart("req_in")
@@ -377,7 +377,7 @@ var _ = Describe("Cache milestones", func() {
 		w.TrafficBytes = 64 + 12
 		w.TrafficClass = "req"
 		c.GetPortByName("Top").Deliver(w)
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 		Expect(drainResponses()).To(HaveLen(1))
 
 		reqInStart, ok := rec.firstStart("req_in")

--- a/mem/datamover/datamoving_test.go
+++ b/mem/datamover/datamoving_test.go
@@ -119,7 +119,7 @@ var _ = Describe("DataMover", func() {
 
 		dataMover.GetPortByName("Top").Deliver(req)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		Expect(insideStorage.Read(0, 4096)).To(Equal(data))
 		Expect(srcPort.RetrieveIncoming()).To(
@@ -150,7 +150,7 @@ var _ = Describe("DataMover", func() {
 
 		dataMover.GetPortByName("Top").Deliver(req)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		Expect(insideStorage.Read(8192, 2048)).To(Equal(data))
 		Expect(srcPort.RetrieveIncoming()).To(
@@ -177,7 +177,7 @@ var _ = Describe("DataMover", func() {
 
 		dataMover.GetPortByName("Top").Deliver(req)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		Expect(insideStorage.Read(0, 4096)).To(Equal(data))
 		Expect(srcPort.RetrieveIncoming()).To(
@@ -204,7 +204,7 @@ var _ = Describe("DataMover", func() {
 
 		dataMover.GetPortByName("Top").Deliver(req)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		Expect(outsideStorage.Read(4096, 4096)).To(Equal(data))
 		Expect(srcPort.RetrieveIncoming()).To(
@@ -231,7 +231,7 @@ var _ = Describe("DataMover", func() {
 
 		dataMover.GetPortByName("Top").Deliver(req)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		expected := data[:512]
 		Expect(insideStorage.Read(512, 512)).To(Equal(expected))
@@ -276,7 +276,7 @@ var _ = Describe("DataMover", func() {
 
 		dataMover.GetPortByName("Top").Deliver(req)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		expected := append(data[:512], data[:512]...)
 		Expect(insideStorage.Read(0, 1024)).To(Equal(expected))

--- a/mem/datamover/milestone_test.go
+++ b/mem/datamover/milestone_test.go
@@ -188,7 +188,7 @@ var _ = Describe("DataMover milestones", func() {
 
 		topPort.Deliver(req)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		// The move completed end-to-end.
 		Expect(insideStorage.Read(0, 4096)).To(Equal(data))
@@ -239,7 +239,7 @@ var _ = Describe("DataMover milestones", func() {
 
 		topPort.Deliver(req)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		// The move completed end-to-end, so reads and writes were issued and
 		// acknowledged.
@@ -301,7 +301,7 @@ var _ = Describe("DataMover milestones", func() {
 		topPort.Deliver(req1)
 		topPort.Deliver(req2)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		// Both transactions completed: two responses come back to the source.
 		Expect(srcPort.RetrieveIncoming()).To(

--- a/mem/dram/memcontroller_test.go
+++ b/mem/dram/memcontroller_test.go
@@ -239,7 +239,7 @@ var _ = Describe("DRAM Integration", func() {
 		srcPort.Send(write)
 		srcPort.Send(read)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		// Collect responses
 		var writeDone memprotocol.WriteDoneRsp

--- a/mem/dram/p0_regression_test.go
+++ b/mem/dram/p0_regression_test.go
@@ -119,7 +119,7 @@ var _ = Describe("P0: open-page panic regression", func() {
 		h.src.Send(h.read(0x40))
 		h.src.Send(h.read(0x80))
 
-		Expect(func() { h.engine.Run() }).NotTo(Panic())
+		Expect(h.engine.Run()).To(Succeed())
 
 		reads, _ := h.collect()
 		Expect(reads).To(HaveLen(2))
@@ -133,7 +133,7 @@ var _ = Describe("P0: open-page panic regression", func() {
 		h.src.Send(h.read(0x0))
 		h.src.Send(h.read(0x20000))
 
-		Expect(func() { h.engine.Run() }).NotTo(Panic())
+		Expect(h.engine.Run()).To(Succeed())
 
 		reads, _ := h.collect()
 		Expect(reads).To(HaveLen(2))
@@ -150,7 +150,7 @@ var _ = Describe("P0: open-page panic regression", func() {
 			h.src.Send(h.read(uint64(i) * 64))
 		}
 
-		Expect(func() { h.engine.Run() }).NotTo(Panic())
+		Expect(h.engine.Run()).To(Succeed())
 
 		reads, _ := h.collect()
 		Expect(reads).To(HaveLen(n))
@@ -163,12 +163,12 @@ var _ = Describe("P0: open-page panic regression", func() {
 
 		// Drive the write to completion first so the read observes it.
 		h.src.Send(h.write(0x40, data))
-		h.engine.Run()
+		Expect(h.engine.Run()).To(Succeed())
 		_, writes := h.collect()
 		Expect(writes).To(HaveLen(1))
 
 		h.src.Send(h.read(0x40))
-		h.engine.Run()
+		Expect(h.engine.Run()).To(Succeed())
 		reads, _ := h.collect()
 		Expect(reads).To(HaveLen(1))
 		Expect(reads[0].Data[:len(data)]).To(Equal(data))

--- a/mem/dram/plugins_test.go
+++ b/mem/dram/plugins_test.go
@@ -70,16 +70,16 @@ var _ = Describe("P1: command tracing", func() {
 		// Same workload, with and without the tracer.
 		traced := newP0Harness(spec, tracer)
 		traced.src.Send(traced.write(0x40, []byte{1, 2, 3, 4}))
-		traced.engine.Run()
+		Expect(traced.engine.Run()).To(Succeed())
 		traced.src.Send(traced.read(0x40))
-		traced.engine.Run()
+		Expect(traced.engine.Run()).To(Succeed())
 		tracedReads, tracedWrites := traced.collect()
 
 		plain := newP0Harness(spec)
 		plain.src.Send(plain.write(0x40, []byte{1, 2, 3, 4}))
-		plain.engine.Run()
+		Expect(plain.engine.Run()).To(Succeed())
 		plain.src.Send(plain.read(0x40))
-		plain.engine.Run()
+		Expect(plain.engine.Run()).To(Succeed())
 		plainReads, plainWrites := plain.collect()
 
 		// The tracer saw sub-transaction tasks and command milestones (at least

--- a/mem/dram/respondmw.go
+++ b/mem/dram/respondmw.go
@@ -74,11 +74,8 @@ func (m *respondMW) finalizeWriteTrans(
 	t *transactionState,
 	i int,
 ) bool {
-	err := m.comp.Resources().Storage.Write(
+	m.comp.Resources().Storage.Write(
 		transactionGlobalAddress(t), t.WriteMsg.Data)
-	if err != nil {
-		panic(err)
-	}
 
 	writeDone := memprotocol.WriteDoneRsp{}
 	writeDone.ID = timing.GetIDGenerator().Generate()
@@ -105,11 +102,8 @@ func (m *respondMW) finalizeReadTrans(
 	t *transactionState,
 	i int,
 ) bool {
-	data, err := m.comp.Resources().Storage.Read(
+	data := m.comp.Resources().Storage.Read(
 		transactionGlobalAddress(t), t.ReadMsg.AccessByteSize)
-	if err != nil {
-		panic(err)
-	}
 
 	dataReady := memprotocol.DataReadyRsp{}
 	dataReady.ID = timing.GetIDGenerator().Generate()

--- a/mem/dram/stats_test.go
+++ b/mem/dram/stats_test.go
@@ -125,7 +125,7 @@ var _ = Describe("DRAM Statistics", func() {
 		read.TrafficClass = "memprotocol.ReadReq"
 		srcPort.Send(read)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		state := &dramComp.State
 		Expect(state.CompletedReads).To(BeNumerically(">=", 1))

--- a/mem/dram/validation_tier5_test.go
+++ b/mem/dram/validation_tier5_test.go
@@ -105,7 +105,7 @@ func runAkita(scn tier5Scenario) akitaResult {
 			h.src.Send(h.read(op[1]))
 		}
 	}
-	h.engine.Run()
+	Expect(h.engine.Run()).To(Succeed())
 
 	st := &h.dram.State
 	lat := math.NaN()

--- a/mem/idealmemcontroller/checkpoint_test.go
+++ b/mem/idealmemcontroller/checkpoint_test.go
@@ -33,9 +33,7 @@ func TestCheckpointRoundTrip(t *testing.T) {
 		Build("DRAM")
 
 	storage := dram.Resources().Storage
-	if err := storage.Write(0x40, []byte(payload)); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	storage.Write(0x40, []byte(payload))
 	dram.State.CurrentCmdID = 7
 
 	if err := sim.SaveCheckpoint(path, buildID); err != nil {
@@ -43,19 +41,14 @@ func TestCheckpointRoundTrip(t *testing.T) {
 	}
 
 	// Mutate the resource and the component state away from the checkpoint.
-	if err := storage.Write(0x40, make([]byte, len(payload))); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	storage.Write(0x40, make([]byte, len(payload)))
 	dram.State.CurrentCmdID = 99
 
 	if err := sim.LoadCheckpoint(path, buildID); err != nil {
 		t.Fatalf("LoadCheckpoint: %v", err)
 	}
 
-	got, err := storage.Read(0x40, uint64(len(payload)))
-	if err != nil {
-		t.Fatalf("Read: %v", err)
-	}
+	got := storage.Read(0x40, uint64(len(payload)))
 	if string(got) != payload {
 		t.Fatalf("storage = %q, want %q", got, payload)
 	}

--- a/mem/idealmemcontroller/idealmemcontroller_test.go
+++ b/mem/idealmemcontroller/idealmemcontroller_test.go
@@ -164,8 +164,7 @@ var _ = Describe("Ideal Memory Controller", func() {
 		Expect(rsp).To(BeAssignableToTypeOf(memprotocol.WriteDoneRsp{}))
 
 		// Verify data was written to storage
-		data, err := storage.Read(0, 4)
-		Expect(err).ToNot(HaveOccurred())
+		data := storage.Read(0, 4)
 		Expect(data).To(Equal([]byte{0, 1, 2, 3}))
 	})
 
@@ -212,8 +211,7 @@ var _ = Describe("Ideal Memory Controller", func() {
 
 	It("should write with dirty mask", func() {
 		// Pre-write data
-		err := storage.Write(0, []byte{10, 20, 30, 40})
-		Expect(err).ToNot(HaveOccurred())
+		storage.Write(0, []byte{10, 20, 30, 40})
 
 		writeReq := memprotocol.WriteReq{}
 		writeReq.ID = timing.GetIDGenerator().Generate()
@@ -238,8 +236,7 @@ var _ = Describe("Ideal Memory Controller", func() {
 		memController.Tick()
 
 		// Check that only dirty bytes were written
-		data, err := storage.Read(0, 4)
-		Expect(err).ToNot(HaveOccurred())
+		data := storage.Read(0, 4)
 		Expect(data).To(Equal([]byte{10, 20, 2, 40}))
 	})
 

--- a/mem/idealmemcontroller/memmiddleware.go
+++ b/mem/idealmemcontroller/memmiddleware.go
@@ -131,10 +131,7 @@ func (m *memMiddleware) sendResponse(tx *inflightTransaction) bool {
 }
 
 func (m *memMiddleware) sendReadResponse(tx *inflightTransaction) bool {
-	data, err := m.comp.Resources().Storage.Read(tx.Address, tx.AccessByteSize)
-	if err != nil {
-		log.Panic(err)
-	}
+	data := m.comp.Resources().Storage.Read(tx.Address, tx.AccessByteSize)
 
 	rsp := memprotocol.DataReadyRsp{}
 	rsp.ID = timing.GetIDGenerator().Generate()
@@ -174,15 +171,9 @@ func (m *memMiddleware) sendWriteResponse(tx *inflightTransaction) bool {
 	addr := tx.Address
 
 	if tx.DirtyMask == nil {
-		err := m.comp.Resources().Storage.Write(addr, tx.Data)
-		if err != nil {
-			log.Panic(err)
-		}
+		m.comp.Resources().Storage.Write(addr, tx.Data)
 	} else {
-		data, err := m.comp.Resources().Storage.Read(addr, uint64(len(tx.Data)))
-		if err != nil {
-			panic(err)
-		}
+		data := m.comp.Resources().Storage.Read(addr, uint64(len(tx.Data)))
 
 		for i := 0; i < len(tx.Data); i++ {
 			if tx.DirtyMask[i] {
@@ -190,10 +181,7 @@ func (m *memMiddleware) sendWriteResponse(tx *inflightTransaction) bool {
 			}
 		}
 
-		err = m.comp.Resources().Storage.Write(addr, data)
-		if err != nil {
-			panic(err)
-		}
+		m.comp.Resources().Storage.Write(addr, data)
 	}
 
 	m.traceReqComplete(tx.RecvTaskID, tx.ReqID)

--- a/mem/memcontrolprotocol/checkpoint_test.go
+++ b/mem/memcontrolprotocol/checkpoint_test.go
@@ -222,10 +222,7 @@ func TestCheckpoint_DrainFlushReset_PersistsAndServesCorrectData(t *testing.T) {
 	// Guarantee 1: after Drain+Flush the backing memory is a complete,
 	// correct snapshot of everything written.
 	for addr, data := range want {
-		got, err := h.dramStorage.Read(addr, uint64(len(data)))
-		if err != nil {
-			t.Fatalf("backing read %#x: %v", addr, err)
-		}
+		got := h.dramStorage.Read(addr, uint64(len(data)))
 		if !bytes.Equal(got, data) {
 			t.Errorf("after Flush, backing memory[%#x] = %v, want %v",
 				addr, got, data)

--- a/mem/memcontrolprotocol/sequence_test.go
+++ b/mem/memcontrolprotocol/sequence_test.go
@@ -413,9 +413,7 @@ func installDirtyBlock(
 	for i := range data {
 		data[i] = fill
 	}
-	if err := storage.Write(block.CacheAddress, data); err != nil {
-		t.Fatalf("seed storage: %v", err)
-	}
+	storage.Write(block.CacheAddress, data)
 
 	return setID
 }

--- a/mem/simplebankedmemory/milestone_test.go
+++ b/mem/simplebankedmemory/milestone_test.go
@@ -210,7 +210,7 @@ var _ = Describe("SimpleBankedMemory pipeline-traversal milestones", func() {
 	It("attributes the bank-pipeline traversal as work on the read "+
 		"req_in", func() {
 		data := []byte{1, 2, 3, 4}
-		Expect(storage.Write(0x40, data)).To(Succeed())
+		storage.Write(0x40, data)
 
 		read := memprotocol.ReadReq{Address: 0x40, AccessByteSize: 4}
 		read.ID = timing.GetIDGenerator().Generate()

--- a/mem/simplebankedmemory/simplebankedmemory_test.go
+++ b/mem/simplebankedmemory/simplebankedmemory_test.go
@@ -135,8 +135,8 @@ func (a *testAgent) NotifyPortFree(messaging.Port) {
 	// No-op.
 }
 
-func (a *testAgent) Handle(timing.Event) error {
-	return nil
+func (a *testAgent) Handle(timing.Event) {
+	return
 }
 
 func (a *testAgent) send(msg messaging.Msg) {
@@ -189,8 +189,8 @@ func (a *bandwidthAgent) NotifyRecv(port messaging.Port) {
 
 func (a *bandwidthAgent) NotifyPortFree(messaging.Port) {}
 
-func (a *bandwidthAgent) Handle(timing.Event) error {
-	return nil
+func (a *bandwidthAgent) Handle(timing.Event) {
+	return
 }
 
 const (
@@ -297,8 +297,7 @@ var _ = Describe("SimpleBankedMemory", func() {
 
 	It("should return read data after configured latency", func() {
 		data := []byte{1, 2, 3, 4}
-		err := storage.Write(0x0, data)
-		Expect(err).NotTo(HaveOccurred())
+		storage.Write(0x0, data)
 
 		topPort := memComp.GetPortByName("Top")
 		read := memprotocol.ReadReq{}
@@ -325,8 +324,7 @@ var _ = Describe("SimpleBankedMemory", func() {
 		addr := uint64(0x100)
 
 		initial := []byte{0xAA, 0xBB, 0xCC, 0xDD}
-		err := storage.Write(addr, initial)
-		Expect(err).NotTo(HaveOccurred())
+		storage.Write(addr, initial)
 
 		newData := []byte{0x10, 0x20, 0x30, 0x40}
 
@@ -366,8 +364,7 @@ var _ = Describe("SimpleBankedMemory", func() {
 		Expect(ok).To(BeTrue())
 		Expect(readRsp.Data).To(Equal(newData))
 
-		committed, err := storage.Read(addr, uint64(len(newData)))
-		Expect(err).NotTo(HaveOccurred())
+		committed := storage.Read(addr, uint64(len(newData)))
 		Expect(committed).To(Equal(newData))
 	})
 

--- a/mem/simplebankedmemory/tickfinalizemw.go
+++ b/mem/simplebankedmemory/tickfinalizemw.go
@@ -1,8 +1,6 @@
 package simplebankedmemory
 
 import (
-	"log"
-
 	"github.com/sarchlab/akita/v5/mem/memcontrolprotocol"
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/modeling"
@@ -67,11 +65,8 @@ func (m *tickFinalizeMW) finalizeRead(
 	readReq := &item.ReadMsg
 
 	if !item.Committed {
-		data, err := m.comp.Resources().Storage.Read(
+		data := m.comp.Resources().Storage.Read(
 			readReq.Address, readReq.AccessByteSize)
-		if err != nil {
-			log.Panic(err)
-		}
 
 		item.ReadData = data
 		item.Committed = true
@@ -119,14 +114,9 @@ func (m *tickFinalizeMW) finalizeWrite(
 		addr := writeReq.Address
 
 		if writeReq.DirtyMask == nil {
-			if err := m.comp.Resources().Storage.Write(addr, writeReq.Data); err != nil {
-				log.Panic(err)
-			}
+			m.comp.Resources().Storage.Write(addr, writeReq.Data)
 		} else {
-			data, err := m.comp.Resources().Storage.Read(addr, uint64(len(writeReq.Data)))
-			if err != nil {
-				log.Panic(err)
-			}
+			data := m.comp.Resources().Storage.Read(addr, uint64(len(writeReq.Data)))
 
 			for i := range writeReq.Data {
 				if writeReq.DirtyMask[i] {
@@ -134,9 +124,7 @@ func (m *tickFinalizeMW) finalizeWrite(
 				}
 			}
 
-			if err := m.comp.Resources().Storage.Write(addr, data); err != nil {
-				log.Panic(err)
-			}
+			m.comp.Resources().Storage.Write(addr, data)
 		}
 
 		item.Committed = true

--- a/mem/storage.go
+++ b/mem/storage.go
@@ -1,7 +1,6 @@
 package mem
 
 import (
-	"errors"
 	"sync"
 )
 
@@ -99,25 +98,21 @@ func (s *Storage) parseAddress(addr uint64) (baseAddr, inUnitAddr uint64) {
 	return
 }
 
-func (s *Storage) validateRange(address, length uint64) error {
+func (s *Storage) validateRange(address, length uint64) {
 	if length == 0 {
-		return errors.New("storage access length must be greater than zero")
+		panic("storage access length must be greater than zero")
 	}
 	// Subtraction avoids overflowing address + length.
 	if address > s.capacity || length > s.capacity-address {
-		return errors.New("accessing physical address beyond the storage capacity")
+		panic("accessing physical address beyond the storage capacity")
 	}
-
-	return nil
 }
 
-// Read returns length bytes starting at address. It returns an error for an
+// Read returns length bytes starting at address. It panics for an
 // empty range or a range extending beyond capacity, before allocating data or
 // storage units. A nonempty range may end exactly at capacity.
-func (s *Storage) Read(address uint64, length uint64) ([]byte, error) {
-	if err := s.validateRange(address, length); err != nil {
-		return nil, err
-	}
+func (s *Storage) Read(address uint64, length uint64) []byte {
+	s.validateRange(address, length)
 
 	currAddr := address
 	lenLeft := length
@@ -145,16 +140,14 @@ func (s *Storage) Read(address uint64, length uint64) ([]byte, error) {
 		currAddr += lenToRead
 	}
 
-	return res, nil
+	return res
 }
 
-// Write stores data starting at address. It returns an error for empty data or
+// Write stores data starting at address. It panics for empty data or
 // a range extending beyond capacity, without allocating storage units or
 // changing stored bytes. A nonempty range may end exactly at capacity.
-func (s *Storage) Write(address uint64, data []byte) error {
-	if err := s.validateRange(address, uint64(len(data))); err != nil {
-		return err
-	}
+func (s *Storage) Write(address uint64, data []byte) {
+	s.validateRange(address, uint64(len(data)))
 
 	currAddr := address
 	dataOffset := uint64(0)
@@ -179,6 +172,4 @@ func (s *Storage) Write(address uint64, data []byte) error {
 		dataOffset += lenToWrite
 		currAddr += lenToWrite
 	}
-
-	return nil
 }

--- a/mem/storage_checkpoint_test.go
+++ b/mem/storage_checkpoint_test.go
@@ -10,13 +10,9 @@ import (
 
 func TestStorageCheckpointRoundTrip(t *testing.T) {
 	src := mem.NewStorage(1 * mem.MB)
-	if err := src.Write(0, []byte{1, 2, 3, 4}); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	src.Write(0, []byte{1, 2, 3, 4})
 	// A second write in a different allocation unit (default unit size 4 KB).
-	if err := src.Write(64*mem.KB, []byte{9, 9, 9}); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	src.Write(64*mem.KB, []byte{9, 9, 9})
 
 	var buf bytes.Buffer
 	if err := src.SaveCheckpoint(&buf); err != nil {
@@ -28,16 +24,16 @@ func TestStorageCheckpointRoundTrip(t *testing.T) {
 		t.Fatalf("LoadCheckpoint: %v", err)
 	}
 
-	got, _ := dst.Read(0, 4)
+	got := dst.Read(0, 4)
 	if !bytes.Equal(got, []byte{1, 2, 3, 4}) {
 		t.Fatalf("Read(0,4) = %v, want [1 2 3 4]", got)
 	}
-	got, _ = dst.Read(64*mem.KB, 3)
+	got = dst.Read(64*mem.KB, 3)
 	if !bytes.Equal(got, []byte{9, 9, 9}) {
 		t.Fatalf("Read(64KB,3) = %v, want [9 9 9]", got)
 	}
 	// An untouched region restores as zeros.
-	got, _ = dst.Read(4, 4)
+	got = dst.Read(4, 4)
 	if !bytes.Equal(got, []byte{0, 0, 0, 0}) {
 		t.Fatalf("untouched Read = %v, want zeros", got)
 	}

--- a/mem/storage_panic_test.go
+++ b/mem/storage_panic_test.go
@@ -1,0 +1,35 @@
+package mem_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/timing"
+)
+
+type storagePanicHandler func(timing.Event)
+
+func (h storagePanicHandler) Handle(evt timing.Event) { h(evt) }
+
+func TestStoragePreconditionPanicBecomesRunError(t *testing.T) {
+	for _, operation := range []string{"read", "write"} {
+		t.Run(operation, func(t *testing.T) {
+			e := timing.NewSerialEngine()
+			storage := mem.NewStorage(16)
+			e.RegisterHandler("memory", storagePanicHandler(func(timing.Event) {
+				if operation == "read" {
+					storage.Read(16, 1)
+				} else {
+					storage.Write(16, []byte{1})
+				}
+			}))
+			e.Schedule(timing.EventBase{Time_: 1, HandlerID_: "memory"})
+			var failure *timing.PanicError
+			if err := e.Run(); !errors.As(err, &failure) || failure.Handler != "memory" || failure.Time != 1 {
+				t.Fatalf("storage panic escaped its owning engine: %v", err)
+			}
+			t.Logf("invalid storage %s returned a PanicError from Run at memory event time 1", operation)
+		})
+	}
+}

--- a/mem/storage_range_test.go
+++ b/mem/storage_range_test.go
@@ -46,25 +46,16 @@ func testInvalidStorageRange(t *testing.T, capacity, address, length uint64, ope
 	s := NewStorageWithUnitSize(capacity, 4)
 	original := []byte{1, 2, 3, 4}
 	if capacity >= 4 {
-		if err := s.Write(0, original); err != nil {
-			t.Fatal(err)
-		}
+		s.Write(0, original)
 	}
 	unitsBefore := len(s.data)
-
-	var err error
-	if operation == "read" {
-		var data []byte
-		data, err = s.Read(address, length)
-		if err != nil && data != nil {
-			t.Errorf("rejected read returned data: %v", data)
+	mustPanicStorage(t, func() {
+		if operation == "read" {
+			s.Read(address, length)
+		} else {
+			s.Write(address, make([]byte, length))
 		}
-	} else {
-		err = s.Write(address, make([]byte, length))
-	}
-	if err == nil {
-		t.Error("invalid range succeeded")
-	}
+	})
 	if len(s.data) != unitsBefore {
 		t.Errorf("invalid range allocated units: %d -> %d", unitsBefore, len(s.data))
 	}
@@ -75,10 +66,7 @@ func testInvalidStorageRange(t *testing.T, capacity, address, length uint64, ope
 
 func TestStorageRejectsHugeReadBeforeAllocation(t *testing.T) {
 	s := NewStorageWithUnitSize(10, 4)
-	data, err := s.Read(1, math.MaxUint64)
-	if err == nil || data != nil {
-		t.Fatalf("huge out-of-range read returned (%v, %v)", data, err)
-	}
+	mustPanicStorage(t, func() { s.Read(1, math.MaxUint64) })
 	if len(s.data) != 0 {
 		t.Fatal("rejected read allocated storage units")
 	}
@@ -103,17 +91,25 @@ func TestStorageValidBoundaryRanges(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewStorageWithUnitSize(tt.capacity, tt.unitSize)
-			data, err := s.Read(tt.address, uint64(len(tt.data)))
-			if err != nil || !bytes.Equal(data, make([]byte, len(tt.data))) {
-				t.Fatalf("untouched boundary read = (%v, %v)", data, err)
+			data := s.Read(tt.address, uint64(len(tt.data)))
+			if !bytes.Equal(data, make([]byte, len(tt.data))) {
+				t.Fatalf("untouched boundary read = %v", data)
 			}
-			if err := s.Write(tt.address, tt.data); err != nil {
-				t.Fatal(err)
-			}
-			data, err = s.Read(tt.address, uint64(len(tt.data)))
-			if err != nil || !bytes.Equal(data, tt.data) {
-				t.Fatalf("boundary round trip = (%v, %v), want %v", data, err, tt.data)
+			s.Write(tt.address, tt.data)
+			data = s.Read(tt.address, uint64(len(tt.data)))
+			if !bytes.Equal(data, tt.data) {
+				t.Fatalf("boundary round trip = %v, want %v", data, tt.data)
 			}
 		})
 	}
+}
+
+func mustPanicStorage(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Error("invalid storage range did not panic")
+		}
+	}()
+	fn()
 }

--- a/mem/storage_test.go
+++ b/mem/storage_test.go
@@ -10,10 +10,10 @@ var _ = Describe("Storage", func() {
 		storage := NewStorage(4096)
 		storage.Write(0, []byte{1, 2, 3, 4})
 
-		res, _ := storage.Read(0, 2)
+		res := storage.Read(0, 2)
 		Expect(res).To(Equal([]byte{1, 2}))
 
-		res, _ = storage.Read(1, 2)
+		res = storage.Read(1, 2)
 		Expect(res).To(Equal([]byte{2, 3}))
 	})
 
@@ -21,19 +21,15 @@ var _ = Describe("Storage", func() {
 		storage := NewStorage(8192)
 		storage.Write(4094, []byte{1, 2, 3, 4})
 
-		res, _ := storage.Read(4094, 4)
+		res := storage.Read(4094, 4)
 		Expect(res).To(Equal([]byte{1, 2, 3, 4}))
 	})
 
-	It("should return error if accessing over the capacity", func() {
+	It("should panic if accessing over the capacity", func() {
 		storage := NewStorage(4096)
-		err := storage.Write(4097, []byte{1})
-		Expect(err).To(MatchError(
+		Expect(func() { storage.Write(4097, []byte{1}) }).To(PanicWith(
 			"accessing physical address beyond the storage capacity"))
-
-		_, err = storage.Read(4097, 1)
-		Expect(err).To(MatchError(
+		Expect(func() { storage.Read(4097, 1) }).To(PanicWith(
 			"accessing physical address beyond the storage capacity"))
 	})
-
 })

--- a/mem/vm/tlb/tlb_test.go
+++ b/mem/vm/tlb/tlb_test.go
@@ -545,7 +545,7 @@ var _ = Describe("TLB Integration", func() {
 		req.TrafficClass = "vmprotocol.TranslationReq"
 		agent.port.Send(req)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsp := agent.lastDelivered.(vmprotocol.TranslationRsp)
 		Expect(rsp.Page).To(Equal(page))
@@ -563,7 +563,7 @@ var _ = Describe("TLB Integration", func() {
 		req.TrafficClass = "vmprotocol.TranslationReq"
 		agent.port.Send(req)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsp := agent.lastDelivered.(vmprotocol.TranslationRsp)
 		Expect(rsp.Page).To(Equal(page))
@@ -580,7 +580,7 @@ var _ = Describe("TLB Integration", func() {
 		req2.TrafficClass = "vmprotocol.TranslationReq"
 		agent.port.Send(req2)
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		rsp = agent.lastDelivered.(vmprotocol.TranslationRsp)
 		Expect(rsp.Page).To(Equal(page))

--- a/modeling/component_checkpoint.go
+++ b/modeling/component_checkpoint.go
@@ -16,8 +16,8 @@ import (
 // directly — alongside the engine's matching tick event — so load is a single
 // pass with no post-load reconciliation against the queue.
 type componentCheckpoint struct {
-	SpecHash  string            `json:"spec_hash"`
-	State     json.RawMessage   `json:"state"`
+	SpecHash  string              `json:"spec_hash"`
+	State     json.RawMessage     `json:"state"`
 	Scheduler schedulerCheckpoint `json:"scheduler"`
 }
 

--- a/modeling/eventdriven.go
+++ b/modeling/eventdriven.go
@@ -87,14 +87,12 @@ func (c *EventDrivenComponent[S, T, R]) ScheduleWakeNow() {
 
 // Handle processes an event. For TimerFiredEvent, it resets the dedup guard
 // and calls the processor.
-func (c *EventDrivenComponent[S, T, R]) Handle(e timing.Event) error {
+func (c *EventDrivenComponent[S, T, R]) Handle(e timing.Event) {
 	c.Lock()
 	defer c.Unlock()
 
 	c.pendingWakeup = math.MaxUint64
 	c.processor.Process(c, e.Time())
-
-	return nil
 }
 
 // NotifyRecv is called when a port receives a message. It schedules an

--- a/modeling/eventdriven_test.go
+++ b/modeling/eventdriven_test.go
@@ -123,10 +123,7 @@ func TestEventDrivenHandle(t *testing.T) {
 
 	evt := timing.MakeEventBase(10, comp.Name())
 
-	err := comp.Handle(evt)
-	if err != nil {
-		t.Fatalf("Handle() returned error: %v", err)
-	}
+	comp.Handle(evt)
 
 	if proc.callCount != 1 {
 		t.Errorf("processor called %d times, want 1", proc.callCount)

--- a/modeling/example_test.go
+++ b/modeling/example_test.go
@@ -29,10 +29,10 @@ type PingSpec struct {
 }
 
 type PingState struct {
-	NumPingNeedToSend int                 `json:"num_ping_need_to_send"`
-	NextSeqID         int                 `json:"next_seq_id"`
+	NumPingNeedToSend int                     `json:"num_ping_need_to_send"`
+	NextSeqID         int                     `json:"next_seq_id"`
 	StartTimes        []timing.VTimeInPicoSec `json:"start_times"`
-	CompletedPings    int                 `json:"completed_pings"`
+	CompletedPings    int                     `json:"completed_pings"`
 }
 
 type pingTransaction struct {

--- a/modeling/ticker.go
+++ b/modeling/ticker.go
@@ -178,13 +178,11 @@ func (c *TickingComponent) NotifyRecv(
 }
 
 // Handle triggers the tick function of the TickingComponent
-func (c *TickingComponent) Handle(e timing.Event) error {
+func (c *TickingComponent) Handle(e timing.Event) {
 	madeProgress := c.ticker.Tick()
 	if madeProgress {
 		c.TickLater()
 	}
-
-	return nil
 }
 
 // NewTickingComponent creates a new ticking component

--- a/monitoring2/monitor.go
+++ b/monitoring2/monitor.go
@@ -457,7 +457,7 @@ func (m *Monitor) run(_ http.ResponseWriter, _ *http.Request) {
 	go func() {
 		err := m.engine.Run()
 		if err != nil {
-			panic(err)
+			log.Printf("simulation run failed: %v", err)
 		}
 	}()
 }

--- a/monitoring2/run_panic_test.go
+++ b/monitoring2/run_panic_test.go
@@ -1,0 +1,41 @@
+package monitoring2
+
+import (
+	"log"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sarchlab/akita/v5/timing"
+)
+
+type runPanicHandler struct{}
+
+func (runPanicHandler) Handle(timing.Event) { panic("invalid monitored model") }
+
+type runLog chan string
+
+func (c runLog) Write(p []byte) (int, error) { c <- string(p); return len(p), nil }
+
+func TestMonitorReportsRunFailureWithoutRepanicking(t *testing.T) {
+	e := timing.NewSerialEngine()
+	e.RegisterHandler("model", runPanicHandler{})
+	e.Schedule(timing.EventBase{Time_: 1, HandlerID_: "model"})
+	m := NewMonitor()
+	m.RegisterEngine(e)
+	messages := make(runLog, 1)
+	previous := log.Writer()
+	log.SetOutput(messages)
+	defer log.SetOutput(previous)
+	m.run(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/run", nil))
+	select {
+	case message := <-messages:
+		if !strings.Contains(message, "simulation run failed:") || !strings.Contains(message, "invalid monitored model") {
+			t.Fatalf("missing run diagnostic: %s", message)
+		}
+		t.Log("monitor reported the contained engine panic without crashing the process")
+	case <-time.After(5 * time.Second):
+		t.Fatal("monitor did not report the failed run")
+	}
+}

--- a/noc/directconnection/directconnection_test.go
+++ b/noc/directconnection/directconnection_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Direct Connection Integration", func() {
 			agent.TickLater()
 		}
 
-		engine.Run()
+		Expect(engine.Run()).To(Succeed())
 
 		totalRecvedMsgCount := 0
 		for _, agent := range agents {
@@ -245,7 +245,7 @@ func directConnectionTest(seed int64) timing.VTimeInPicoSec {
 		agent.TickLater()
 	}
 
-	engine.Run()
+	Expect(engine.Run()).To(Succeed())
 
 	return engine.CurrentTime()
 }

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -473,7 +473,7 @@ var _ = Describe("Checkpoint round trip", func() {
 
 		// Establish runtime state across all four entity kinds.
 		comp.State = roundTripState{Count: 7}
-		Expect(storage.Write(0, []byte{1, 2, 3, 4})).To(Succeed())
+		storage.Write(0, []byte{1, 2, 3, 4})
 		for i := 0; i < 5; i++ {
 			timing.GetIDGenerator().Generate()
 		}
@@ -485,7 +485,7 @@ var _ = Describe("Checkpoint round trip", func() {
 
 		// Mutate every piece of runtime state away from the checkpoint.
 		comp.State = roundTripState{Count: 999}
-		Expect(storage.Write(0, []byte{0, 0, 0, 0})).To(Succeed())
+		storage.Write(0, []byte{0, 0, 0, 0})
 		timing.GetIDGenerator().Generate()
 		timing.GetIDGenerator().Generate()
 		engine.SetCurrentTime(500)
@@ -494,8 +494,7 @@ var _ = Describe("Checkpoint round trip", func() {
 		Expect(sim.LoadCheckpoint(path, "test-build")).To(Succeed())
 
 		Expect(comp.State.Count).To(Equal(7))
-		data, err := storage.Read(0, 4)
-		Expect(err).ToNot(HaveOccurred())
+		data := storage.Read(0, 4)
 		Expect(data).To(Equal([]byte{1, 2, 3, 4}))
 		Expect(timing.GetIDGeneratorNextID()).To(Equal(savedCounter))
 		Expect(engine.CurrentTime()).To(Equal(timing.VTimeInPicoSec(100)))

--- a/timing/ERROR_HANDLING.md
+++ b/timing/ERROR_HANDLING.md
@@ -1,0 +1,54 @@
+# Engine errors and model panics
+
+`Handler.Handle(Event)` has no error result. A model invariant violation may
+panic; an expected simulated failure belongs in a response, status, or event.
+Backpressure, lookup misses, and no work retain their ordinary result types.
+
+`SerialEngine.Run`, `SerialEngine.RunUntil`, and `ParallelEngine.Run` return
+errors. An ordinary Go panic during execution, including before/after hooks,
+becomes a `*timing.PanicError`. It retains the original cause and stack, plus
+best-effort event/handler/time details. Error-valued causes support
+`errors.Is` and `errors.As`. A handler panic skips its after-event hook.
+
+Check the execution error and discard the failed engine and its model state.
+Recovery does not roll back mutations. A failed engine rejects subsequent runs
+and scheduling; a failed serial engine also rejects checkpoint save/load.
+Independent engines can continue executing in the same process.
+
+```go
+if err := engine.Run(); err != nil {
+    // Report this engine's failure and discard its model state.
+    return err
+}
+```
+
+Serial recovery is installed once around the run, on its existing goroutine.
+Parallel recovery runs inside the existing workers as well as the dispatcher.
+Parallel failure wakes workers waiting to borrow a queue, and Run joins started
+workers before returning. Queues, event ordering, concurrency, and pause/resume
+contracts are otherwise unchanged. There is no extension-worker API or new
+serial scheduling concurrency.
+
+Containment covers ordinary Go panics during engine execution. Construction,
+direct handler calls, and caller-created goroutines remain the caller's
+responsibility. Recovery cannot stop a nonreturning handler or contain fatal
+runtime failures, `os.Exit`, or unsafe/native corruption. It does not isolate
+host-shared mutable resources or change global ID/checkpoint ownership.
+
+`mem.Storage.Read(address, length)` returns `[]byte`; `Write(address, data)`
+has no result. Empty, overflowing, or out-of-capacity accesses panic before
+allocating storage units or changing stored bytes. The existing valid-range
+behavior is unchanged, including accesses ending exactly at capacity.
+
+Existing external I/O, validation, JSON, and checkpoint error signatures remain
+unchanged. Setup/finalization error handling, reader/recorder normalization, and
+broader ownership or restore policy are separate work under RFC #478.
+
+## Migration
+
+- Remove `error` from `Handle` declarations and remove their `return nil`.
+  Express modeled failures through the model protocol; panic for violated
+  invariants. Always inspect the error from `Run`/`RunUntil`.
+- Replace `data, err := storage.Read(...)` with `data := storage.Read(...)`.
+  Call `storage.Write(...)` directly. Invalid ranges are programmer errors;
+  handle a resulting execution failure at the engine boundary.

--- a/timing/README.md
+++ b/timing/README.md
@@ -44,7 +44,7 @@ evt := tickEvent{timing.MakeEventBase(now, comp.Name())}
 
 ```go
 type Handler interface {
-    Handle(e Event) error
+    Handle(e Event)
 }
 ```
 

--- a/timing/engine_bench_test.go
+++ b/timing/engine_bench_test.go
@@ -1,0 +1,32 @@
+package timing
+
+import "testing"
+
+type dispatchBenchHandler struct {
+	engine *SerialEngine
+	left   int
+}
+
+func (h *dispatchBenchHandler) Handle(evt Event) {
+	h.left--
+	if h.left > 0 {
+		next := evt.Time() + 1
+		h.engine.Schedule(EventBase{ID: uint64(next), Time_: next, HandlerID_: "bench"})
+	}
+}
+func BenchmarkSerialEngineEvents(b *testing.B) {
+	e := NewSerialEngine()
+	h := &dispatchBenchHandler{engine: e}
+	e.RegisterHandler("bench", h)
+	const perRun = 10000
+	b.ReportAllocs()
+	for b.Loop() {
+		h.left = perRun
+		next := e.CurrentTime() + 1
+		e.Schedule(EventBase{ID: uint64(next), Time_: next, HandlerID_: "bench"})
+		if err := e.Run(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*perRun), "ns/event")
+}

--- a/timing/event.go
+++ b/timing/event.go
@@ -18,10 +18,10 @@ type Event interface {
 
 // EventBase provides the basic fields and getters for other events.
 type EventBase struct {
-	ID         uint64     `json:"id"`
+	ID         uint64         `json:"id"`
 	Time_      VTimeInPicoSec `json:"time"`
-	HandlerID_ string     `json:"handler_id"`
-	Secondary  bool       `json:"secondary"`
+	HandlerID_ string         `json:"handler_id"`
+	Secondary  bool           `json:"secondary"`
 }
 
 // MakeEventBase creates a new EventBase as a value.
@@ -54,5 +54,5 @@ func (e EventBase) IsSecondary() bool {
 // One event is always constrained to one Handler, which means the event can
 // only be scheduled by one handler and can only directly modify that handler.
 type Handler interface {
-	Handle(e Event) error
+	Handle(e Event)
 }

--- a/timing/eventqueue.go
+++ b/timing/eventqueue.go
@@ -81,17 +81,17 @@ func NewEventQueue() *EventQueueImpl {
 // Push adds an event to the event queue.
 func (q *EventQueueImpl) Push(evt Event) {
 	q.Lock()
+	defer q.Unlock()
 	q.events = append(q.events, queuedEvent{event: evt, seq: q.nextSeq})
 	q.nextSeq++
 	q.events.up(len(q.events) - 1)
-	q.Unlock()
 }
 
 // Pop returns the next earliest event.
 func (q *EventQueueImpl) Pop() Event {
 	q.Lock()
+	defer q.Unlock()
 	evt := popHeap(&q.events)
-	q.Unlock()
 
 	return evt
 }
@@ -99,8 +99,8 @@ func (q *EventQueueImpl) Pop() Event {
 // Len returns the number of events in the queue.
 func (q *EventQueueImpl) Len() int {
 	q.Lock()
+	defer q.Unlock()
 	l := len(q.events)
-	q.Unlock()
 
 	return l
 }
@@ -109,8 +109,8 @@ func (q *EventQueueImpl) Len() int {
 // queue.
 func (q *EventQueueImpl) Peek() Event {
 	q.Lock()
+	defer q.Unlock()
 	evt := q.events[0].event
-	q.Unlock()
 
 	return evt
 }

--- a/timing/eventqueue_order_test.go
+++ b/timing/eventqueue_order_test.go
@@ -48,9 +48,8 @@ type orderRecordingHandler struct {
 	order []int
 }
 
-func (h *orderRecordingHandler) Handle(e Event) error {
+func (h *orderRecordingHandler) Handle(e Event) {
 	h.order = append(h.order, e.(*orderEvent).id)
-	return nil
 }
 
 func TestSerialEngineFiresSameTimeInScheduleOrder(t *testing.T) {

--- a/timing/panic.go
+++ b/timing/panic.go
@@ -1,0 +1,43 @@
+package timing
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// PanicError reports an ordinary Go panic caught while executing an engine.
+// The failed engine must be discarded; recovery does not roll back model state.
+// Cause preserves the panic value, including error values for errors.Is/As.
+type PanicError struct {
+	Cause     any
+	Stack     []byte
+	EventType string
+	Handler   string
+	Time      VTimeInPicoSec
+}
+
+func (e *PanicError) Error() string {
+	return fmt.Sprintf("simulation panicked (handler %q, event %s, time %d): %v",
+		e.Handler, e.EventType, e.Time, e.Cause)
+}
+
+func (e *PanicError) Unwrap() error {
+	err, _ := e.Cause.(error)
+	return err
+}
+
+func newPanicError(cause any, event Event) *PanicError {
+	err := &PanicError{Cause: cause, Stack: debug.Stack()}
+	if event != nil {
+		err.EventType = fmt.Sprintf("%T", event)
+		annotatePanic(err, event)
+	}
+	return err
+}
+
+func annotatePanic(err *PanicError, event Event) {
+	// A broken event accessor must not replace the original panic.
+	defer func() { _ = recover() }()
+	err.Handler = event.HandlerID()
+	err.Time = event.Time()
+}

--- a/timing/panic_test.go
+++ b/timing/panic_test.go
@@ -1,0 +1,206 @@
+package timing
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sarchlab/akita/v5/hooking"
+)
+
+type panicHandler func(Event)
+
+func (h panicHandler) Handle(e Event) { h(e) }
+
+type panicHook func(hooking.HookCtx)
+
+func (h panicHook) Func(ctx hooking.HookCtx) { h(ctx) }
+
+type testEngine interface {
+	Engine
+	HandlerRegistrar
+}
+
+func finishRun(t *testing.T, run func() error) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- run() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("engine did not finish after panic")
+		return nil
+	}
+}
+
+func catchPanic(t *testing.T, fn func()) (cause any) {
+	t.Helper()
+	defer func() {
+		cause = recover()
+		if cause == nil {
+			t.Error("expected panic")
+		}
+	}()
+	fn()
+	return nil
+}
+
+func TestEnginePanicIsolation(t *testing.T) {
+	factories := map[string]func() testEngine{
+		"serial":   func() testEngine { return NewSerialEngine() },
+		"parallel": func() testEngine { return NewParallelEngine() },
+	}
+	for name, build := range factories {
+		t.Run(name, func(t *testing.T) {
+			for _, phase := range []string{"before", "handler", "after"} {
+				t.Run(phase, func(t *testing.T) {
+					for _, cause := range []any{errors.New("model failure"), "model failure", struct{ Code int }{7}} {
+						checkEnginePanic(t, build, phase, cause)
+					}
+				})
+			}
+		})
+	}
+}
+
+func checkEnginePanic(t *testing.T, build func() testEngine, phase string, cause any) {
+	t.Helper()
+	bad, good := build(), build()
+	var goodEvents, afterHooks atomic.Int32
+	bad.RegisterHandler("model", panicHandler(func(Event) {
+		if phase == "handler" {
+			panic(cause)
+		}
+	}))
+	bad.AcceptHook(panicHook(func(ctx hooking.HookCtx) {
+		if phase == "before" && ctx.Pos == HookPosBeforeEvent {
+			panic(cause)
+		}
+		if ctx.Pos == HookPosAfterEvent {
+			afterHooks.Add(1)
+			if phase == "after" {
+				panic(cause)
+			}
+		}
+	}))
+	good.RegisterHandler("model", panicHandler(func(Event) { goodEvents.Add(1) }))
+	for i := 1; i <= 100; i++ {
+		bad.Schedule(EventBase{ID: uint64(i), Time_: VTimeInPicoSec(i), HandlerID_: "model"})
+		good.Schedule(EventBase{ID: uint64(i), Time_: VTimeInPicoSec(i), HandlerID_: "model"})
+	}
+	goodDone := make(chan error, 1)
+	go func() { goodDone <- good.Run() }()
+	err := finishRun(t, bad.Run)
+	var failure *PanicError
+	if !errors.As(err, &failure) || !reflect.DeepEqual(failure.Cause, cause) || len(failure.Stack) == 0 ||
+		failure.Handler != "model" || failure.Time != 1 || failure.EventType == "" {
+		t.Fatalf("missing panic diagnostics: %+v", err)
+	}
+	if wrapped, ok := cause.(error); ok && !errors.Is(err, wrapped) {
+		t.Fatal("lost original error identity")
+	}
+	if phase != "after" && afterHooks.Load() != 0 {
+		t.Fatal("success hook ran after failure")
+	}
+	if err := finishRun(t, func() error { return <-goodDone }); err != nil {
+		t.Fatal(err)
+	}
+	if goodEvents.Load() != 100 || good.CurrentTime() != 100 {
+		t.Fatalf("peer completed %d events at %d", goodEvents.Load(), good.CurrentTime())
+	}
+	if bad.Run() != err {
+		t.Fatal("failed engine accepted another run or lost its first failure")
+	}
+	catchPanic(t, func() { bad.Schedule(EventBase{Time_: 200, HandlerID_: "model"}) })
+	t.Logf("%s panic (%T) contained at time 1; independent engine completed 100 events at time 100", phase, cause)
+}
+
+func TestRunUntilContainsPanicAndRejectsReuse(t *testing.T) {
+	e := NewSerialEngine()
+	e.RegisterHandler("model", panicHandler(func(Event) { panic("broken model") }))
+	e.Schedule(EventBase{Time_: 1, HandlerID_: "model"})
+	err := finishRun(t, func() error { return e.RunUntil(1) })
+	if err == nil || e.RunUntil(2) != err {
+		t.Fatal("RunUntil did not preserve terminal failure")
+	}
+	var out bytes.Buffer
+	if e.SaveCheckpoint(&out) != err || out.Len() != 0 {
+		t.Fatal("failed engine produced a checkpoint")
+	}
+	if e.LoadCheckpoint(bytes.NewBufferString("{}")) != err {
+		t.Fatal("failed engine accepted restore")
+	}
+}
+
+// This queue makes dispatcher failure deterministic while a worker is waiting
+// for a queue token. Healthy scheduling still uses the original queue design.
+type panicDispatchQueue struct{ events []Event }
+
+func (q *panicDispatchQueue) Len() int     { return len(q.events) }
+func (q *panicDispatchQueue) Peek() Event  { return q.events[0] }
+func (q *panicDispatchQueue) Pop() Event   { e := q.events[0]; q.events = q.events[1:]; return e }
+func (q *panicDispatchQueue) Push(e Event) { q.events = append(q.events, e) }
+
+type panicTimeEvent struct {
+	EventBase
+	attempted <-chan struct{}
+}
+
+func (e panicTimeEvent) Time() VTimeInPicoSec { <-e.attempted; panic("dispatcher failure") }
+
+func TestParallelDispatcherPanicReleasesWaitingWorker(t *testing.T) {
+	e := NewParallelEngine()
+	attempted := make(chan struct{})
+	var joined atomic.Bool
+	e.RegisterHandler("model", panicHandler(func(Event) {
+		defer joined.Store(true)
+		close(attempted)
+		e.Schedule(EventBase{Time_: 2, HandlerID_: "model"})
+	}))
+	q := &panicDispatchQueue{events: []Event{
+		EventBase{Time_: 1, HandlerID_: "model"},
+		panicTimeEvent{attempted: attempted},
+	}}
+	e.queues = []EventQueue{q}
+	e.queueChan = make(chan EventQueue, 1)
+	e.queueChan <- q
+	err := finishRun(t, e.Run)
+	var failure *PanicError
+	if !errors.As(err, &failure) || failure.Cause != "dispatcher failure" || !joined.Load() {
+		t.Fatalf("dispatcher did not contain panic and join worker: %v joined=%v", err, joined.Load())
+	}
+	if !e.pauseLock.TryLock() {
+		t.Fatal("round lock was left held")
+	}
+	e.pauseLock.Unlock()
+	t.Log("dispatcher failure released and joined a worker blocked in Schedule")
+}
+
+func TestEventQueueReleasesExistingLockOnPanic(t *testing.T) {
+	for _, op := range []string{"peek", "pop", "push"} {
+		t.Run(op, func(t *testing.T) {
+			q := NewEventQueue()
+			catchPanic(t, func() {
+				switch op {
+				case "peek":
+					q.Peek()
+				case "pop":
+					q.Pop()
+				case "push":
+					q.Push(EventBase{Time_: 1})
+					ready := make(chan struct{})
+					close(ready)
+					q.Push(panicTimeEvent{attempted: ready})
+				}
+			})
+			if !q.TryLock() {
+				t.Fatal("queue lock was left held after panic")
+			}
+			q.Unlock()
+		})
+	}
+}

--- a/timing/parallelengine.go
+++ b/timing/parallelengine.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"github.com/sarchlab/akita/v5/hooking"
 )
@@ -30,6 +31,8 @@ type ParallelEngine struct {
 	secondaryQueueChan chan EventQueue
 
 	registry map[string]Handler
+	failure  atomic.Pointer[PanicError]
+	failed   chan struct{}
 }
 
 // Name returns the name of the engine. The engine is registered as a simulation
@@ -41,6 +44,7 @@ func (e *ParallelEngine) Name() string {
 // NewParallelEngine creates a ParallelEngine.
 func NewParallelEngine() *ParallelEngine {
 	e := new(ParallelEngine)
+	e.failed = make(chan struct{})
 
 	e.eventChan = make(chan Event, 10000)
 
@@ -100,34 +104,51 @@ func (e *ParallelEngine) Schedule(evt Event) {
 			reflect.TypeOf(evt), evt.Time(), now)
 	}
 
+	queueChan := e.queueChan
 	if evt.IsSecondary() {
-		queue := <-e.secondaryQueueChan
-		queue.Push(evt)
-
-		e.secondaryQueueChan <- queue
-
-		return
+		queueChan = e.secondaryQueueChan
 	}
-
-	queue := <-e.queueChan
-	queue.Push(evt)
-
-	e.queueChan <- queue
+	select {
+	case <-e.failed:
+		panic(e.failure.Load())
+	case queue := <-queueChan:
+		// Return the borrowed queue even if an event accessor panics in Push.
+		defer func() { queueChan <- queue }()
+		if failure := e.failure.Load(); failure != nil {
+			panic(failure)
+		}
+		queue.Push(evt)
+	}
 }
 
 // Run processes all the events scheduled in the ParallelEngine.
-func (e *ParallelEngine) Run() error {
+func (e *ParallelEngine) Run() (err error) {
+	defer func() {
+		if cause := recover(); cause != nil {
+			e.recordPanic(cause, nil)
+		}
+		if failure := e.failure.Load(); failure != nil {
+			err = failure
+		}
+	}()
 	for {
+		if failure := e.failure.Load(); failure != nil {
+			return failure
+		}
 		if !e.hasMoreEvents() {
 			return nil
 		}
 
-		e.pauseLock.Lock()
-		e.determineWhatToRun()
-		e.runRound()
-
-		e.pauseLock.Unlock()
+		e.runNextRound()
 	}
+}
+
+// Keep the existing round lock and always release it during panic unwinding.
+func (e *ParallelEngine) runNextRound() {
+	e.pauseLock.Lock()
+	defer e.pauseLock.Unlock()
+	e.determineWhatToRun()
+	e.runRound()
 }
 
 func (e *ParallelEngine) determineWhatToRun() {
@@ -165,6 +186,14 @@ func (e *ParallelEngine) earliestTimeInQueueGroup(
 }
 
 func (e *ParallelEngine) runRound() {
+	defer func() {
+		// Signal failure before joining: workers may be waiting to borrow a
+		// queue still held by this round's dispatcher.
+		if cause := recover(); cause != nil {
+			e.recordPanic(cause, nil)
+		}
+		e.waitGroup.Wait()
+	}()
 	queues := e.queues
 	queueChan := e.queueChan
 
@@ -175,7 +204,6 @@ func (e *ParallelEngine) runRound() {
 
 	e.emptyQueueChan(queues, queueChan)
 	e.runEventsUntilConflict(queues, queueChan)
-	e.waitGroup.Wait()
 }
 
 func (e *ParallelEngine) emptyQueueChan(
@@ -223,6 +251,9 @@ func (e *ParallelEngine) runEventsUntilConflict(
 
 	for _, queue := range queues {
 		for queue.Len() > 0 {
+			if e.failure.Load() != nil {
+				break
+			}
 			evt := queue.Peek()
 			if evt.Time() == now {
 				queue.Pop()
@@ -247,6 +278,15 @@ func (e *ParallelEngine) runEventWithTempWorker(evt Event) {
 }
 
 func (e *ParallelEngine) tempWorkerRun(evt Event) {
+	defer e.waitGroup.Done()
+	defer func() {
+		if cause := recover(); cause != nil {
+			e.recordPanic(cause, evt)
+		}
+	}()
+	if e.failure.Load() != nil {
+		return
+	}
 	now := e.readNow()
 
 	if evt.Time() < now {
@@ -261,12 +301,15 @@ func (e *ParallelEngine) tempWorkerRun(evt Event) {
 	e.InvokeHook(hookCtx)
 
 	handler := e.registry[evt.HandlerID()]
-	_ = handler.Handle(evt)
+	if e.failure.Load() != nil {
+		return
+	}
+	handler.Handle(evt)
 
-	hookCtx.Pos = HookPosAfterEvent
-	e.InvokeHook(hookCtx)
-
-	e.waitGroup.Done()
+	if e.failure.Load() == nil {
+		hookCtx.Pos = HookPosAfterEvent
+		e.InvokeHook(hookCtx)
+	}
 }
 
 // Pause will prevent the engine to move forward. For events that are scheduled
@@ -284,4 +327,11 @@ func (e *ParallelEngine) Continue() {
 // Specifically, the run time of the current event.
 func (e *ParallelEngine) CurrentTime() VTimeInPicoSec {
 	return e.readNow()
+}
+
+func (e *ParallelEngine) recordPanic(cause any, evt Event) {
+	failure := newPanicError(cause, evt)
+	if e.failure.CompareAndSwap(nil, failure) {
+		close(e.failed)
+	}
 }

--- a/timing/serialengine.go
+++ b/timing/serialengine.go
@@ -23,7 +23,9 @@ type SerialEngine struct {
 
 	singleRunLock sync.Mutex
 
-	registry map[string]Handler
+	registry     map[string]Handler
+	failure      *PanicError
+	currentEvent Event
 }
 
 // NewSerialEngine creates a SerialEngine.
@@ -51,6 +53,9 @@ func (e *SerialEngine) RegisterHandler(name string, handler Handler) {
 
 // Schedule registers an event to happen in the future.
 func (e *SerialEngine) Schedule(evt Event) {
+	if e.failure != nil {
+		panic(e.failure)
+	}
 	if evt.Time() < e.time {
 		log.Panic("scheduling an event earlier than current time")
 	}
@@ -65,13 +70,18 @@ func (e *SerialEngine) Schedule(evt Event) {
 }
 
 // Run processes all the events scheduled in the SerialEngine.
-func (e *SerialEngine) Run() error {
+func (e *SerialEngine) Run() (err error) {
 	e.singleRunLock.Lock()
 	defer e.singleRunLock.Unlock()
+	if e.failure != nil {
+		return e.failure
+	}
+	defer e.recoverRun(&err)
 
 	hasHooks := e.NumHooks() > 0
 
 	for {
+		e.currentEvent = nil
 		if e.noMoreEvent() {
 			return nil
 		}
@@ -91,13 +101,18 @@ func (e *SerialEngine) Run() error {
 // last processed event and all later events still queued. This is a
 // deterministic mid-run boundary — unlike Pause, which stops at a
 // non-reproducible point — used to take a mid-transaction checkpoint.
-func (e *SerialEngine) RunUntil(t VTimeInPicoSec) error {
+func (e *SerialEngine) RunUntil(t VTimeInPicoSec) (err error) {
 	e.singleRunLock.Lock()
 	defer e.singleRunLock.Unlock()
+	if e.failure != nil {
+		return e.failure
+	}
+	defer e.recoverRun(&err)
 
 	hasHooks := e.NumHooks() > 0
 
 	for {
+		e.currentEvent = nil
 		if e.noMoreEvent() {
 			return nil
 		}
@@ -116,6 +131,7 @@ func (e *SerialEngine) RunUntil(t VTimeInPicoSec) error {
 // dispatchNext pops the earliest event and runs it, invoking hooks when present.
 func (e *SerialEngine) dispatchNext(hasHooks bool) {
 	evt := e.nextEvent()
+	e.currentEvent = evt
 
 	if evt.Time() < e.time {
 		log.Panicf(
@@ -135,13 +151,13 @@ func (e *SerialEngine) dispatchNext(hasHooks bool) {
 		e.InvokeHook(hookCtx)
 
 		handler := e.registry[evt.HandlerID()]
-		_ = handler.Handle(evt)
+		handler.Handle(evt)
 
 		hookCtx.Pos = HookPosAfterEvent
 		e.InvokeHook(hookCtx)
 	} else {
 		handler := e.registry[evt.HandlerID()]
-		_ = handler.Handle(evt)
+		handler.Handle(evt)
 	}
 }
 
@@ -225,4 +241,13 @@ func (e *SerialEngine) CurrentTime() VTimeInPicoSec {
 // SetCurrentTime sets the current time of the engine.
 func (e *SerialEngine) SetCurrentTime(t VTimeInPicoSec) {
 	e.time = t
+}
+
+// recoverRun is deferred once by Run/RunUntil, not once per event.
+func (e *SerialEngine) recoverRun(err *error) {
+	if cause := recover(); cause != nil {
+		e.failure = newPanicError(cause, e.currentEvent)
+		*err = e.failure
+	}
+	e.currentEvent = nil
 }

--- a/timing/serialengine_checkpoint.go
+++ b/timing/serialengine_checkpoint.go
@@ -17,6 +17,9 @@ type serialEngineCheckpoint struct {
 
 // SaveCheckpoint writes the engine's current time and queued events.
 func (e *SerialEngine) SaveCheckpoint(w io.Writer) error {
+	if e.failure != nil {
+		return e.failure
+	}
 	primary, err := eventCodec.EncodeSlice(e.queue.snapshot())
 	if err != nil {
 		return err
@@ -38,6 +41,9 @@ func (e *SerialEngine) SaveCheckpoint(w io.Writer) error {
 // pop order so the (time, sequence) ordering is reproduced, and each event's
 // handler must already be registered.
 func (e *SerialEngine) LoadCheckpoint(r io.Reader) error {
+	if e.failure != nil {
+		return e.failure
+	}
 	if e.queue.Len() != 0 || e.secondaryQueue.Len() != 0 {
 		return fmt.Errorf(
 			"timing: cannot load a checkpoint into a non-empty serial engine queue")

--- a/timing/serialengine_checkpoint_test.go
+++ b/timing/serialengine_checkpoint_test.go
@@ -15,9 +15,8 @@ type idRecordingHandler struct {
 	ids []uint64
 }
 
-func (h *idRecordingHandler) Handle(e Event) error {
+func (h *idRecordingHandler) Handle(e Event) {
 	h.ids = append(h.ids, e.(queueTestEvent).ID)
-	return nil
 }
 
 func TestSerialEngineQueueRoundTrip(t *testing.T) {

--- a/timing/serialengine_rununtil_test.go
+++ b/timing/serialengine_rununtil_test.go
@@ -59,7 +59,7 @@ type rescheduleHandler struct {
 	until  VTimeInPicoSec
 }
 
-func (h *rescheduleHandler) Handle(e Event) error {
+func (h *rescheduleHandler) Handle(e Event) {
 	now := e.Time()
 	h.fired = append(h.fired, now)
 
@@ -70,8 +70,6 @@ func (h *rescheduleHandler) Handle(e Event) error {
 		ev.HandlerID_ = "h"
 		h.engine.Schedule(ev)
 	}
-
-	return nil
 }
 
 func TestRunUntilProcessesEventsScheduledWithinBoundary(t *testing.T) {

--- a/timing/timing_test.go
+++ b/timing/timing_test.go
@@ -11,9 +11,8 @@ type recordingHandler struct {
 	labels []string
 }
 
-func (h *recordingHandler) Handle(e Event) error {
+func (h *recordingHandler) Handle(e Event) {
 	h.labels = append(h.labels, e.(testEvent).label)
-	return nil
 }
 
 func TestSerialEngineRunsEventsInTimeOrder(t *testing.T) {


### PR DESCRIPTION
Model handlers return errors that the engines discard, while an ordinary model panic can crash the host. This PR makes `Handler.Handle(Event)` return no value and makes engine execution return a contextual `*timing.PanicError` when a handler, hook, or dispatcher panics. A failed engine is terminal; independent engines continue running.

This is a fresh implementation from main of the core engine/storage phase of #478, replacing the closed #479.

- Install serial recovery once around `Run`/`RunUntil`. Preserve the existing event loop and pause behavior.
- Recover inside the existing parallel workers and dispatcher. Signal failure to queue borrowers, release existing locks/borrowed queues during unwinding, and join started workers before returning. Keep the existing parallel queues and scheduling design.
- Make `Storage.Read` return bytes and `Storage.Write` return no value. Empty, overflowing, and out-of-capacity ranges panic before allocation or mutation; preserve #476's range guarantees.
- Migrate handlers, storage callers, examples, tutorials, and tests. Check run errors in test callers, and have the monitor report a returned run failure instead of repanicking it in a goroutine.

The contract and migration are documented in `timing/ERROR_HANDLING.md`. This PR does not implement the RFC's separate setup/finalization, recording, checkpoint ownership/restore, or tooling redesigns. It adds no serial queue/dispatch locks, worker-launch API, ID ownership changes, or output-completion protocol.

Local validation: all 41 Ginkgo suites passed, golangci-lint reported zero issues, and `go test -race ./timing ./mem ./modeling ./monitoring2 -count=1` passed. Failure tests verify that a peer engine completes 100 events, failed runs reject reuse, dispatcher failure releases and joins a worker blocked in Schedule, storage panics become run errors, and monitor-triggered run failure is reported without crashing the process.

Performance: a 10,000-event serial dispatch/reschedule microbenchmark (five one-second samples, Go 1.27.0, Apple M5 Max) measured median 24.73 ns/event at recorded main base `324bfff7` and 25.65 ns/event for this implementation, about +3.7% (+0.92 ns/event). Both use one allocation and approximately 48 bytes per event. This measures the scheduling loop, not complete-model performance. The final README-only commit leaves the measured runtime code unchanged.

Final head: `dd27e3ad657c181911c5f19f5baf5812e070aab0`. All six CI jobs passed, including 57 memory acceptance cases and nine NoC scenarios. Exact-head behavior tests again observed an independent engine completing 100 events while its peer failed, blocked-worker cleanup, storage panic conversion, and monitor diagnostics. Two Claude Code independent review rounds ended with `approve`, `ready_to_merge: true`, and no findings; the first round's stale storage README example was fixed. Claude performed source review; its optional test commands were denied by session permissions, so runtime evidence comes from Codex and CI. Codex independently finds no blocker. PR remains unmerged.
